### PR TITLE
i166: added check for spaces in filenames in new-run.components.ts.

### DIFF
--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -106,17 +106,26 @@ export class NewRunComponent implements OnInit, OnDestroy {
       model.additionalTestFiles = this.testFiles;
     }
     model.isTest = this.submitType === 'test';
-    this._teamService.submitRun(model)
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ => {
-        this.clearNewSubmission();
-        this.close();
-        this._uiHelper.alert('Run has been submitted successfully!');
-        this._teamService.runsUpdated.next();
-      }, (error: any) => {
-        this._uiHelper.alert('Error submitting problem! Check console for details');
-        console.error(error);
-      });
+
+	//make sure no file names contain blanks (the PC2 server chokes on such filenames)
+	if (this.filenameContainsBlanks(this.mainFile, this.additionalFiles, this.testFiles)){
+		//pop up an error dialog
+	    this._uiHelper.alert('File names may not contain spaces');
+	    console.error('One or more submitted file contains a space in its filename');
+	} else {
+		//submit the run
+	    this._teamService.submitRun(model)
+	      .pipe(takeUntil(this._unsubscribe))
+	      .subscribe(_ => {
+	        this.clearNewSubmission();
+	        this.close();
+	        this._uiHelper.alert('Run has been submitted successfully!');
+	        this._teamService.runsUpdated.next();
+	      }, (error: any) => {
+	        this._uiHelper.alert('Error submitting problem! Check console for details');
+	        console.error(error);
+	      });
+	}
   }
 
   async buildFileSubmission(file: File) {
@@ -158,4 +167,23 @@ export class NewRunComponent implements OnInit, OnDestroy {
       testDataFiles: []
     });
   }
+
+  //returns true if any of the filenames of any of the specified FileSubmissions contain a blank (space); false if none do.
+  private filenameContainsBlanks(mainfile: FileSubmission, additionalFiles: FileSubmission [], testFiles: FileSubmission []): boolean {
+	if (mainfile.fileName.indexOf(" ") > -1) {
+		return true;
+	}
+	for (var file of additionalFiles) {
+		if (file.fileName.indexOf(" ") > -1){
+			return true;
+		}
+	}
+	for (var file of testFiles) {
+		if (file.fileName.indexOf(" ") > -1) {
+			return true;
+		}
+	}
+	//none of the specified FileSubmission files contains a space in its name
+	return false;
+	}
 }


### PR DESCRIPTION
### Description of what the PR does:

Causes the browser code (WTI-UI) to refuse to submit a new run if any of the selected files
have a space in the filename.

### Issue which the PR fixes
Fixes #166 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 8.1, Eclipse 2019-12, Java 1.8.0_201

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

- Download and unzip the distribution which contains this fix.
- Start pc2 server using --load sumithello
- Start pc2 admin
- Create "scoreboard2" account
- Under "projects", unzip the WTI project
- In the WTI distribution folder, start WTI (`./bin/pc2wti`)
- In the pc2 `samps` folder, make a copy of file "hello.java" so that the copied file has spaces in its filename
- Start the contest (on the admin)
- Start a pc2 judge (or autojudge judging problem "hello"; aj4 is so configured in contest "sumithello")
- Open a browser to `http://localhost:8080`
- Login to pc2 as "team1".
- Press "Submit Problem" button.
- In the submission dialog, select Problem Hello, Language Java, then navigate to the pc2 "samps" folder and select "hello.java" as the main file.
- Click the "Submit" button.  You should get back a "Yes" result.
- Press the "Submit Problem" button again.
- Select problem "Hello" and language "Java", but this time for the main file select the copied file containing spaces in the filename.
- Press the "Submit" button.

The UI will refuse to send the submission; it will display a standard "WTI Alert" at the bottom of the screen saying "File names may not contain spaces".   Go to the Admin to verify that no submission was received for this new attempt.

Repeat the above, selecting one or more files whose filenames contain spaces for the "Additional Files" box.  When "Submit" is pressed the UI will again refuse to submit and will display the "File names may not contain spaces" message.
