### PR TITLE
I108 wti scoreboard2 password

### DIFF
--- a/projects/WTI-API/packageWTI.xml
+++ b/projects/WTI-API/packageWTI.xml
@@ -36,6 +36,9 @@
 		
 		<!-- copy pc2v9.ini to staging -->
 		<copy file="pc2v9.ini" todir="${staging.dist.dir}"/> 
+		
+		<!-- add a default scoreboard2 password to the WTI's pc2v9.ini -->
+		<concat destfile="${staging.dist.dir}/pc2v9.ini" append="true">scoreboard2password=scoreboard2</concat>
 
 		<!-- copy scripts to staging /bin folder-->
 		<mkdir dir="${staging.dist.dir}/bin" />

--- a/projects/WTI-API/packageWTI.xml
+++ b/projects/WTI-API/packageWTI.xml
@@ -16,6 +16,10 @@
 	
 	<!-- the directory where the user documentation (user manual) can be found -->
 	<property name="doc.dir" location ="doc/User Manual" />
+	
+	<!-- the set of properties we want to add to the WTI pc2v9.ini file -->
+	<property name="wtiDefaultScoreboardInfo" 
+				value="wtiscoreboardaccount=scoreboard2${line.separator}wtiscoreboardpassword=scoreboard2${line.separator}" />
 
 	<!-- remove any files left over in the distribution directory -->
     <target name="cleandist" description="remove any previous dist files">
@@ -37,8 +41,15 @@
 		<!-- copy pc2v9.ini to staging -->
 		<copy file="pc2v9.ini" todir="${staging.dist.dir}"/> 
 		
-		<!-- add a default scoreboard2 password to the WTI's pc2v9.ini -->
-		<concat destfile="${staging.dist.dir}/pc2v9.ini" append="true">scoreboard2password=scoreboard2</concat>
+		<!-- add default scoreboard account/password properties to the WTI's pc2v9.ini, in front of the "# eof" line -->
+		<!--  NOTE: this will fail (i.e., do nothing) if somebody, someday, deletes the "# eof" line from the pc2v9/pc2v9.ini file.
+		      The ramification will be that an end user will have to manually add "wtiscoreboardaccount=xxx" and 
+		      "wtiscoreboardpassword=yyy" entries to their WTI pc2v9.ini file in order to connect to the PC2 server.
+		      -->
+		<replaceregexp file="${staging.dist.dir}/pc2v9.ini"
+		               match="# eof.*"
+		               replace="${wtiDefaultScoreboardInfo}${line.separator}# eof"
+		               byline="true"/>
 
 		<!-- copy scripts to staging /bin folder-->
 		<mkdir dir="${staging.dist.dir}/bin" />

--- a/projects/WTI-API/packageWTI.xml
+++ b/projects/WTI-API/packageWTI.xml
@@ -17,10 +17,6 @@
 	<!-- the directory where the user documentation (user manual) can be found -->
 	<property name="doc.dir" location ="doc/User Manual" />
 	
-	<!-- the set of properties we want to add to the WTI pc2v9.ini file -->
-	<property name="wtiDefaultScoreboardInfo" 
-				value="wtiscoreboardaccount=scoreboard2${line.separator}wtiscoreboardpassword=scoreboard2${line.separator}" />
-
 	<!-- remove any files left over in the distribution directory -->
     <target name="cleandist" description="remove any previous dist files">
         <delete dir="${staging.dist.dir}" />
@@ -41,16 +37,6 @@
 		<!-- copy pc2v9.ini to staging -->
 		<copy file="pc2v9.ini" todir="${staging.dist.dir}"/> 
 		
-		<!-- add default scoreboard account/password properties to the WTI's pc2v9.ini, in front of the "# eof" line -->
-		<!--  NOTE: this will fail (i.e., do nothing) if somebody, someday, deletes the "# eof" line from the pc2v9/pc2v9.ini file.
-		      The ramification will be that an end user will have to manually add "wtiscoreboardaccount=xxx" and 
-		      "wtiscoreboardpassword=yyy" entries to their WTI pc2v9.ini file in order to connect to the PC2 server.
-		      -->
-		<replaceregexp file="${staging.dist.dir}/pc2v9.ini"
-		               match="# eof.*"
-		               replace="${wtiDefaultScoreboardInfo}${line.separator}# eof"
-		               byline="true"/>
-
 		<!-- copy scripts to staging /bin folder-->
 		<mkdir dir="${staging.dist.dir}/bin" />
 		<copy todir="${staging.dist.dir}/bin">  <fileset dir="${scripts.src.dir}"/>  </copy>

--- a/projects/WTI-API/pc2v9.ini
+++ b/projects/WTI-API/pc2v9.ini
@@ -24,5 +24,7 @@ server=localhost:50002
 # For WebTeamInterface server
 wtiport=8080
 wtiwsName=/websocket
+wtiscoreboardaccount=scoreboard2
+wtiscoreboardpassword=scoreboard2
 
 # eof 

--- a/projects/WTI-UI/.classpath
+++ b/projects/WTI-UI/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container/WTI-API"/>
 	<classpathentry kind="lib" path="/pc2v9/vendor/lib/junit-4.11.jar"/>
-	<classpathentry kind="src" path="/WTI-API"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
### Description of what the PR does
  Updates the **packageWTI.xml** file so that after it copies the (default) **pc2v9.ini** file from the pc2v9 project source into the WTI distribution, it appends to the file a set of entries defining default "wti scoreboard account" and "wti scoreboard password" values.  Also updates the WTI-UI .classpath to reference the WTI-API project (which is necessary for the WTI-UI project to build correctly).

The default scoreboard values inserted into the WTI **pc2v9.ini** are the same as those originally used by the EWTeam:  account "scoreboard2" with the PC2 default password (also "scoreboard2").

This allows an end user to make zero configuration changes in order to use the WTI; all they have to do is create the "scoreboard2" account.  In addition, having property values in the WTI's **pc2v9.ini** file allows the user to change to a different scoreboard account if desired; all they have to do is edit the property values in the **pc2v9.ini** prior to starting the WTI.

A separate PR  (#107) has been submitted which contains Admin Guide documentation for this change.

### Issue which the PR fixes
Fixes #108 

### Environment in which the PR was developed:
Windows 10 with Java 1.8.0_201 and Ant version 1.10.6.

### How to Test this PR :

 1. Download the code for this PR.
 1. Use Ant to run **pc2v9/package.xml** to build a complete PC2v9 distribution (this will automatically include the WTI project distribution using the PR-updated **packageWTI.xml** file).
 1. Copy the resulting **pc2-9.xbuild-xxx .zip** or **.tar.gz** PC2 distribution file (created in the **pc2v9/dist** folder by the previous step) to any convenient location, and  unzip it.
 1. Go into the **pc2buildxx/projects** folder in the distribution and copy the **WebTeamInterface-xx** **.zip** or **.tar.gz** file to any convenient location, then unzip it.
 1. Go into the resulting **WebTeamInterface-xx** folder
 1. Examine the **pc2v9.ini** file in the **WebTeamInterface-xx** folder; verify that it contains the following entries:
  * wtiscoreboardaccount=scoreboard2
  * wtiscoreboardpassword=scoreboard2



