### PR TITLE
fix url for docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # GitLab build configuration
 # this image includes openjdk-8-jdk, hugo, ant, curl, jq, httpie
-image: pc2fromecs:jdk8hugo
+image: pc2fromecs/jdk8hugo
 
 before_script:
   - echo "Running (empty) before_script cleanup..."


### PR DESCRIPTION
:blah denotes a tag name,  should have been :blah instead.
(latest is the default tag name, so it is not needed).

fixes #65
