### PR TITLE
update gitlab-ci to deploy to ECS.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,13 @@
 # GitLab build configuration
 image: openjdk:8
+# if we wanted openconnect, use:
+#image: openjdk:8-slim-buster
 
 before_script:
-  - echo "Runnning before_script setup..."
-  - apt-get update
-  - apt-get install -y ant git
+  - echo "Running (empty) before_script cleanup..."
 
 after_script:
-  - echo "Running after_script cleanup..."
+  - echo "Running (empty) after_script cleanup..."
 
 # Define the stages to which jobs can be assigned.
 # The order of stages in this parameter defines the order of execution: all jobs of the same stage are run in parallel;
@@ -22,12 +22,17 @@ stages:
 # TODO re-organize package.xml (along with build.xml) into building, testing, packaging.
 
 # TODO figure out how to restrict the build/test/deploy to the current branch
+# ANSEWR: use only,  but really there should be different deploy steps
+#   for master (or maybe tags?) vs the other branches
 
 job-build:
   stage: build
   script:
+    - apt-get update
+    - apt-get install -y ant git
     - echo "Running ant on package.xml"
     - ant -file package.xml
+    - echo $CI_JOB_ID > dist/ci_job_id.txt
   artifacts:
     paths:
     - dist/*.zip
@@ -45,4 +50,8 @@ job-test:
 job-deploy:
   stage: deploy
   script:
-    - echo "Running (currently empty) deploy stage"
+    - echo "Running deploy stage"
+    - apt-get install -y curl
+    - export BUILDNUMBER=`echo dist/pc2-*.zip | sed 's#^dist.*build-\([0-9]*\)[.~].*#\1#'`
+    - BUILD_JOB_ID=$(cat dist/ci_job_id.txt)
+    - curl "http://pc2.ecs.csus.edu/cgi-bin/grabgitlabartifacts.cgi?authkey=$AUTHKEY&url=https://gitlab.com/api/v4/projects/$CI_PROJECT_ID/jobs/$BUILD_JOB_ID/artifacts&buildnumber=$BUILDNUMBER"

--- a/build.xml
+++ b/build.xml
@@ -137,11 +137,17 @@
         </condition>
     </target>
     <target name="-getenv" if="exists.CI_PIPELINE_IID">
-       <add operand1="5145" operand2="${env.CI_PIPELINE_IID}" result="repo.version"/>
+       <add operand1="5145" operand2="${env.CI_PIPELINE_IID}" result="repo.version0"/>
 <!--
 TODO consider switching back to this at 9.7.0/9.8build
-        <property name="repo.version" value="${env.CI_PIPELINE_IID}"/>
+        <property name="repo.version0" value="${env.CI_PIPELINE_IID}"/>
 -->
+        <condition property="version.add" value="~${env.CI_COMMIT_REF_SLUG}" else="">
+           <not>
+               <equals arg1="${env.CI_COMMIT_REF_SLUG}" arg2="master"/>
+           </not>
+        </condition>
+        <property name="repo.version" value="${repo.version0}${version.add}"/>
     </target>
 
     <target name="compile" depends="init,checkstyle" description="compile the source ">


### PR DESCRIPTION
fixes #9

uses a access token from gitlab with api access, with that token being exposed in CI/CD variables to the build as $AUTHKEY