### PR TITLE
i206: preserve state of AllowMultipleLogins on Admin restart. Fixes #206

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -213,7 +213,6 @@ public class ContestInformationPane extends JPanePlugin {
     private JCheckBox shadowModeCheckbox;
 
     private JCheckBox allowMultipleTeamLoginsCheckbox;
-    private boolean allowMultipleLoginsPerTeam = false;
 
     private Component rigidArea1;
     
@@ -857,7 +856,7 @@ public class ContestInformationPane extends JPanePlugin {
         String maxFileSizeString = "0" + getMaxOutputSizeInKTextField().getText();
         long maximumFileSize = Long.parseLong(maxFileSizeString);
         newContestInformation.setMaxFileSize(maximumFileSize * 1000);
-        newContestInformation.setAllowMultipleLoginsPerTeam(allowMultipleLoginsPerTeam);
+        newContestInformation.setAllowMultipleLoginsPerTeam(getAllowMultipleTeamLoginsCheckbox().isSelected());
 
         //fill in values already saved, if any
         if (savedContestInformation != null) {
@@ -870,7 +869,9 @@ public class ContestInformationPane extends JPanePlugin {
             newContestInformation.setContestShortName(savedContestInformation.getContestShortName());
             newContestInformation.setExternalYamlPath(savedContestInformation.getExternalYamlPath());
             
+            //TODO: why is the following being done here when it is overridden below?
             newContestInformation.setFreezeTime(savedContestInformation.getFreezeTime());
+            
             newContestInformation.setLastRunNumberSubmitted(savedContestInformation.getLastRunNumberSubmitted());
             newContestInformation.setAutoStartContest(savedContestInformation.isAutoStartContest());
         }
@@ -1315,7 +1316,6 @@ public class ContestInformationPane extends JPanePlugin {
             allowMultipleTeamLoginsCheckbox.addActionListener (new ActionListener() {
                 
                 public void actionPerformed(ActionEvent e) {
-                    allowMultipleLoginsPerTeam = getAllowMultipleTeamLoginsCheckbox().isSelected();
                     enableUpdateButton();
                 }
             });


### PR DESCRIPTION
### Description of what the PR does

Fixes the issue of losing the state of "Allow Multiple Logins per Team" when the Admin is shut down and restarted.

The root cause of the issue was that the state of the "allow multiple logins" condition was being tracked by a boolean field (variable) which was not being saved/restored when the Admin was restarted.

Specifically, the field `allowMultipleTeamLogins` was initialized "false" when the AdminView's ContestInformationPane was constructed.  Subsequently, checking the "Allow multiple logins per team" checkbox then clicking "Update" was saving the state of the checkbox in the Contest Settings on the server (as it should), along with updating the value of the boolean variable.  However, the _value of the boolean variable was NOT being saved on the server_.   

The result was that when the Admin is restarted, `populateGUI()` repopulates the checkbox _from the contest settings fetched from the server_ (as it does for all GUI components).  This caused the checkbox itself to become "checked" (because the state of the checkbox was saved on the server), implying that the previous activation of that setting was preserved (which in essence it was).  

However, when any OTHER setting on the GUI was changed, the `updateContestInformation()` method (the actionListener for the Update button) was invoking `getFromFields()`, which was updating the contest information _based on the value of the boolean variable, not the current state of the checkbox_.

The above analysis revealed that _the only place the boolean field was being used was in `getFromFields()`_, so rather than complicate things by trying to also save the boolean field in the contest settings on the server, instead the field was simply _eliminated_, and the current value of the `allowMultipleTeamLogins` checkbox was used to update the contest settings.

### Issue which the PR fixes

Fixes #206 

### Environment in which the PR was developed:

Windows 8.1, Java 1.8.0_201, Eclipse Version: 2019-12 (4.14.0)

### Precise steps for _testing_ the PR:

- start a server with --load sumithello 
- start an Admin
- select the "Settings" pane
- Check "Allow multiple logins"
- Click Update
- Exit Admin

- Restart Admin
- Verify that "Allow Multiple Logins is still checked (it should be; this worked prior to this PR)
- Change any setting other than "Allow Multiple Logins"
- Click Update

Previously, the above sequence would cause the "Allow Multiple Logins" checkbox to become UNCHECKED.  Now, the checkbox remains checked while the other settings are updated.

To verify this, stop and then restart the Admin again; observe that the Allow Multiple Logins checkbox is still checked.


