### PR TITLE
I172: Added two scoreboard html to yaml - automation

### DIFF
--- a/createAPIJar.xml
+++ b/createAPIJar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project name="v9VersionAndJarBuild" default="jar" basedir=".">
+<project name="Create pc2apiTest.jar" default="jar" basedir=".">
 	<!-- $Id$ -->
 	<!-- $HeadURL$ -->
 	<!-- 
@@ -108,10 +108,6 @@ dal
 			<format property="millisecond" pattern="S" timezone="UTC" />
 		</tstamp>
 		<property name="build.number" value="${millisecond}" />
-
-		<!-- include the images in the jar -->
-		<copy file="images/csus_logo.png" todir="${build.prod.dir}/images"/>
-		<copy file="images/icpc_banner.png" todir="${build.prod.dir}/images"/>
 
 		<!-- consider doing the manifest in a separate target
              then the Version can be ommitted if not set -->

--- a/samps/contests/ccs1/config/contest.yaml
+++ b/samps/contests/ccs1/config/contest.yaml
@@ -9,6 +9,9 @@ start-time:        2060-02-04 01:23Z
 duration:          5:00:00
 scoreboard-freeze: 4:00:00
 
+output-private-score-dir: super_secret
+output-public-score-dir: public_html_dir
+
 default-clars:
   - No comment, read problem statement.
   - This will be answered during the answers to questions session.

--- a/src/edu/csus/ecs/pc2/core/export/ExportYAML.java
+++ b/src/edu/csus/ecs/pc2/core/export/ExportYAML.java
@@ -35,6 +35,7 @@ import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.ProblemDataFiles;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 import edu.csus.ecs.pc2.core.model.Site;
+import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
 import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 
 /**
@@ -163,6 +164,9 @@ public class ExportYAML {
 
 //        contestWriter.println("scoreboard-freeze: " + info.getFreezeTime());
         contestWriter.println("scoreboard-freeze-length: " + info.getFreezeTime());
+        
+        contestWriter.println(IContestLoader.OUTPUT_PRIVATE_SCORE_DIR_KEY+": " + info.getScoringProperties().getProperty(DefaultScoringAlgorithm.JUDGE_OUTPUT_DIR));
+        contestWriter.println(IContestLoader.OUTPUT_PUBLIC_SCORE_DIR_KEY+": " + info.getScoringProperties().getProperty(DefaultScoringAlgorithm.PUBLIC_OUTPUT_DIR));
 
         contestWriter.println("# " + IContestLoader.PROBLEM_LOAD_DATA_FILES_KEY + ": false");
 

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -69,8 +69,14 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
     
     public static final String POINTS_PER_NO_SECURITY_VIOLATION = "Points per Security Violation";
     
+    /**
+     * Non-frozen scoreboard output directory key
+     */
     public static final String JUDGE_OUTPUT_DIR = "Output HTML dir for Judges";
 
+    /**
+     * Frozen scoreboard output directory key
+     */
     public static final String PUBLIC_OUTPUT_DIR = "Output Public HTML dir";
     
     /**

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -56,6 +56,7 @@ import edu.csus.ecs.pc2.core.model.Problem.VALIDATOR_TYPE;
 import edu.csus.ecs.pc2.core.model.ProblemDataFiles;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 import edu.csus.ecs.pc2.core.model.Site;
+import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
 import edu.csus.ecs.pc2.core.security.Permission.Type;
 import edu.csus.ecs.pc2.tools.PasswordGenerator;
 import edu.csus.ecs.pc2.tools.PasswordType2;
@@ -337,6 +338,20 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         return value;
     }
 
+    /**
+     * Set Scoring properties value.
+     * @param contest
+     * @param keyName key in Scoring Properties
+     * @param value value to be assigned
+     */
+    private void setScoringPropertyValue (IInternalContest contest, String keyName, String value)
+    {
+        ContestInformation contestInformation = contest.getContestInformation();
+        Properties props = contestInformation.getScoringProperties();
+        props.put(keyName, value);
+        contestInformation.setScoringProperties(props);
+    }
+
     private void setContestStartDateTime(IInternalContest contest, Date date) {
         ContestInformation contestInformation = contest.getContestInformation();
         contestInformation.setScheduledStartDate(date);
@@ -513,6 +528,25 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                         throw new YamlLoadException("Invalid start-time value '" + startTime + " expected ISO 8601 format, " + e.getMessage(), e, contestFileName);
                     }
                 }
+            }
+        }
+        
+        
+        Object privatehtmlOutputDirectory = fetchObjectValue(content, OUTPUT_PRIVATE_SCORE_DIR_KEY);
+        if (privatehtmlOutputDirectory != null) {
+            if (privatehtmlOutputDirectory instanceof String) {
+                setScoringPropertyValue(contest, DefaultScoringAlgorithm.JUDGE_OUTPUT_DIR, (String) privatehtmlOutputDirectory);
+            } else {
+                throw new YamlLoadException("Invalid value/type for " + OUTPUT_PRIVATE_SCORE_DIR_KEY + " <" + privatehtmlOutputDirectory + ">");
+            }
+        }
+
+        Object publichtmlOutputDirectory = fetchObjectValue(content, OUTPUT_PUBLIC_SCORE_DIR_KEY);
+        if (publichtmlOutputDirectory != null) {
+            if (publichtmlOutputDirectory instanceof String) {
+                setScoringPropertyValue(contest, DefaultScoringAlgorithm.PUBLIC_OUTPUT_DIR, (String) publichtmlOutputDirectory);
+            } else {
+                throw new YamlLoadException("Invalid value/type for " + OUTPUT_PUBLIC_SCORE_DIR_KEY + " <" + publichtmlOutputDirectory + ">");
             }
         }
 

--- a/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
@@ -60,6 +60,10 @@ public interface IContestLoader {
     String CONTEST_START_TIME_KEY = "start-time";
     
     String MAX_OUTPUT_SIZE_K_KEY = "max-output-size-K";
+    
+    final String OUTPUT_PRIVATE_SCORE_DIR_KEY = "output-private-score-dir";
+
+    final String OUTPUT_PUBLIC_SCORE_DIR_KEY = "output-public-score-dir";
 
     String CONTEST_DURATION_KEY = "duration";
     

--- a/test/edu/csus/ecs/pc2/core/report/ExportYamlReportTest.java
+++ b/test/edu/csus/ecs/pc2/core/report/ExportYamlReportTest.java
@@ -52,6 +52,9 @@ public class ExportYamlReportTest extends AbstractTestCase {
         String filename = testDirectory + File.separator + "exportYaml.txt";
         report.createReportFile(filename, new Filter());
 
+//        editFile(filename);
+//        startExplorer(testDirectory);
+
         if (debugMode) {
             System.out.println("Wrote to " + filename);
         }

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 
@@ -50,6 +51,7 @@ import edu.csus.ecs.pc2.core.model.ProblemDataFiles;
 import edu.csus.ecs.pc2.core.model.SampleContest;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 import edu.csus.ecs.pc2.core.model.Site;
+import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 import edu.csus.ecs.pc2.validator.clicsValidator.ClicsValidatorSettings;
 
@@ -3459,6 +3461,43 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         boolean explicitlySetTrue = contest.getContestInformation().isAllowMultipleLoginsPerTeam();
         assertTrue("Loading YAML file with explicit 'allow-multiple-logins: true' flag failed to set 'allow multiple logins'", explicitlySetTrue);
         
+    }
+    
+    public void testScoreboardHTMLLocations() throws Exception {
+
+        String dataDirName = getDataDirectory(getName());
+        Utilities.insureDir(dataDirName);
+        assertDirectoryExists(dataDirName);
+
+        String yamlFilename = getTestFilename(getName() + File.separator + "contest.testScoreboardHTMLLocations.yaml");
+
+//        startExplorer(dataDirName);
+//        editFile(yamlFilename);
+
+        String[] contents = Utilities.loadFile(yamlFilename);
+        assertFalse("Cannot find file " + yamlFilename, contents.length == 0);
+
+        IInternalContest contest = loader.fromYaml(null, contents, dataDirName);
+        assertNotNull(contest);
+
+        ContestInformation info = contest.getContestInformation();
+        assertNotNull("expecting info", info);
+        Properties props = info.getScoringProperties();
+        assertNotNull("expecting getScoringProperties", props);
+
+        String privateDir = props.getProperty(DefaultScoringAlgorithm.JUDGE_OUTPUT_DIR);
+        assertNotNull("expecting " + DefaultScoringAlgorithm.JUDGE_OUTPUT_DIR + " defined in " + yamlFilename, privateDir);
+
+        String publicDir = props.getProperty(DefaultScoringAlgorithm.PUBLIC_OUTPUT_DIR);
+        assertNotNull("expecting " + DefaultScoringAlgorithm.PUBLIC_OUTPUT_DIR + " defined in " + yamlFilename, publicDir);
+
+        // From yaml:
+//        output_private_score_dir: super_secret
+//        output_public_score_dir: public_html_dir
+
+        assertEquals("Private HTML Directory", "super_secret", privateDir);
+        assertEquals("Public HTML Directory", "public_html_dir", publicDir);
+
     }
 }
 

--- a/testdata/ContestSnakeYAMLLoaderTest/testScoreboardHTMLLocations/contest.testScoreboardHTMLLocations.yaml
+++ b/testdata/ContestSnakeYAMLLoaderTest/testScoreboardHTMLLocations/contest.testScoreboardHTMLLocations.yaml
@@ -1,0 +1,89 @@
+# Contest configuration
+# 
+#
+# Wed Feb 17 12:59:37 PDT 2021
+#
+
+---
+name:              Unit Test 4
+short-name:        UT4
+start-time:        2011-02-04 01:23Z
+duration:          5:00:00
+scoreboard-freeze: 4:00:00
+
+# New scoreboard definitions
+
+output-private-score-dir: super_secret
+output-public-score-dir: public_html_dir
+
+timeout:  20
+
+default-validator: /bin/true
+
+default-clars:
+  - No comment, read problem statement.
+  - This will be answered during the answers to questions session.
+
+clar-categories:
+  - General
+  - SysOps
+  - Operations
+
+languages:
+  - name: C++
+    compiler: /usr/bin/g++
+    compiler-args: -O2 -Wall -o a.out -static {files}
+
+  - name: C
+    compiler: /usr/bin/gcc
+    compiler-args: -O2 -Wall -std=gnu99 -o a.out -static {files} -lm
+
+  - name: Java
+    compiler: /usr/bin/javac
+    compiler-args: -O {files}
+    runner: /usr/bin/java
+    runner-args:
+
+  - name: 'Python'
+    active: true
+    compilerCmd: 'python -m py_compile {:mainfile}'
+    exemask: ''
+    execCmd: 'python {:mainfile}'
+    runner: 'python'
+    runner-args: '{:mainfile}'
+    use-judge-cmd: false
+    judge-exec-cmd: 'python {:mainfile}'
+
+# no problems
+
+sites:
+ - number: 1
+   name: Uno Site Arcadia
+   IP: localhost
+   port: 50002
+
+accounts:
+  - account: TEAM
+    site: 1
+    count: 14
+
+  - account: JUDGE
+    site: 1
+    count: 12
+
+  - account: TEAM
+    site: 2
+    count: 21
+
+  - account: TEAM
+    site: 3
+    start: 300
+    count: 30
+
+  - account: JUDGE
+    site: 2
+    count: 8
+
+
+# eof $Id: contest.yaml 2704 2013-10-16 05:38:06Z laned $
+


### PR DESCRIPTION
### Description of what the PR does

Automate the load of these scoring settings if present in yaml.
Output HTML dir for Judges, yaml: output_private_score_dir
Output Public HTML dir, yaml: output_public_score_dir

Also fixed ant build that creates the API testing jar.

### Issue which the PR fixes

172

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

All.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Download and unpack distribution.
In jake directory start server with ccs1 sample contest, that now contains the two new yaml lines. See samps/contests/ccs1/config/contest.yaml for those new keys.
```
$ bin/pc2server --login s --contestpassword foo  --load ccs1
# then start admin
$ bin/pc2admin --login r

1  view Scoring properties
2. Navigate Configure Contest pane -> Settings -> Edit Scoring Properties button
```
Expected: 
Output HTML dir for Judges='super_secret'
Output Public HTML dir='public_html_dir'