### PR TITLE
I219: fix unit test error

### DIFF
--- a/test/edu/csus/ecs/pc2/core/report/ProblemGroupAssignmentReportTest.java
+++ b/test/edu/csus/ecs/pc2/core/report/ProblemGroupAssignmentReportTest.java
@@ -40,7 +40,7 @@ public class ProblemGroupAssignmentReportTest extends AbstractTestCase {
         String sampleContestDirName = "valtest";
 
         String dirname = getContestSampleCDPDirname(sampleContestDirName);
-        dirname = "/test/cdps/PacificNWReal2020/";
+//        dirname = "/test/cdps/PacificNWReal2020/";   // local CDP
 
         File cdpConfigDirectory = new File(dirname);
         IInternalContest contest = new InternalContest();
@@ -56,7 +56,7 @@ public class ProblemGroupAssignmentReportTest extends AbstractTestCase {
         report.createReportFile(filename, new Filter());
         
         assertFileExists(filename, "Expecting report file for ProblemGroupAssignmentReport");
-
+        
 //        editFile(filename);
 //        catFile(filename);
     }


### PR DESCRIPTION
Test failed because CDP for test was local to my machine.
Test now uses sample CDP.

### Description of what the PR does

Fix path for unit test

### Issue which the PR fixes

#219 - unit test

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

gitLab build.