### PR TITLE
i191: no longer allows update contest time if contest running

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/EditContestTimePane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditContestTimePane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -30,10 +30,8 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
  * Add/Edit ContestTime Pane.
  * 
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
 
-// $HeadURL$
 public class EditContestTimePane extends JPanePlugin {
 
     private static final long serialVersionUID = -1060536964672397704L;
@@ -303,6 +301,11 @@ public class EditContestTimePane extends JPanePlugin {
     }
 
     protected void handleUpdate() {
+        
+        if (getContest().getContestTime().isContestRunning()) {
+            showMessage("Updating of time while contest clock is running is not allowed");
+            return;
+        }
 
         //check contest length, elapsed, and remaining times in GUI textboxes
         if (!validateContestTimeFields()) {


### PR DESCRIPTION


### Description of what the PR does

shows message and does not update contest time values, see #191
small comment cleanup.

### Issue which the PR fixes

Fixes #191 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

all.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

From #191

1. start server
1. start admin
1. start contest time, Times -> Start ALL
1. select and edit current site's time
1. modify the time and update

**Expected behavior**: 

Does not update/save new time settings.
Show a message - "Updating of time while contest clock is running is not allowed"
