### PR TITLE
i78: remove warning from Readme.md page. Partial fix for Issue #78.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,8 +1,4 @@
 # PC^2 Version 9
- 
-**NOTICE**  This public repository for the PC&sup2; Contest Control System is still _under development_.  You're welcome to look around, 
-but until an official announcement is made (and this notice is removed), _we do not recommend relying on the code published here_.
-If you are interested in obtaining a copy of PC&sup2; for running a contest, please refer to the [PC&sup2; home page](https://pc2.ecs.csus.edu).
 
 PC^ 2 (the **P**rogramming **C**ontest **C**ontrol system, pronounced "P-C-squared" or sometimes just "P-C-Two" for short) is a 
 software system designed to support programming contest operations in a variety of computing environments including MS Windows, Mac OS/X,

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,18 +1,13 @@
 ---
 title: "Home"
 description: "Programing Contest Control (PC^2) system implemented by the PC^2 Development Team for use at the ICPC World Finals and other programming contests"
-date: 2019-11-12T21:10:52+01:00
+date: Tuesday, March 16, 2021 4:03:24 PM GMT-07:00
 draft: false
 weight: 1
 icon: fas fa-home
 ---
 
 {{< figure src="/img/logo-full.png" alt="PC^2 logo" class="float-right" >}}
-
-**NOTICE**  This public repository for the PC&sup2; Contest Control System is still _under development_.  You're welcome to look around,
-but until an official announcement is made (and this notice is removed), _we do not recommend relying on the code published here_.
-If you are interested in obtaining a copy of PC&sup2; for running a contest, please refer to the [PC&sup2; home page](https://pc2.ecs.csus.edu).
-
 
 PC&sup2; (the **P**rogramming **C**ontest **C**ontrol system,
 pronounced "P-C-squared" or sometimes just "P-C-Two" for short) is a
@@ -64,7 +59,7 @@ See the <a href="https://github.com/pc2ccs/pc2v9/wiki">PC&sup2; Wiki</a> for mor
 
 ### Disclaimer
 
-The software available through this site is provided free and “as is”, with the usual disclaimers: lack of guarantee of suitability
+The software available through this site is provided free and "as is", with the usual disclaimers: lack of guarantee of suitability
 for any particular purpose, no stated or implied responsibility for the results of their use, etc.
 
 In other words, we find this system to be very useful for managing programming contest operations, and we think you will too; but we

--- a/website/content/all-builds.md
+++ b/website/content/all-builds.md
@@ -1,15 +1,11 @@
 ---
 title: "All builds"
 description: "Download any build of PC&sup2;"
-date: 2019-12-15T11:52:23+01:00
+date: Tuesday, March 16, 2021 4:03:24 PM GMT-07:00
 draft: false
 weight: 10
 icon: fas fa-download
 ---
-
-**NOTICE**  This public repository for the PC&sup2; Contest Control System is still _under development_.  You're welcome to look around,
-but until an official announcement is made (and this notice is removed), _we do not recommend relying on the code published here_.
-If you are interested in obtaining a copy of PC&sup2; for running a contest, please refer to the [PC&sup2; home page](https://pc2.ecs.csus.edu).
 
 Below you will find all the available builds for the PC&sup2; CCS. Most builds also have a `.sha256` and .`sha512` file, which can be used to validate the downloads.
 

--- a/website/content/current.md
+++ b/website/content/current.md
@@ -1,15 +1,11 @@
 ---
 title: "Current Downloads"
 description: "The PC^2 Contest Control System interconnects teams submissions with judging"
-date: 2020-03-26T18:36:38-07:00
+date: Tuesday, March 16, 2021 4:03:24 PM GMT-07:00
 draft: false
 weight: 2
 icon: fas fa-server
 ---
-
-**NOTICE**  This public repository for the PC&sup2; Contest Control System is still _under development_.  You're welcome to look around,
-but until an official announcement is made (and this notice is removed), _we do not recommend relying on the code published here_.
-If you are interested in obtaining a copy of PC&sup2; for running a contest, please refer to the [PC&sup2; home page](https://pc2.ecs.csus.edu).
 
 <ul>
 <li>    <b>Latest stable release</b>: the main public release. This release has been widely used around the world in many contests and is recommended for those who want the assurances of a stable, vetted system for running their contest.</li>


### PR DESCRIPTION
Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Removes from the pc2v9 code repo "ReadMe.md" file the Warning Notice about the GitHub code pages not being "current".

### Issue which the PR fixes
Partial fix for #78 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 8.1.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Read the Readme, verify it looks correct but doesn't have a "Notice" warning at the top.
- Generate new .io web pages, examine the Home, AllBuilds, and CurrentBuilds pages to make sure they look correct but do not have a "Notice" warning at the top.
- Examine the PC2v9 GitHub Wiki; make sure the home page (https://github.com/pc2ccs/pc2v9/wiki) does not have a "Notice" warning at the top.
