### PR TITLE
i257: removed thrown exception which was causing BEING_JUDGED issue.

### DIFF
--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Vector;
+import java.util.logging.Level;
 
 import edu.csus.ecs.pc2.core.exception.ClarificationUnavailableException;
 import edu.csus.ecs.pc2.core.exception.ContestSecurityException;
@@ -1857,7 +1858,7 @@ public class PacketHandler {
         JudgementRecord judgementRecord = (JudgementRecord) PacketFactory.getObjectValue(packet, PacketFactory.JUDGEMENT_RECORD);
         RunResultFiles runResultFiles = (RunResultFiles) PacketFactory.getObjectValue(packet, PacketFactory.RUN_RESULTS_FILE);
         ClientId whoJudgedRunId = (ClientId) PacketFactory.getObjectValue(packet, PacketFactory.CLIENT_ID);
-        judgeRun(run, judgementRecord, runResultFiles, whoJudgedRunId, connectionHandlerID, packet);
+        sendRunJudgementToClients(run, judgementRecord, runResultFiles, whoJudgedRunId, connectionHandlerID, packet);
 
     }
 
@@ -3297,7 +3298,7 @@ public class PacketHandler {
     }
 
     /**
-     * Judge a run
+     * This method sends the specified judgement to all clients that need to know about it.
      * 
      * @param run
      * @param judgementRecord
@@ -3309,7 +3310,7 @@ public class PacketHandler {
      * @throws ClassNotFoundException 
      * @throws IOException 
      */
-    protected void judgeRun(Run run, JudgementRecord judgementRecord, RunResultFiles runResultFiles, 
+    protected void sendRunJudgementToClients(Run run, JudgementRecord judgementRecord, RunResultFiles runResultFiles, 
             ClientId whoJudgedId, ConnectionHandlerID connectionHandlerID, Packet packet) throws ContestSecurityException, IOException, ClassNotFoundException, FileSecurityException {
 
         if (isServer()) {
@@ -3331,9 +3332,24 @@ public class PacketHandler {
 
                 Run theRun = contest.getRun(run.getElementId());
 
-                if (judgementRecord.isComputerJudgement()) {
-                    if (contest.getProblem(theRun.getProblemId()).isManualReview()) {
-                        if (contest.getProblem(theRun.getProblemId()).isPrelimaryNotification()) {
+                try {
+                    
+                    //try to send the judgement to the team
+                    if (judgementRecord.isComputerJudgement()) {
+                        
+                        if (contest.getProblem(theRun.getProblemId()).isManualReview()) {
+                            if (contest.getProblem(theRun.getProblemId()).isPrelimaryNotification()) {
+
+                                // Do not send RunResultFiles to the team
+                                RunResultFiles rrf = runResultFiles;
+                                if (run.getSubmitter().getClientType().equals(ClientType.Type.TEAM)) {
+                                    rrf = null;
+                                }
+                                Packet judgementPacket = PacketFactory.createRunJudgement(contest.getClientId(), run.getSubmitter(), theRun, judgementRecord, rrf);
+                                
+                                sendJudgementToTeam (judgementPacket, theRun);
+                            }
+                        } else {
 
                             // Do not send RunResultFiles to the team
                             RunResultFiles rrf = runResultFiles;
@@ -3341,7 +3357,6 @@ public class PacketHandler {
                                 rrf = null;
                             }
                             Packet judgementPacket = PacketFactory.createRunJudgement(contest.getClientId(), run.getSubmitter(), theRun, judgementRecord, rrf);
-                            
                             sendJudgementToTeam (judgementPacket, theRun);
                         }
                     } else {
@@ -3354,17 +3369,12 @@ public class PacketHandler {
                         Packet judgementPacket = PacketFactory.createRunJudgement(contest.getClientId(), run.getSubmitter(), theRun, judgementRecord, rrf);
                         sendJudgementToTeam (judgementPacket, theRun);
                     }
-                } else {
-
-                    // Do not send RunResultFiles to the team
-                    RunResultFiles rrf = runResultFiles;
-                    if (run.getSubmitter().getClientType().equals(ClientType.Type.TEAM)) {
-                        rrf = null;
-                    }
-                    Packet judgementPacket = PacketFactory.createRunJudgement(contest.getClientId(), run.getSubmitter(), theRun, judgementRecord, rrf);
-                    sendJudgementToTeam (judgementPacket, theRun);
+                } catch (Exception e) {
+                    
+                    controller.getLog().log(Level.WARNING, "Exception attempting to send judgement for run " + run + " in packet " + packet + ": "+ e.getMessage(), e);
                 }
 
+                //try to send the judgement to other clients 
                 Packet judgementUpdatePacket = PacketFactory.createRunJudgmentUpdate(contest.getClientId(), PacketFactory.ALL_SERVERS, theRun, whoJudgedId);
                 controller.sendToJudgesAndOthers(judgementUpdatePacket, true);
             }


### PR DESCRIPTION
### Description of what the PR does

Removes a thrown exception which was causing a bypass of sending RUN_JUDGEMENT packets to Admin/Judge/Feeder/etc. clients.
Adds try/catches to handle various low-level exceptions.
Added additional logging.

### Issue which the PR fixes
fixes #257

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Eclipse 2020.12, Windows 10.1

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
TBD