### PR TITLE
i136: add "windows eol/eof" params to Viva pattern files.

### DIFF
--- a/testdata/VivaAdapterTest/Viva.InvalidPattern.viva
+++ b/testdata/VivaAdapterTest/Viva.InvalidPattern.viva
@@ -1,3 +1,4 @@
+# eolnstyle="windows" eofstyle="windows" #
 {
 [= n (n=0)]
 n:integer (minint<=n<=maxint)

--- a/testdata/VivaAdapterTest/Viva.ValidPattern.FailOnDataPastZeroSentinel.viva
+++ b/testdata/VivaAdapterTest/Viva.ValidPattern.FailOnDataPastZeroSentinel.viva
@@ -1,3 +1,4 @@
+# eolnstyle="windows" eofstyle="windows" #
 {
 [= n (n=0)]
 <n>;

--- a/testdata/VivaAdapterTest/Viva.ValidPattern.FailOnMultipleDataPerLine.viva
+++ b/testdata/VivaAdapterTest/Viva.ValidPattern.FailOnMultipleDataPerLine.viva
@@ -1,3 +1,4 @@
+# eolnstyle="windows" eofstyle="windows" #
 {
 n:integer ;
 }

--- a/testdata/VivaAdapterTest/Viva.ValidPattern.FailOnNegative.viva
+++ b/testdata/VivaAdapterTest/Viva.ValidPattern.FailOnNegative.viva
@@ -1,3 +1,4 @@
+# eolnstyle="windows" eofstyle="windows" #
 {
 <n:integer (0<=n)>;
 }


### PR DESCRIPTION
### Description of what the PR does
Adds the Viva parameter list `# eolnstyle="windows" eofstyle="windows" #` to the four Viva pattern files used by the VivaAdapterTest JUnit, as recommended by Viva author Vanb.

### Issue which the PR fixes
Fixes #136 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10, Java 8_201.

### Precise steps for _testing_ the PR:
- Download the code and run the VivaAdapterTest JUnit on a Windows machine; verify it passes all tests.
- Download and run the same JUnit on a Linux machine; verify it passes all tests.

### Additional Notes:
An alternative way to fix Issue #136  would be to add to all the Viva JUnits code which 

1. detects the current OS platform, 
2. reads the `SerializedFile`s containing each of the test data files in the `testdata/VivaAdapterTest` folder, 
3. tests each of those files to determine its _current_ OS eol/eof conventions, 
4. writes new data files conforming to the current OS platform, 
5. creates new SerializedFiles for each of those new data files, and 
6. uses the updated SerializedFiles in doing all the Viva tests.

In addition to being WAY more work than is necessary (as opposed to the simple fix given in this PR, which is to _use Viva's already-built-in support for this issue_), this would be subject to failure if new test data files were added in the future; the JUnit would have to be updated to recognized those new files which also need to be converted.  With the current approach (the one recommended by Vanb), new data files would "just work correctly".