### PR TITLE
I170: fix unit test fail due to OS file seperator

### DIFF
--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -32,7 +32,6 @@ import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.YamlLoadException;
 import edu.csus.ecs.pc2.core.export.MailMergeFile;
-import edu.csus.ecs.pc2.core.imports.LoadAccounts;
 import edu.csus.ecs.pc2.core.imports.LoadICPCTSVData;
 import edu.csus.ecs.pc2.core.list.AccountList;
 import edu.csus.ecs.pc2.core.list.AccountList.PasswordType;

--- a/test/edu/csus/ecs/pc2/core/JudgementLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/core/JudgementLoaderTest.java
@@ -15,6 +15,8 @@ import edu.csus.ecs.pc2.core.util.AbstractTestCase;
  */
 public class JudgementLoaderTest extends AbstractTestCase {
     
+    private static final String NATIVE_FILE_SEPERATOR = File.separator;
+
     /**
      * Test Load from list of lines. 
      * @throws Exception
@@ -226,7 +228,7 @@ public class JudgementLoaderTest extends AbstractTestCase {
 
         msg = JudgementLoader.loadJudgements(contest, false);
         judgements = contest.getJudgements();
-        assertEquals("Judgements not loaded, no judgement file found at .\\reject.ini", msg);
+        assertEquals("Judgements not loaded, no judgement file found at ." + NATIVE_FILE_SEPERATOR + "reject.ini", msg);
         assertEquals(0, judgements.length);
 
         // no reject.ini at ., default judgements loaded
@@ -234,7 +236,7 @@ public class JudgementLoaderTest extends AbstractTestCase {
         msg = JudgementLoader.loadJudgements(contest, false, ".");
         judgements = contest.getJudgements();
         assertEquals(0, judgements.length);
-        assertEquals("Judgements not loaded, no judgement file found at .\\reject.ini", msg);
+        assertEquals("Judgements not loaded, no judgement file found at ." + NATIVE_FILE_SEPERATOR + "reject.ini", msg);
 
         if (contest.getJudgements().length == 0) {
             JudgementLoader.loadDefaultJudgements(contest);
@@ -291,7 +293,7 @@ public class JudgementLoaderTest extends AbstractTestCase {
             InternalContest contest = new InternalContest();
             String msg = JudgementLoader.loadJudgements(contest, false);
             Judgement[] judgements = contest.getJudgements();
-            assertEquals("Loaded judgements from .\\reject.ini", msg);
+            assertEquals("Loaded judgements from ." + NATIVE_FILE_SEPERATOR + "reject.ini", msg);
             assertEquals(9, judgements.length);
         }
 


### PR DESCRIPTION
### Description of what the PR does

Fixed unit test failure when unit test run under Unix.
cleanup, removed unused import

### Issue which the PR fixes

170 unit test failure under Unix.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

n/a - build should succeed, no unit test failures.