### PR TITLE
correct how to get to published_at times.

### DIFF
--- a/website/layouts/shortcodes/pc2block.html
+++ b/website/layouts/shortcodes/pc2block.html
@@ -11,7 +11,7 @@
     <p>
         Downloads: <br/> 
         Stable Release: &nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.tar.gz</a><br />
-{{ if gt $prereleaseTool.published_at $stableTool.published_at }}
+{{ if gt $preRelease.published_at $stableRelease.published_at }}
         Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
 {{ else }}
         No release candidate at this time.<br />

--- a/website/layouts/shortcodes/pc2download.html
+++ b/website/layouts/shortcodes/pc2download.html
@@ -17,7 +17,7 @@
     <br />
 </p>
 <p>
-{{ if gt $prereleaseTool.published_at $stableTool.published_at }}
+{{ if gt $preRelease.published_at $stableRelease.published_at }}
         Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
     The latest release candidate {{ .Get "name" }} version is {{ $prereleaseTool.version }}, released on {{ $preRelease.date }}.
 </p>


### PR DESCRIPTION
This should be cherry-picked to master after develop builds.
Though the develop building should expose the RC.

fixes #158