### PR TITLE
add tar.gz support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,7 +218,7 @@ update website:
     - cd $CI_PROJECT_DIR/website
     - hugo
     - cd ~/website
-    - sed -i -e 's/&amp;/\&/' index.html current/index.html all-builds/index.html previous/index.html history/index.html permission/index.html
+    - sed -i -e 's/&amp;/\&/g' index.html */index.html
     - git add .
     - git commit --allow-empty -m "Update website for pc2v9 commit $CI_COMMIT_SHA"
     - git push

--- a/website/layouts/shortcodes/allbuilds.html
+++ b/website/layouts/shortcodes/allbuilds.html
@@ -15,14 +15,24 @@
             {{ $download := index $build.downloads $pc2.tool }}
             <tr>
                 <td><b>{{ $pc2.name }}</b></td>
-                <td align="right">{{ $download.size }} MB</td>
                 <td>
-                    <a href="{{ $download.urls.zip }}">{{ $pc2.tool }}-{{ $download.version }}.zip</a>
-                    {{ if and (isset $download.urls "sha256") (isset $download.urls "sha512") }}
-                    (<a href="{{ $download.urls.sha256 }}">sha256</a>, <a href="{{ $download.urls.sha512 }}">sha512</a>)
+                    <a href="{{ $download.urls.zip }}">{{ $pc2.tool }}-{{ $download.version }}.zip</a> ({{ $download.sizes.zip }} MB)
+                    {{ if and (isset $download.urls.sha256 "zip") (isset $download.urls.sha512 "zip") }}
+                    (<a href="{{ $download.urls.sha256.zip }}">sha256</a>, <a href="{{ $download.urls.sha512.zip }}">sha512</a>)
                     {{ end }}
                 </td>
             </tr>
+                {{ if isset $download.urls "tar_gz" }}
+            <tr>
+                <th>{{ $pc2.name }} in tar.gz form</th>
+                <td>
+                    <a href="{{ $download.urls.tar_gz }}">{{ $pc2.tool }}-{{ $download.version }}.tar.gz</a> ({{ $download.sizes.tar_gz }} MB)
+                    {{ if and (isset $download.urls.sha256 "tar_gz") (isset $download.urls.sha512 "tar_gz") }}
+                    (<a href="{{ $download.urls.sha256.tar_gz }}">sha256</a>, <a href="{{ $download.urls.sha512.tar_gz }}">sha512</a>)
+                    {{ end }}
+                </td>
+            </tr>
+                {{ end }}
             {{ end }}
         {{ end }}
     </tbody>

--- a/website/layouts/shortcodes/pc2block.html
+++ b/website/layouts/shortcodes/pc2block.html
@@ -4,16 +4,16 @@
 {{ $stableTool := index $stableRelease.downloads (.Get "toolname") }}
 {{ $prerelaseTool := index $preRelease.downloads (.Get "toolname") }}
 {{ $nightlyTool := index $nightly.downloads (.Get "toolname") }}
-<div class="col-md-6 mb-3">
+<div class="col-md-9 mb-3">
     <p>
         {{ .Get "description" }}
     </p>
     <p>
         Downloads: <br/> 
-        Stable Release: <a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} version {{ $stableTool.version }}</a><br />
-        Release Candidate: <a href="{{ $prerelaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prerelaseTool.version }}</a><br />
-        Nightly Build: <a href="{{ $nightlyTool.urls.zip }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}</a><br />
-        Documentation: <a href="/docs/{{ .Get "doc" }}.pdf">Contest Administrator's Guide (PDF)</a><br />
+        Stable Release: &nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.tar.gz</a><br />
+        Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prerelaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prerelaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prerelaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prerelaseTool.version }}.tar.gz</a><br />
+        Nightly Build: &nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.zip }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}.tar.gz</a><br />
+        Documentation: &nbsp;&nbsp;&nbsp;<a href="/docs/{{ .Get "doc" }}.pdf">Contest Administrator's Guide (PDF)</a><br />
     </p>
     <p>
         <a href="{{ .Get "page" }}">More information</a>

--- a/website/layouts/shortcodes/pc2download.html
+++ b/website/layouts/shortcodes/pc2download.html
@@ -10,19 +10,31 @@
     The latest stable release {{ .Get "name" }} version is {{ $stableTool.version }}, released on {{ $stableRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-primary" href="{{ $stableTool.urls.zip }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" }}</i> (version {{ $stableTool.version }})</a>
+    <a class="btn btn-primary" href="{{ $stableTool.urls.zip }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" }}</i> (version {{ $stableTool.version }}) as zip</a>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <a class="btn btn-primary" href="{{ $stableTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" }}</i> (version {{ $stableTool.version }}) as tar.gz</a>
+    <br />
+    <br />
 </p>
 <p>
     The latest release candidate {{ .Get "name" }} version is {{ $prerelaseTool.version }}, released on {{ $preRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.zip }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prerelaseTool.version }})</a>
+    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.zip }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prerelaseTool.version }}) as zip</a>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prerelaseTool.version }}) as tar.gz</a>
+    <br />
+    <br />
 </p>
 <p>
     The latest nightly build {{ .Get "name" }} version is {{ $nightlyTool.version }}, released on {{ $nightly.date }}.
 </p>
 <p>
-    <a class="btn btn-danger" href="{{ $nightlyTool.urls.zip }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" }}</i> (version {{ $nightlyTool.version }})</a>
+    <a class="btn btn-danger" href="{{ $nightlyTool.urls.zip }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" }}</i> (version {{ $nightlyTool.version }}) as zip</a>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <a class="btn btn-danger" href="{{ $nightlyTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" }}</i> (version {{ $nightlyTool.version }}) as tar.gz</a>
+    <br />
+    <br />
 </p>
 <h2>Documentation</h2>
 

--- a/website/layouts/shortcodes/previousbuilds.html
+++ b/website/layouts/shortcodes/previousbuilds.html
@@ -15,14 +15,24 @@
             {{ $download := index $build.downloads $pc2.tool }}
             <tr>
                 <th>{{ $pc2.name }}</th>
-                <td align="right">{{ $download.size }} MB</td>
                 <td>
-                    <a href="{{ $download.urls.zip }}">{{ $pc2.tool }}-{{ $download.version }}.zip</a>
-                    {{ if and (isset $download.urls "sha256") (isset $download.urls "sha512") }}
-                    (<a href="{{ $download.urls.sha256 }}">sha256</a>, <a href="{{ $download.urls.sha512 }}">sha512</a>)
+                    <a href="{{ $download.urls.zip }}">{{ $pc2.tool }}-{{ $download.version }}.zip</a> ({{ $download.sizes.zip }} MB)
+                    {{ if and (isset $download.urls.sha256 "zip") (isset $download.urls.sha512 "zip") }}
+                    (<a href="{{ $download.urls.sha256.zip }}">sha256</a>, <a href="{{ $download.urls.sha512.zip }}">sha512</a>)
                     {{ end }}
                 </td>
             </tr>
+                {{ if isset $download.urls "tar_gz" }}
+            <tr>
+                <th>{{ $pc2.name }} in tar.gz form</th>
+                <td>
+                    <a href="{{ $download.urls.tar_gz }}">{{ $pc2.tool }}-{{ $download.version }}.tar.gz</a> ({{ $download.sizes.tar_gz }} MB)
+                    {{ if and (isset $download.urls.sha256 "tar_gz") (isset $download.urls.sha512 "tar_gz") }}
+                    (<a href="{{ $download.urls.sha256.tar_gz }}">sha256</a>, <a href="{{ $download.urls.sha512.tar_gz }}">sha512</a>)
+                    {{ end }}
+                </td>
+            </tr>
+                {{ end }}
             {{ end }}
         {{ end }}
     </tbody>

--- a/website/scripts/populate-releases.py
+++ b/website/scripts/populate-releases.py
@@ -82,15 +82,23 @@ def release_info(release):
         if not tool in info['downloads']:
             info['downloads'][tool] = {
                 'version': version,
-                'urls': {}
+                'urls': {'sha256': {}, 'sha512': {}},
+                'sizes': {},
             }
         if check == "":
-            info['downloads'][tool]['urls']['zip'] = url
-            info['downloads'][tool]['size'] = round(asset['size'] / 1024 / 1024, 2)
+            if 'zip' in url:
+                info['downloads'][tool]['urls']['zip'] = url
+                info['downloads'][tool]['sizes']['zip'] = round(asset['size'] / 1024 / 1024, 2)
+            else:
+                info['downloads'][tool]['urls']['tar_gz'] = url
+                info['downloads'][tool]['sizes']['tar_gz'] = round(asset['size'] / 1024 / 1024, 2)
         else:
             if ".txt" in check:
                 check = check[:-4]
-            info['downloads'][tool]['urls'][check] = url
+            if 'zip' in url:
+                info['downloads'][tool]['urls'][check]['zip'] = url
+            else:
+                info['downloads'][tool]['urls'][check]['tar_gz'] = url
 
     return info
 


### PR DESCRIPTION
### Description of what the PR does
This exposes the tar.gz files in the json created by populate-release.py, along
with separate checksums and sizes per zip or tar.gz, necessary changes in the html shortcodes, to show both zip and tar.gz files.

### Issue which the PR fixes
fixes #93 

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

checkout this PR locally,  from the pc2v9 dir run ./website/scripts/populate-releases.py,
from the website subdir run `hugo` (and run the sed from .gitlab-ci.yml, and then copy the public somewhere you can look at it), or run `hugo server` (be aware that hugo server will show `&ampsup2;` in the titles and previous/all-builds pages).