### PR TITLE
#52 - now {files} will substitute all submitted filenames

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2437,7 +2437,7 @@ public class Executable extends Plugin implements IExecutable {
                 return origString;
             }
             newString = replaceString(origString, "{:mainfile}", runFiles.getMainFile().getName());
-            newString = replaceString(newString, "{files}", runFiles.getMainFile().getName());
+            newString = replaceString(newString, "{files}", ExecuteUtilities.getAllSubmittedFilenames(runFiles));
             newString = replaceString(newString, "{:basename}", removeExtension(runFiles.getMainFile().getName()));
             newString = replaceString(newString, "{:package}", packageName);
 

--- a/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
@@ -160,6 +160,16 @@ public class ExecuteUtilities extends Plugin {
     }
     
     
+    public static String getAllSubmittedFilenames(RunFiles files){
+        String filelist = files.getMainFile().getName();
+        if (files.getOtherFiles() != null && files.getOtherFiles().length > 0){
+            for (SerializedFile file : files.getOtherFiles()) {
+                filelist += " " + file.getName();
+            }
+        }
+        return filelist;
+    }
+    
     /**
      * return string with all field variables filled with values.
      * 
@@ -197,7 +207,7 @@ public class ExecuteUtilities extends Plugin {
             return origString;
         }
         newString = replaceString(origString, "{:mainfile}", runFiles.getMainFile().getName());
-        newString = replaceString(newString, "{files}", runFiles.getMainFile().getName());
+        newString = replaceString(newString, "{files}", getAllSubmittedFilenames(runFiles));
         newString = replaceString(newString, "{:basename}", removeExtension(runFiles.getMainFile().getName()));
 
         if (problem != null){

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1895,4 +1895,45 @@ public class ExecutableTest extends AbstractTestCase {
 
         assertValidationFailure(run, executable, 0, 1, noJudgement);
     }
+    
+    public void testsubstituteFiles() throws Exception {
+        SampleContest sampleContest = new SampleContest();
+        IInternalContest contest = sampleContest.createContest(2, 2, 12, 12, true);
+
+        Account[] teams = SampleContest.getTeamAccounts(contest);
+
+        Problem[] problems = contest.getProblems();
+        Language[] languages = contest.getLanguages();
+
+        Problem problem = problems[problems.length - 1];
+        Language language = languages[languages.length - 1];
+
+        ClientId submitter = teams[teams.length - 1].getClientId();
+
+        Run run = new Run(submitter, language, problem);
+
+        SerializedFile mainFile = new SerializedFile(getSamplesSourceFilename("Sumit.java"));
+
+        /**
+         * Expected list of files
+         */
+        String expected = "Sumit.java";
+
+        String[] sampleNames = { "ISumitFloatOutputTenUnitsOff.java", "ISumitFloatOutputTenPercentOff.java", "ISumitWrongOutputCase.java", };
+
+        SerializedFile[] otherFiles = new SerializedFile[sampleNames.length];
+        for (int i = 0; i < otherFiles.length; i++) {
+            otherFiles[i] = new SerializedFile(sampleNames[i]);
+            expected += " " + sampleNames[i];
+        }
+        RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);
+
+        Executable executable = new Executable(contest, controller, run, runFiles);
+
+        String filelist = executable.substituteAllStrings(run, "{files}");
+
+        assertEquals("Expected file list ", expected, filelist);
+
+    }
+    
 }

--- a/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
@@ -413,4 +413,52 @@ public class ExecuteUtilitiesTest extends AbstractTestCase {
         assertNotEquals("pc2.jar (path to) not found", path, ExecuteUtilities.DEFAULT_PC2_JAR_PATH);
     }
     
+    /**
+     * Test {files} substitution
+     * 
+     * @throws Exception
+     */
+    public void testgetAllSubmittedFilenames() throws Exception {
+        
+        SampleContest sampleContest = new SampleContest();
+        IInternalContest contest = sampleContest.createContest(2, 2, 12, 12, true);
+        
+        Account[] teams = SampleContest.getTeamAccounts(contest);
+
+        Problem[] problems = contest.getProblems();
+        Language[] languages = contest.getLanguages();
+
+        Problem problem = problems[problems.length-1];
+        Language language = languages[languages.length-1];
+        
+        ClientId submitter = teams[teams.length-1].getClientId();
+
+        Run run = new Run(submitter, language, problem);
+                
+        SerializedFile mainFile = new SerializedFile(getSamplesSourceFilename("Sumit.java"));
+        
+        /**
+         * Expected list of files
+         */
+        String expected = "Sumit.java";
+        
+        String [] sampleNames = {
+                "ISumitFloatOutputTenUnitsOff.java",
+                "ISumitFloatOutputTenPercentOff.java",
+                "ISumitWrongOutputCase.java",
+        };
+        
+        SerializedFile[] otherFiles = new SerializedFile[sampleNames.length];
+        for (int i = 0; i < otherFiles.length; i++) {
+            otherFiles[i] = new SerializedFile(sampleNames[i]);
+            expected += " " + sampleNames[i];
+        }
+        RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);
+        
+        String filelist = ExecuteUtilities.getAllSubmittedFilenames(runFiles);
+        
+        assertEquals("Expected file list ", expected, filelist);
+        
+    }
+    
 }


### PR DESCRIPTION
## Description

{files} now substitutes all files submitted, before it
just substituted the mainfilename.

Before {files} only substituted the main file, this fix
{files} will be substituted with all submitted filenames,
mainfile will be first filename


Steps to reproduce are in #52

## Issue(s)

#52

## Environment

All.

All.
