### PR TITLE
compare the pusblished_at dates to determine if there is a pre-release

### DIFF
--- a/website/layouts/shortcodes/pc2block.html
+++ b/website/layouts/shortcodes/pc2block.html
@@ -2,7 +2,7 @@
 {{ $preRelease := index $.Site.Data.releases.prerelease }}
 {{ $nightly := index $.Site.Data.releases.nightly }}
 {{ $stableTool := index $stableRelease.downloads (.Get "toolname") }}
-{{ $prerelaseTool := index $preRelease.downloads (.Get "toolname") }}
+{{ $prereleaseTool := index $preRelease.downloads (.Get "toolname") }}
 {{ $nightlyTool := index $nightly.downloads (.Get "toolname") }}
 <div class="col-md-9 mb-3">
     <p>
@@ -11,7 +11,11 @@
     <p>
         Downloads: <br/> 
         Stable Release: &nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.tar.gz</a><br />
-        Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prerelaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prerelaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prerelaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prerelaseTool.version }}.tar.gz</a><br />
+{{ if gt $prereleaseTool.published_at $stableTool.published_at }}
+        Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
+{{ else }}
+        No release candidate at this time.<br />
+{{ end }}
         Nightly Build: &nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.zip }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}.tar.gz</a><br />
         Documentation: &nbsp;&nbsp;&nbsp;<a href="/docs/{{ .Get "doc" }}.pdf">Contest Administrator's Guide (PDF)</a><br />
     </p>

--- a/website/layouts/shortcodes/pc2download.html
+++ b/website/layouts/shortcodes/pc2download.html
@@ -2,7 +2,7 @@
 {{ $preRelease := index $.Site.Data.releases.prerelease }}
 {{ $nightly := index $.Site.Data.releases.nightly }}
 {{ $stableTool := index $stableRelease.downloads (.Get "toolname") }}
-{{ $prerelaseTool := index $preRelease.downloads (.Get "toolname") }}
+{{ $prereleaseTool := index $preRelease.downloads (.Get "toolname") }}
 {{ $nightlyTool := index $nightly.downloads (.Get "toolname") }}
 
 <h2>Download</h2>
@@ -17,12 +17,17 @@
     <br />
 </p>
 <p>
-    The latest release candidate {{ .Get "name" }} version is {{ $prerelaseTool.version }}, released on {{ $preRelease.date }}.
+{{ if gt $prereleaseTool.published_at $stableTool.published_at }}
+        Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
+    The latest release candidate {{ .Get "name" }} version is {{ $prereleaseTool.version }}, released on {{ $preRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.zip }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prerelaseTool.version }}) as zip</a>
+    <a class="btn btn-danger" href="{{ $prereleaseTool.urls.zip }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prereleaseTool.version }}) as zip</a>
     &nbsp;&nbsp;&nbsp;&nbsp;
-    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prerelaseTool.version }}) as tar.gz</a>
+    <a class="btn btn-danger" href="{{ $prereleaseTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prereleaseTool.version }}) as tar.gz</a>
+{{ else }}
+        No release candidate at this time.
+{{ end }}
     <br />
     <br />
 </p>


### PR DESCRIPTION
Hides the pre-release unless it is newer then the Stable.
also fixes release typo.

fixes #99 

See [testing website changes](https://github.com/pc2ccs/pc2v9/wiki/Building-the-PC2-GitHub-Website#testing-website-changes)