### PR TITLE
i90: updated URL in README.MD to point to github.io website.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -34,7 +34,7 @@ guidelines for contributing.  Substantial additional information can also be fou
 [here](https://github.com/pc2ccs/pc2v9/wiki) and [here](https://github.com/pc2ccs/pc2v9/wiki/Contents).
 
 # Contact Information
-Website:  http://pc2.ecs.csus.edu/  
+Website:  https://pc2ccs.github.io/  
 mailto: pc2@ecs.csus.edu
 
 # How to report bugs or request new features


### PR DESCRIPTION
### Description of what the PR does
Changes the URL under "Contact Information" on the main GitHub repository page (i.e., in the README.MD file) to point to the pc2ccs.github.io website (instead of the old ECS website).

### Issue which the PR fixes
#90 

### Environment in which the PR was developed:
Windows 10 in Eclipse 2019-12.

### Additional Info:
  Part of the reason for this PR is to verify the operation of the GitLab build pipeline.  It requires a change to the "develop" (or master) branch to do that.
