### PR TITLE
i32: change to halt and issue message if shadow cannot start

### DIFF
--- a/src/edu/csus/ecs/pc2/services/eventFeed/EventFeederModule.java
+++ b/src/edu/csus/ecs/pc2/services/eventFeed/EventFeederModule.java
@@ -97,12 +97,21 @@ public class EventFeederModule implements UIPlugin {
             shadowController = new ShadowController(contest, controller);
             if (contest.getContestInformation().isShadowMode()) {
                 showMessage("Starting shadow controller");
-                shadowController.start();
-                // the shadowController will autostart if the ContestInformation changes later
+
+                if (! shadowController.start()) {
+                    fatalError("Unable to start shadow controller (contact primary CCS?), check log", null);
+                }
             }
         } catch (Exception e) {
-            showMessage("Unable to start shadow controller " + e.getMessage(), e);
+            fatalError("Unable to start shadow controller", e);
         }
+    }
+
+    private void fatalError(String errorMessage, Exception e) {
+        String message = "Halting program.  " + errorMessage;
+        System.err.println(message);
+        getLog().log(Log.SEVERE, message, e);
+        System.exit(10);
     }
 
     protected String getL10nDateTime() {

--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -239,7 +239,12 @@ public class ShadowController {
             //construct an EventFeedMonitor for keeping track of the remote CCS events
             log.info("Constructing new RemoteEventFeedMonitor");
             monitor = new RemoteEventFeedMonitor(localController, remoteContestAPIAdapter, remoteCCSURL, remoteCCSLogin, remoteCCSPassword, submitter);
- 
+
+            if (! remoteContestAPIAdapter.testConnection()){
+                
+                return false;
+            }
+            
             //start the monitor running as a thread listening for submissions from the remote CCS
             monitorThread = new Thread(monitor);
             monitorThread.start();


### PR DESCRIPTION
**Feature Description**: 

When starting a shadow from the command line and the shadow cannot start, ex. cannot contact primary CCS, halt the program and issue an error message.

Currently the program silently fails and continues.   This give a false perception that the shadow has started.

**Have you considered other ways to accomplish the same thing?** 

Yes, but that requires a user to know know that the shadow has failed... somehow.

**Do you have any specific suggestions for how your feature would be ***implemented*** in PC^2?** If so, please describe.  

If there is any Exception on shadow startup, 
1 - print the message and full exception to the log
2 - print the exception message to console
3 - print message "Shadow could not start, halting program"
4 - System.exit(10);  // non zero exit code

**Additional context**: 

(PR Try 2)