### PR TITLE
update node and npm versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,14 @@ job-build:
   stage: build
   script:
     - echo "Running ant on package.xml"
+    # we were running node/npm v8.10/3.5.2 which started failing in Nov of 2020
+    # install "n" the Node/npm version manager/updater
+    - npm install -g n
+    # Install the latest stable version of nodejs/npm
+    - n stable
+    - export PATH="/usr/local/bin:$PATH"
+    - npm --version
+    - node --version
     - ant -file package.xml
     - echo $CI_JOB_ID > dist/ci_job_id.txt
   artifacts:


### PR DESCRIPTION
from v8.10.0/3.5.2 to v14.15.1 (with npm 6.14.8)

fixes #140

to reproduce the steps you would have to start with nodejs and npm on ubuntu18.04
which should get to v8.10.0/3.5.2
(or you can look at the fix_npm pipelines in gitlab.com to see that node and npm are being upgraded,  and the build is now working.
