### PR TITLE
i146: add support for WTI public IP override in pc2v9.ini.

### DIFF
--- a/projects/WTI-API/src/main/config/ServerInit.java
+++ b/projects/WTI-API/src/main/config/ServerInit.java
@@ -166,20 +166,18 @@ public class ServerInit {
 	 * @return a String containing an IP address, or null if an exception occurs while fetching the local IP address.
 	 */
 	public static String getLocalIp() {
-		// Source: https://stackoverflow.com/questions/9481865/getting-the-ip-address-of-the-current-machine-using-java
-		try (final DatagramSocket socket = new DatagramSocket()) {
-			socket.connect(InetAddress.getByName("8.8.8.8"), 10002);
-			String myIP = socket.getLocalAddress().getHostAddress();
-			if (publicIPOverride!=null) {
-			    myIP = publicIPOverride;
+		if (publicIPOverride != null) {
+			return publicIPOverride;
+		} else {
+			// Source: https://stackoverflow.com/questions/9481865/getting-the-ip-address-of-the-current-machine-using-java
+			try (final DatagramSocket socket = new DatagramSocket()) {
+				socket.connect(InetAddress.getByName("8.8.8.8"), 10002);
+				return socket.getLocalAddress().getHostAddress();
+			} catch (Exception ex) {
+				Logging.getLogger().log(Log.SEVERE, "Exception getting local IP address: " + ex.getMessage());
 			}
-			return myIP ;
+			return null;
 		}
-		catch (Exception ex) {
-		    Logging.getLogger().log(Log.SEVERE, "Exception getting local IP address: " + ex.getMessage());
-		}
-		
-		return null;
 	}
 
 	/** Returns the {@link pc2.core.log.Log} logger being used by this WTI server


### PR DESCRIPTION
### Description of what the PR does
Adds support for WTI Public IP Override in pc2v9.ini.

### Issue which the PR fixes
Fixes #146 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10, Eclipse 2019-12, Java 8_201

### Precise steps for _testing_ the PR:
- Start a PC2 server with at least one scoreboard account and one team account.
- Start a WTI-API server on a machine with a local private IP address and a public IP address (e.g., NAT'd behind a firewall), with a WTI `pc2v9.ini` specifying the PC2 Server scoreboard login (the WTI needs to connect to the PC2 server at startup), but NOT specifying any Public IP Override.
- Start a browser and connect to the WTI-Server at its public address. The browser should display the WTI "login" screen.
- Enter valid credentials for a PC2 team account, then click "Login".
- Verify that the team login fails, producing the message "Invalid Credentials!" after a timeout delay (approx. 1 minute).

- Stop (kill) the WTI server.
- Edit the WTI `pc2v9.ini file`; add an entry like
`wtiOverridePublicIP=w.x.y.z` where `w.x.y.z` is the PUBLIC address of the WTI server machine.
- Open a browser to the WTI server and again attempt to login as a team.  
- Verify that the browser now successfully completes the login and displays the "main team screen".
