### PR TITLE
I 76 add warning to repo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
  
 **NOTICE**  This public repository for the PC&sup2; Contest Control System is still _under development_.  You're welcome to look around, 
 but until an official announcement is made (and this is notice removed), _we do not recommend relying on the code published here_.
-If you are interested in obtaining a copy of PC&sup2; for running a contest, please refer to the [PC&sup2; home page](http://pc2.ecs.csus.edu).
+If you are interested in obtaining a copy of PC&sup2; for running a contest, please refer to the [PC&sup2; home page](https://pc2.ecs.csus.edu).
 
 PC^ 2 (the **P**rogramming **C**ontest **C**ontrol system, pronounced "P-C-squared" or sometimes just "P-C-Two" for short) is a 
 software system designed to support programming contest operations in a variety of computing environments including MS Windows, Mac OS/X,


### PR DESCRIPTION
# Description of what the PR does

Adds a "notice" to the Readme.md file indicating that the GitHub repo, while public, is not yet stable.  Includes a link to the PC2 home page on ECS.

### Issue which the PR fixes
Partial fix for #76.   The other part of the fix is to add the same notice to the pc2ccs.github.io Home page.
