### PR TITLE
I177 report submission os

### DIFF
--- a/projects/WTI-API/src/main/config/ServerInit.java
+++ b/projects/WTI-API/src/main/config/ServerInit.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import javax.json.Json;
@@ -33,10 +35,13 @@ public class ServerInit {
     
 	private static ServerInit init = null;
 	private static String publicIPOverride;
+	private static List<String> allowedOSNames;
+	
 	private int portNum;
 	private String socketSource;
 	private String scoreboardAccount;
 	private String scoreboardPassword;
+
 
 	private Log logger;
 	
@@ -61,7 +66,12 @@ public class ServerInit {
 		      this.socketSource = p.getProperty("wtiwsName");
 		      this.scoreboardAccount = p.getProperty("wtiscoreboardaccount", "scoreboard2");
 		      this.scoreboardPassword = p.getProperty("wtiscoreboardpassword", "scoreboard2");
+		      
 		      publicIPOverride = p.getProperty(WTI_PUBLIC_IP_OVERRIDE_KEY);
+		      allowedOSNames = getAllowedOSNames(p);
+		      
+		      System.out.println ("Found the following properties in pc2v9.ini: " + p);
+
 		} catch(FileNotFoundException e) {
 			this.logger.info("pc2v9.ini File missing; reverting to default WTI port/socket/scoreboard values");
 			setDefaults();
@@ -74,6 +84,26 @@ public class ServerInit {
 		}
 	}
 	
+	/**
+	 * Returns a list of property values for every entry in the specified Properties object
+	 * whose key starts with the String "allowedOSName".
+	 * 
+	 * @param p a Properties object which potentially contains entries giving allowed OS names.
+	 * @return a List<String> containing the values for all entries in the specified Properties whose key starts with "allowedOSName".
+	 * 			The returned list may be empty but will never be null.
+	 */
+	private List<String> getAllowedOSNames(Properties p) {
+
+		List<String> allowedNames = new ArrayList<String>();
+		for (Object key : p.keySet()) {
+			String keyName = key.toString();
+			if (keyName.startsWith("allowedOSName")) {
+				allowedNames.add(p.getProperty(keyName)); 
+			}
+		}
+		return allowedNames;
+	}
+
 	private void setDefaults() {
 		this.portNum = 8080;
 		this.socketSource ="/websocket";
@@ -186,6 +216,15 @@ public class ServerInit {
 	 */
 	public Log getLogger() {
 		return logger;
+	}
+
+	/**
+	 * Returns a List<String> of the OS names which have been specified in the pc2v9 ini file with keys starting with
+	 * "allowedOSName" -- for example, "allowedOSName1=Windows", or "allowedOSName2=Linux".
+	 * @return a List<String> of allowed OS names.
+	 */
+	public static List<String> getAllowedOSNames() {
+		return allowedOSNames;
 	}
 
 }

--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -251,13 +251,14 @@ public class TeamsController extends MainController {
 				int siteNum = teamClient.getSiteNumber();
 				String probName = prob.getShortName();
 				String msg = "Team " + teamNum + " at Site " + siteNum + " appears to have sent a submission for problem "
-							+ probName + " from a not-authorized platform."
-							+ "\n OS used to send the submission: " + submittingOS ;
-				List<String> allowedOSNames = getAllowedOSNames();
-				msg += "\n Allowed OS names:";
-				for (String osName : allowedOSNames) {
-					msg += "\n    " + osName ;
-				}
+							+ probName + " from the following non-authorized platform:" + "\n   " + submittingOS ;
+				
+				//don't list the allowed names; this gets exposed on the team in the clar -- which might allow them to hack in an allowed name.
+//				List<String> allowedOSNames = getAllowedOSNames();
+//				msg += "\n Allowed OS names:";
+//				for (String osName : allowedOSNames) {
+//					msg += "\n    " + osName ;
+//				}
 				teamsConn.submitClarification(prob, msg);
 			}
 		} 
@@ -313,7 +314,7 @@ public class TeamsController extends MainController {
 		
 		//check the specified name against each element in the list
 		for (String name : allowedOSNames) {
-			if (osName.contentEquals(name)) {
+			if (osName.trim().contentEquals(name)) {
 				return true;
 			}
 		}

--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -9,12 +9,16 @@ import javax.ws.rs.Path;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import config.ServerInit;
+
 import javax.inject.Singleton;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 
 import edu.csus.ecs.pc2.api.exceptions.NotLoggedInException;
 import edu.csus.ecs.pc2.core.model.IFile;
+import edu.csus.ecs.pc2.api.IClient;
 import edu.csus.ecs.pc2.api.ILanguage;
 import edu.csus.ecs.pc2.api.IProblem;
 import edu.csus.ecs.pc2.api.IRun;
@@ -238,6 +242,24 @@ public class TeamsController extends MainController {
 			else{
 				teamsConn.submitJudgeRun(prob, lang, main);
 			}
+			
+			//some systems (e.g. VCSS) want to be notified if the submission came from a not-allowed source
+			String submittingOS = run.getOSName();
+			if (!isAllowedOSName(submittingOS)) {
+				IClient teamClient = teamsConn.getMyClient();
+				int teamNum = teamClient.getAccountNumber();
+				int siteNum = teamClient.getSiteNumber();
+				String probName = prob.getShortName();
+				String msg = "Team " + teamNum + " at Site " + siteNum + " appears to have sent a submission for problem "
+							+ probName + " from a not-authorized platform."
+							+ "\n OS used to send the submission: " + submittingOS ;
+				List<String> allowedOSNames = getAllowedOSNames();
+				msg += "\n Allowed OS names:";
+				for (String osName : allowedOSNames) {
+					msg += "\n    " + osName ;
+				}
+				teamsConn.submitClarification(prob, msg);
+			}
 		} 
 		catch(NullPointerException e) {
 			return Response.status(Response.Status.BAD_REQUEST)
@@ -258,6 +280,45 @@ public class TeamsController extends MainController {
 		}
 
 		return Response.ok().type(MediaType.APPLICATION_JSON).build();
+	}
+
+	private List<String> getAllowedOSNames() {
+
+		return ServerInit.getAllowedOSNames();
+
+	}
+
+	/**
+	 * Checks whether the specified osName String is the name of an OS/platform from which submissions are allowed to be sent.
+	 * An osName is an "allowed" OS name if either (a) the specified name appears in the list of allowed OS names returned by
+	 * {@link #getAllowedOSNames()}, or if the list returned by {@link #getAllowedOSNames()} is null or empty (which is frequently the case).
+	 * 
+	 * @param osName a String specifying the OS name to be checked.
+	 * @return true if the specified osName appears in the list of allowed OS names or if the list of allowed OS names is null or empty;
+	 * 			false if the list of allowed names is NOT null/empty but the the specified name does not appear in the list.
+	 */
+	private boolean isAllowedOSName(String osName) {
+		//get a list of allowed OS names
+		List<String> allowedOSNames = getAllowedOSNames();
+		
+		//if the list is empty, we default to "allowed"
+		if (allowedOSNames==null || allowedOSNames.size()==0) {
+			return true;
+		}
+		
+		//the list is not empty; make sure we were passed something to check
+		if (osName==null || osName.contentEquals("")) {
+			return false;
+		}
+		
+		//check the specified name against each element in the list
+		for (String name : allowedOSNames) {
+			if (osName.contentEquals(name)) {
+				return true;
+			}
+		}
+		//the name we were given is not in the allowed list
+		return false;
 	}
 
 	/**

--- a/projects/WTI-API/src/main/models/SubmitRunRequestModel.java
+++ b/projects/WTI-API/src/main/models/SubmitRunRequestModel.java
@@ -9,6 +9,7 @@ public class SubmitRunRequestModel {
 	public File testFile;
 	public File[] additionalTestFiles;
 	public boolean isTest;
+	public String osName = "No OS name set";
 
 	public SubmitRunRequestModel(String probName, String language, File mainFile, File[] extraFiles, File testFile,
 			boolean isTest) {
@@ -93,6 +94,10 @@ public class SubmitRunRequestModel {
 
 	public void setTest(boolean isTest) {
 		this.isTest = isTest;
+	}
+	
+	public String getOSName() {
+		return osName;
 	}
 
 }

--- a/projects/WTI-UI/src/app/app.module.ts
+++ b/projects/WTI-UI/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { SharedModule } from './modules/shared/shared.module';
 import { OptionsModule } from './modules/options/options.module';
 import { ClarificationsModule } from './modules/clarifications/clarifications.module';
 import { ScoreboardModule } from './modules/scoreboard/scoreboard.module';
+//import { DeviceDetectorModule } from 'ngx-device-detector';
 
 @NgModule({
   declarations: [
@@ -25,7 +26,8 @@ import { ScoreboardModule } from './modules/scoreboard/scoreboard.module';
     OptionsModule,
     ClarificationsModule,
     ScoreboardModule,
-    BrowserAnimationsModule
+    BrowserAnimationsModule,
+//	DeviceDetectorModule.forRoot()
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/projects/WTI-UI/src/app/modules/core/models/submission.ts
+++ b/projects/WTI-UI/src/app/modules/core/models/submission.ts
@@ -8,4 +8,5 @@ export class Submission {
   testFile: FileSubmission = null;
   additionalTestFiles: FileSubmission[] = [];
   isTest: boolean;
+  osName: string;
 }

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -7,6 +7,8 @@ import { ITeamsService } from 'src/app/modules/core/abstract-services/i-teams.se
 import { Subject } from 'rxjs';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { UiHelperService } from '../../../core/services/ui-helper.service';
+import * as os  from 'os';
+
 
 export interface DialogData {
   submitType: 'judged' | 'test';
@@ -106,6 +108,9 @@ export class NewRunComponent implements OnInit, OnDestroy {
       model.additionalTestFiles = this.testFiles;
     }
     model.isTest = this.submitType === 'test';
+    model.osName = this.getOSName();
+
+    console.log('getOSName() returned : ' + model.osName);
 
 	//make sure no file names contain blanks (the PC2 server chokes on such filenames)
 	if (this.filenameContainsBlanks(this.mainFile, this.additionalFiles, this.testFiles)){
@@ -185,5 +190,15 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	}
 	//none of the specified FileSubmission files contains a space in its name
 	return false;
+	}
+	
+	private getOSName() : string {
+		//these are commented-out until we can figure out how to get access to WebPack Node modules
+//		console.log("OS type = " + os.type()) ;
+//		console.log("OS release = " + os.release()) ;
+//		console.log("OS platform =" + os.platform());
+		
+		return "A HardCoded (fake) OS Name string";
+
 	}
 }

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -7,7 +7,11 @@ import { ITeamsService } from 'src/app/modules/core/abstract-services/i-teams.se
 import { Subject } from 'rxjs';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { UiHelperService } from '../../../core/services/ui-helper.service';
-import * as os  from 'os';
+
+//See the comments in method getOSName() regarding these services
+//import * as os  from 'os';
+//import { DeviceDetectorService } from 'ngx-device-detector';
+//import * as child_process from 'child_process' ;
 
 
 export interface DialogData {
@@ -108,6 +112,7 @@ export class NewRunComponent implements OnInit, OnDestroy {
       model.additionalTestFiles = this.testFiles;
     }
     model.isTest = this.submitType === 'test';
+    
     model.osName = this.getOSName();
 
     console.log('getOSName() returned : ' + model.osName);
@@ -192,13 +197,47 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	return false;
 	}
 	
+	//returns a string intended to identify the platform on which the browser is running
 	private getOSName() : string {
-		//these are commented-out until we can figure out how to get access to WebPack Node modules
+		
+		console.log(navigator.userAgent);
+		return navigator.userAgent.toString();
+		
+// The following were all attempts to get the Angular Typescript/Javascript code to invoke the underlying OS to obtain
+// platform information (instead of using the "userAgent", which can vary).  
+// All of these attempts failed, most commonly with the browser throwing a "xxx is not a function" error.
+// It's not even clear that it's *possible* to do this -- isn't Typescript/Javascript constrained to run inside the browser sandbox?
+
+// Try using the Node "os" module:
+//		os = new os();
 //		console.log("OS type = " + os.type()) ;
 //		console.log("OS release = " + os.release()) ;
 //		console.log("OS platform =" + os.platform());
-		
-		return "A HardCoded (fake) OS Name string";
+//		console.log("OS version = " + os.version());
+//		return os.version();
+	
+// Try using the  DeviceDetectorService from 'ngx-device-detector' (https://www.npmjs.com/package/ngx-device-detector)
+//		this.deviceInfo = this._deviceService.getDeviceInfo();
+//		console.log("OS name = " + this._deviceService.os);
+//		console.log("OS version = " + this._deviceService.os_version);
+//  	console.log("Browser = " + this._deviceService.browser);
+//		return this._deviceService.os_version;
+//
+// Try using the Node 'child_process' package to spawn a host-system process
+//		var spawn = require('child_process').spawn;
+//		var prc = spawn('java',  ['-jar', '-Xmx512M', '-Dfile.encoding=utf8', 'script/importlistings.jar']);
+//		//noinspection JSUnresolvedFunction
+//		prc.stdout.setEncoding('utf8');
+//		prc.stdout.on('data', function (data) {
+//  	var str = data.toString()
+//		var lines = str.split(/(\r?\n)/g);
+//		console.log(lines.join(""));
+//
+//		prc.on('close', function (code) {
+//    		console.log('process exit code ' + code);
+//		});
+//
+//		return this.deviceInfo;
 
 	}
 }


### PR DESCRIPTION
### Description of what the PR does

Updates the WTI-UI Angular `new-run.component.ts` code to fetch the browser's `navigator.userAgent` string and return that value in the `osName` field of a run submission.  Updates the WTI-API `TeamsController` to check the supplied osName against a list of "allowedOSNames" defined by properties in the WTI's `pc2v9.ini` file.  If the list of allowed OS names is non-null and non-empty then if the submitting OS name does not match one of the "allowedOSName" property values then the `TeamsController` submits a "clarification" to the Judges indicating that a submission was received from a "non-authorized" platform.  

### Issue which the PR fixes

Fixes #177 

### Environment in which the PR was developed:

Windows 8.1, Eclipse 2019.12, Java 1.8.0_201.

### Precise steps for _testing_ the PR:

- download and unzip the distribution, including unzipping the `projects/WTI-API` project.
- use the distribution to start a PC2 server with at least one problem, one language, one team account, TWO scoreboard accounts (one of which MUST be "scoreboard2").
- Start a PC2 Admin; start the contest.

### Test 1
- In a browser, open a browser console and type "navigator.useragent" to find out the name of the useragent for that browser. 
- edit the pc2v9.ini _**in the WTI unzipped folder**_ by adding an entry `allowedOSName=xxx`, where `xxx` is exactly the string from the browser console.  (This makes that OS platform an "allowed OS".)
- start the WTI server (`.\bin\pc2wti`).
- Enter `http://localhost:8080` into the browser's address bar.  This should display the WTI "login screen".
- Login to pc2 via WTI.
- Select `Submit Problem`; choose a language and a problem and a submission file, then click `Submit`.
- Verify that the submission was accepted by the system, and that _there are NO clarifications in the system_.
### Test 2
- log the team out of pc2.
- kill the WTI server.
- edit the WTI's `pc2v9.ini` file, changing the "allowedOSName=xxx" to some other xxx string (doesn't matter what as long as xxx is non-empty).
- restart the WTI server.
- log the team back in through WTI.
- submit another run. 
- Verify that from the TEAM's point of view the run was "accepted", but then verify that a new "Clar" indicating that the team submitted from a "non-authorized platform" was received by the judges.
### Test 3
- log the team out of pc2.
- kill the WTI server.
- edit the WTI's `pc2v9.ini` file: _completely remove_ the "allowedOSName=" line from the file.  (The effect of this is that ANY OS should be allowed).
- restart the WTI server.
- log the team back in through WTI.
- submit another run. 
- Verify that from the TEAM's point of view the run was "accepted".
- Verify that NO new "Clar" was received for this new submission (i.e. that the system accepted the run without claiming it was from a non-approved platform.

