### PR TITLE
i95: Added draft "history" and "permission" pages for website

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,7 +218,7 @@ update website:
     - cd $CI_PROJECT_DIR/website
     - hugo
     - cd ~/website
-    - sed -i -e 's/&amp;/\&/' index.html current/index.html all-builds/index.html previous/index.html
+    - sed -i -e 's/&amp;/\&/' index.html current/index.html all-builds/index.html previous/index.html history/index.html permission/index.html
     - git add .
     - git commit --allow-empty -m "Update website for pc2v9 commit $CI_COMMIT_SHA"
     - git push

--- a/website/content/history.md
+++ b/website/content/history.md
@@ -1,0 +1,204 @@
+
+---
+title: "A Bit of History"
+description: "The (somewhat abridged) history of PC2"
+date: 2020-05-17T01:09:41+00:00
+draft: false
+weight: 4
+icon: fas fa-highlighter
+---
+
+This page could be titled "PC&sup2; -- the Early Years".  It covers some (certainly not all) of what happened during the first two decades of PC&sup2; development...
+
+## 1988
+
+September: Mary Richmond, Dave Bosley, Paul Meyers, and some other guy named Doug Lane make the mistake of accepting a Senior Project called PC&sup2; from Professor John Clevenger in the Computer Science Department at CSUS.
+That Lane guy still has no clue. Bliss is ignorance.
+
+## 1989
+
+* April: Version 1.0 (Turbo Pascal) is used for CSUS Spring Local Contest.
+* September: Mary, Dave, and Doug start "Special Project" to enhance the system to support multiple sites.
+
+* October: CSUS Local Contest used to test Version 2.? with "red & green" sites. John and Dave travel to Portland to check out UP site for Regional
+
+* November: Version 2.? used to run Pacific Regional at CSUS and University of Portland. Dave at Portland site. Remote site updates via ProComm/Kermit.
+
+## 1990
+
+* February: Version 2.? used to run Contest Finals in Washington, D.C. John detained by White House security (really).
+* October: Version 3.? used to run CSUS local contest
+* October: John and Doug visit Ellensburg, WA (always good to be upwind).
+* November: Version 3.2 used to run Pacific Regionals at CSU,Stanislaus and Central Washington University. Doug at CWU.
+
+## 1991
+
+* March: Version 3.2 described and distributed in a presentation to Regional Contest Director's Workshop at Contest Finals in San Antonio (Unix-based environment used for Finals).
+* April: Version 3.? used in CSUS Spring Local Contest
+
+* September: Eric LaMar and Richard Cuny start "Multi-Site Extension" Senior Project.
+
+* October: Version 3.? used in CSUS Fall Local Contest
+
+* November: John and Doug travel to Pacific Lutheran U., Tacoma
+
+* November: Version 3.? used in Pacific Regional Contest at UOP (Stockton) and PLU (Tacoma)
+
+## 1992
+
+* April: Version ?.? with MSE used in CSUS Spring Local, with Red, Blue, and Green sites
+
+* October: Version ?.? used in CSUS Fall Local Contest, with Red/Blue sites
+
+* November: Doug and John travel to Ohio to run the East Central Regional Contest, using Version ?.? with Red, Green, and Blue sites. Still strictly floppy-based
+
+* November: Version ?.? used in Pacific Regional Contest at Cal State Chico and Western Washington University (Doug went to Bellingham). Still floppy-only.
+
+## 1993
+
+* October: CSUS Fall Local Contest is run using Version 4.?, still floppy-only. First ever attempt to reuse exactly the same bitset to run a contest fails due to Lab Virus.
+* November: unknown person "Sam Ashoo" arrives at John's office with the foolish request to have a copy of PC2 to look at. John foolishly agrees and gives him version ?.? (floppy-mode only).
+
+* November: Pacific Regional Contest at CSU,Fresno and University of Oregon (Eugene). Doug at UO; Sam at Fresno. Used version ?.? (floppy-only); used Borland tools.
+
+* December: we were asked to provide software for the Finals to be held in Phoenix in March 1994.
+
+## 1994
+* January/February 1994 -- Randy Kath, Mark Measures, Dave Brennan, Dick Rinewalt, and Jo Perry came to Sacramento; we worked on some updates to 4.1, mostly on getting it to work with NT/AS. Doug came to Sacramento from Phoenix. We came up with Version "4.2A", which was still floppy-based, but "almost" worked with the LAN. Shortly after everybody left we fixed the last problem with LAN mode, and called it "4.2B".
+
+* March 1994 -- Finals in Phoenix. I spent a long time trying to convince Mark to go with 4.2B (LAN), but he wouldn't budge. We used 4.2A, with floppies, even though the LAN was in place and was used for clarifications (using Microsoft email stuff).
+
+* September 1994 -- we must have either done additional updates, or at least renumbered 4.2B to 4.3.
+
+* October 1994 -- John wrote a complete set of documentation (Administrator's Guide, Installation and Operation Guide) for Version 4.3.
+
+* November 1994 -- Version 4.? used for CSUS Fall Local.
+
+* November 1994 -- Version 4.? used at Pacific Regional at UW and USF. Doug and John at UW; Sam and Rob at USF.
+
+## 1995
+
+* January -- Testing in Sacramento
+* March -- Version 4.5 used in Nashville for Finals. Windows-based Team module, but Master/Judge/Scoreboard old Pascal Version.
+
+* April -- Sam provides "Version 4.5B". Slightly different from 4.5 used in Nashville.
+
+* June -- Development of Windows-based system starts.
+
+* Fall -- Troy Boudreau spends so much time hanging around, he is made official 'tester'. Proves to be a mistake; he's too good at finding bugs.
+
+* October -- PC2/Windows hobbles through local contest.
+
+* November -- Small UFO's contact PC2, claim they are friendly.
+
+## 1996
+
+* March -- Version 6.1 used to run Finals in Philadelphia. COLD! Code wrote funny little messages to our love slaves.
+* November -- Version 6.2 used for Pacific Regional and Mountain Regional.
+
+## 1997
+
+* March -- Version 6.3, Finals in San Jose, other than the bomb threat things went ok. Got those neat laser pointers.
+* Fall -- Tammy Torok makes mistake of asking John if he has any Masters projects available. Carefully making sure she cannot talk to Sam or Doug, John describes the concept of a platform-independent, Internet-based contest system. Tammy starts coding a prototype. Sam and Doug eventually warn her, but it's too late.
+
+* November -- Version 6.33 Pacific Regionals in Chico and Spokane WA. Discovered some very strange timing bugs.
+
+## 1998
+
+* March -- Fixed the timing bugs, but never created a new release number; reverted in fact to 6.3. Posted 6.3 on the Web; froze that as the last Windows-based version.
+Finals in Atlanta GA, cool cars we raced around in..
+
+* May -- Tammy demonstrates working prototype to John.
+
+* June -- Team meeting in which Sam, Doug, and Troy agree to look over prototype code.
+
+* September -- Sam, Doug, and Troy actually DO look over code, start in earnest on development of a complete system based on the prototype. Tammy finishes Master's Degree, makes mistake and accepts invitation to continue working on the project.
+
+* October -- Debut of PC^2 Version 7.0 (Beta) at CSUS Local Contest. Amazingly, it survives quite nicely!
+
+* November -- Version 7 Beta3 used to run South Central Regional in Houston (Rice University). System has performance lag which causes problems in Practice Contest, but does well in Real Contest. Other issues related to that particular contest best left undocumented... Later November -- Version 7 Beta 3, used to run Pacific Regionals at CSU, Chico and up north somewhere.
+
+## 1999
+
+* March - Version 7.1a (aka beta4 3/18) used to run CSUS Spring Programming Contest, works marvelously.
+* April - (Finals) Eindhoven The Netherlands, TUE, Arrived with 7.1a (3/18), used 7.1d used in contest due to new requirements from judges. Practice contest (aka stress test) shows some system/server (PC^2) load issues. Real contest works well, slows down at the end but some "stalls" are attributed to PC² server load. Another success.
+
+* Summer - Version 7.2 prepared for release. 7.1 stalls no longer happen. Supporting Unix and using Java Swing interface.
+
+* November - Mid-Atlantic Regional - Virginia Tech Version 7.3 (10/19) Complete Unix Contest, FreeBSD and Solaris. All went well except one site, which had just bad karma (and poor support). Supported 8 sites with 144 teams.
+
+* November 13 - Pacific Regional - Chico CA Version 7.3 (10/19). During the practice contest, lost complete power to judge's area. Recovered beautifully (once there was power). Within 1 hour of end of the contest, judging done, standings verified, all done - just terrific.
+
+## 2000
+* March 17 - Version 7.4 released on web site.
+
+* March - Finals in Orlando Florida, Version 7.4 (03/18 #3). Supported both the Finals and a site in Europe (TUE) for a team that could not get to Orlando. Went very well, small glitch found but within 5 minutes there was a workaround in place, code fixed.
+
+* April - High School Contest at CSUS - Version 7.4 (3/18 #3). Went very well.
+
+* November 12 - Pacific Regional - Spokane WA Version 7.5 patch 3. Very cold (brr, high of 32), snow. Minor setup issues (not with PC², but with things like compiler PATHs). Contest went just fine.
+
+## 2001
+* February 9 - Version 7.6 released
+
+* February - DeVry University, Fremont, local contest. Excellent setup and people. Contest went nearly perfect.
+
+* March 5th-11th, ACM Finals (Vancouver BC) version 7.4d
+
+* August 17 - New Zealand, practice regional contest.
+
+* September 11th, 2001 - New Zealand trip for regional contest cancelled, could not fly out that day (think about it).
+
+## 2002
+* March 23rd --  ACM Finals (Honolulu HI) Version 8.1
+* Local Contest in Mexico
+
+* November 9th - Northern Pacific Regional Contest, Seattle/Fremont
+
+* November 22nd - Released version 8.3 and posted 7.6 too.
+
+## 2003
+* March 25th --  ACM ICPC Finals (Hollywood CA) using Version 8.4
+* March 26th - Version 8.4 Posted/released.
+* August 25th - Version 8.5 Posted/released. (New, and up to date, documents)
+
+* November 19th - Version 8.5d Posted/released.
+
+* December 12th - a new set of CSUS students, you know who you are, decide to improve the transport (and attitude) of the existing PC2 group. We wish them great luck for obvious reasons.
+
+## 2004
+* March 31st - ACM ICPC Finals (Prague, Czech Republic) using Version 8.5
+* November - North Pacific Regional using version 8.6 Portland/Stockton (UOP)
+* December - PC2 used at the ANARC (Arab and North Africa Regional Contest.
+
+## 2005
+* January 25th - Version 8.6 Posted/released. (WhatsNew document)
+* April 6th - ACM ICPC Finals (Shanghai China) using Version 8.6
+
+* November - North Pacific Regional using version 8.6 Portland/Stockton (UOP)
+
+* November 11th - PC2 Version 8.6 Patch 2 posted/released.
+
+* December - PC2 8.6 Patch 2 used at the ANARC.
+
+* December 5th - First article created in PC² Wiki
+
+## 2006
+* April 12th - ACM ICPC Finals (San Antonio Texas) using Version 8.7
+* June 6th - PC2 Version 8.7 posted/released.
+
+## 2007
+* March 15th - ACM ICPC Finals (Tokyo Japan) using Version 8.7 and new snazzy scoreboards
+* November - North Pacific Regional using version 9.0 beta (Vancouver B.C., Seattle WA Spokane WA, Stanford CA, Hawaii)
+
+## 2008
+* April 9th - ACM ICPC Finals (Banff Alberta Canada) using Version 9.0.2
+* November - North Pacific Regional - November 15th, 2008 (Vancouver B.C., Portland OR, Spokane WA, Stanford CA, Hawaii) using version 9.1.0 build 1655
+
+## 2009
+* April - ACM ICPC Finals (Stockholm Sweden) using Version 9.1.1
+* June - Version 9.1.2 Build 1871 is now public release.
+
+-----------------
+
+For additional (more recent) information, see [PC2 Recent releases](https://github.com/pc2ccs/pc2v9/wiki/PC2-Recent-Releases)

--- a/website/content/history.md
+++ b/website/content/history.md
@@ -4,7 +4,7 @@ title: "A Bit of History"
 description: "The (somewhat abridged) history of PC2"
 date: 2020-05-17T01:09:41+00:00
 draft: false
-weight: 4
+weight: 20
 icon: fas fa-highlighter
 ---
 

--- a/website/content/permission.md
+++ b/website/content/permission.md
@@ -4,7 +4,7 @@ title: "Permission"
 description: "Information regarding use of PC2"
 date: 2020-05-17T01:09:41+00:00
 draft: false
-weight: 5
+weight: 30
 icon: fas fa-balance-scale-right
 ---
 

--- a/website/content/permission.md
+++ b/website/content/permission.md
@@ -1,0 +1,15 @@
+
+---
+title: "Permission"
+description: "Information regarding use of PC2"
+date: 2020-05-17T01:09:41+00:00
+draft: false
+weight: 5
+icon: fas fa-balance-scale-right
+---
+
+The legal use of PC&sup2; is governed by the [Eclipse Public License v2.0](https://github.com/pc2ccs/pc2v9/blob/develop/LICENSE.TXT).  
+
+PC&sup2; was originally developed, and continues to be developed, by a community of volunteers according to a certain set of community principles and guidelines. One of those principles centers around the concept that _we didn't develop it to make money_, but rather to provide tools for people who want to run programming contests.  We have donated it to the open-source community in that same spirit.  As a result, we would take offense if someone were to take our free community project and attempt to make a profit from it.
+
+Note also that the license under which PC&sup2; is distributed requires (Section 3.1a) that _any modifications which are made to the program must be distributed in **source code** form_.  In other words, you can modify it however you like, but if you do then _you must freely distribute your modifications_.


### PR DESCRIPTION

### Description of what the PR does
Adds new "history" and "permission" pages to the website **/content** folder.

### Issue which the PR fixes
Fixes #95 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10 using Eclipse 2019-12.

### Additional info:
All this PR does is define new pages (files) in the **/content** folder.  The added pages are _static_; they don't contain any references to other website data (such as required **layout** information).  I don't _think_ there are any other changes which need to be done to add these pages (but I could be wrong; if so, someone please comment in a review).
