### PR TITLE
join output collectors before destroying process.

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/ProgramRunner.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ProgramRunner.java
@@ -137,10 +137,10 @@ public class ProgramRunner {
                 returnValue = process.waitFor();
                 log.info("execution process returned exit code " + returnValue);
                 executionData.setExecuteExitValue(returnValue);
-                process.destroy();
-
                 stdoutCollector.join();
                 stderrCollector.join();
+
+                process.destroy();
 
                 if (executionTimer != null) {
                     executionTimer.stopTimer();


### PR DESCRIPTION
if the process is destroyed first, the output collectors may
miss the output.

fixes #161

This change is being used in the VCSS successfully.