### PR TITLE
i163: now add problem will assign letter from AA to ZZ

### DIFF
--- a/src/edu/csus/ecs/pc2/core/Utilities.java
+++ b/src/edu/csus/ecs/pc2/core/Utilities.java
@@ -1421,18 +1421,29 @@ public final class Utilities {
     }
 
     /**
-     * For the input number, returns an upper-case letter.
+     * For the input number, returns an upper-case letters.
      * 
-     * 1 = A, 2 = B, etc.
+     * 1 = A, 2 = B, ..., 27 = AA, ... 702 = ZZ
      * 
      * @param id
-     *            problem number, base one (not zero).
-     * @return single upper case letter.
+     *            problem number, base one (not zero), range 1 (A) through 702 (ZZ)
+     * @return uppercase letters
      */
     public static String getProblemLetter(int id) {
-        char let = 'A';
-        let += (id - 1);
-        return Character.toString(let);
+        if (id < 27) {
+            return Character.toString((char) (id + 65 - 1));
+        } else {
+
+            char firstLet = 'A';
+
+            for (int v26 = 53;; v26 += 26) {
+                if (id < v26) {
+                    String letter = firstLet + Character.toString((char) (id - v26 + 26 + 65));
+                    return letter;
+                }
+                firstLet++;
+            }
+        }
     }
 
     /**

--- a/test/edu/csus/ecs/pc2/core/UtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/UtilitiesTest.java
@@ -318,11 +318,22 @@ public class UtilitiesTest extends AbstractTestCase {
         problemNumber = 26;
         actual = Utilities.getProblemLetter(problemNumber);
         assertEquals("Expect letter for " + problemNumber, "Z", actual);
-
-        problemNumber = 5;
+        
+        problemNumber = 27;
         actual = Utilities.getProblemLetter(problemNumber);
-        assertEquals("Expect letter for " + problemNumber, "E", actual);
+        assertEquals("Expect letter for " + problemNumber, "AA", actual);
+        
+        problemNumber = 28;
+        actual = Utilities.getProblemLetter(problemNumber);
+        assertEquals("Expect letter for " + problemNumber, "AB", actual);
+        
+        problemNumber = 55;
+        actual = Utilities.getProblemLetter(problemNumber);
+        assertEquals("Expect letter for " + problemNumber, "BC", actual);
 
+        problemNumber = 702;
+        actual = Utilities.getProblemLetter(problemNumber);
+        assertEquals("Expect letter for " + problemNumber, "ZZ", actual);
     }
 
     public void testgetProblemNumber() throws Exception {


### PR DESCRIPTION
updated Utilities.getProblemLetter(problemNumber), problemNumber
now can be 1 to 702, aka A through ZZ.

### Description of what the PR does

Now add problem will assign letter(s) AA for problem number 27, AB for problem 28, etc.

### Issue which the PR fixes

Issue 163

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Java version 1.8.0_121
OS: Windows 10 10.0 (amd64)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

To Reproduce:

start server, start admin,
On admin, use Add Problem to 27 problems.
Click Report to view Problem Report

Expected behavior:

for problem after Z shows Letter as AA
for problem after AA shows Letter as AB