### PR TITLE
i31: add support for stop on first in contest.yaml

### DIFF
--- a/samps/contests/tenprobs/config/contest.yaml
+++ b/samps/contests/tenprobs/config/contest.yaml
@@ -18,6 +18,9 @@ scoreboard-freeze-length: 01:00:00
 # remaining: 5:00:00
 running: true
 
+# default stop of first fail
+stop-on-first-failed-test-case: true
+
 # Halt contest clock at end of contest
 # auto-stop-clock-at-end: true
 

--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -156,6 +156,13 @@ public class ContestInformation implements Serializable{
     private Date thawed = null;
 
     private boolean allowMultipleLoginsPerTeam;
+    
+    
+    /**
+     * stop-on-first-failed-test-case
+     * 
+     */
+    private boolean stopOnFirstFailedtestCase = false;
 
     /**
      * Returns the date/time when the contest is scheduled (intended) to start.
@@ -725,5 +732,13 @@ public class ContestInformation implements Serializable{
      */
     public boolean isAllowMultipleLoginsPerTeam() {
         return this.allowMultipleLoginsPerTeam;
+    }
+    
+    public boolean isStopOnFirstFailedtestCase() {
+        return stopOnFirstFailedtestCase;
+    }
+    
+    public void setStopOnFirstFailedtestCase(boolean stopOnFirstFailedtestCase) {
+        this.stopOnFirstFailedtestCase = stopOnFirstFailedtestCase;
     }
 }

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -403,11 +403,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         }
         
         boolean stopOnFirstFail = fetchBooleanValue(content, STOP_ON_FIRST_FAILED_TEST_CASE_KEY, false);
-        if (stopOnFirstFail) {
-            setStopOnFirstFailedTestCase (contest, stopOnFirstFail);
-        }
-        
-        System.out.println("debug 22 for stopOnFirstFail is " +contest.getContestInformation().isStopOnFirstFailedtestCase() + " "+directoryName );
+        setStopOnFirstFailedTestCase (contest, stopOnFirstFail);
         
         /**
          * assign shadow values

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -73,8 +73,6 @@ import edu.csus.ecs.pc2.validator.pc2Validator.PC2ValidatorSettings;
  */
 public class ContestSnakeYAMLLoader implements IContestLoader {
 
-
-
     /**
      * Full content of yaml file.
      */
@@ -264,8 +262,14 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         ContestInformation contestInformation = contest.getContestInformation();
         contestInformation.setCcsTestMode(ccsTestMode);
         contest.updateContestInformation(contestInformation);
-
     }
+    
+    
+    private void setStopOnFirstFailedTestCase(IInternalContest contest, boolean stopOnFirstFail) {
+        ContestInformation contestInformation = contest.getContestInformation();
+        contestInformation.setStopOnFirstFailedtestCase(stopOnFirstFail);
+        contest.updateContestInformation(contestInformation);
+    }    
 
     /**
      * Parse and convert dateString to Date.
@@ -397,6 +401,13 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         if (ccsTestMode) {
             setCcsTestMode(contest, ccsTestMode);
         }
+        
+        boolean stopOnFirstFail = fetchBooleanValue(content, STOP_ON_FIRST_FAILED_TEST_CASE_KEY, false);
+        if (stopOnFirstFail) {
+            setStopOnFirstFailedTestCase (contest, stopOnFirstFail);
+        }
+        
+        System.out.println("debug 22 for stopOnFirstFail is " +contest.getContestInformation().isStopOnFirstFailedtestCase() + " "+directoryName );
         
         /**
          * assign shadow values
@@ -753,6 +764,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
     }
 
+    
     /**
      * Generate and write OS password file.
      * @param passfilename
@@ -1354,8 +1366,10 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                 }
             }
         }
+        
+        boolean globlStopOnFirstFail = contest.getContestInformation().isStopOnFirstFailedtestCase();
 
-        boolean stopOnFirstFail = fetchBooleanValue(content, STOP_ON_FIRST_FAILED_TEST_CASE_KEY, false);
+        boolean stopOnFirstFail = fetchBooleanValue(content, STOP_ON_FIRST_FAILED_TEST_CASE_KEY, globlStopOnFirstFail);
         problem.setStopOnFirstFailedTestCase(stopOnFirstFail);
 
         assignJudgingType(content, problem, overrideManualReview);

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3516,14 +3516,14 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         
     }
     
-    public void tesproblemflagtestStopOnFirstFailedTestCase() throws Exception {
+    public void testisStopOnFirstFailedTestCase() throws Exception {
         
-        String sampleName = "problemflagtest";
+        String sampleName = "problemflagtest"; // use CDP sample problemflagtest
         IInternalContest contest  = fullLoadSampleContest(sampleName);
         assertNotNull(contest);
 
         Problem[] problems = contest.getProblems();
-        assertEquals("Num problems ",10, problems.length);
+        assertEquals("Num problems ", 8, problems.length);
         
         for (Problem problem : problems) {
             assertTrue(problem.getShortName()+" stop on first ", problem.isStopOnFirstFailedTestCase());
@@ -3533,6 +3533,11 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
     
     
     
+    /**
+     * Test load problem.yaml isStopOnFirstFailedTestCase.
+     * 
+     * @throws Exception
+     */
     public void testvaltesttStopOnFirstFailedTestCase() throws Exception {
         
         String sampleName = "valtest";

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3499,5 +3499,63 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         assertEquals("Public HTML Directory", "public_html_dir", publicDir);
 
     }
+    
+    
+    public void testTenProbsisStopOnFirstFailedTestCase() throws Exception {
+        
+        String sampleName = "tenprobs";
+        IInternalContest contest  = fullLoadSampleContest(sampleName);
+        assertNotNull(contest);
+
+        Problem[] problems = contest.getProblems();
+        assertEquals("Num problems ",10, problems.length);
+        
+        for (Problem problem : problems) {
+            assertTrue(problem.getShortName()+" stop on first ", problem.isStopOnFirstFailedTestCase());
+        }
+        
+    }
+    
+    public void tesproblemflagtestStopOnFirstFailedTestCase() throws Exception {
+        
+        String sampleName = "problemflagtest";
+        IInternalContest contest  = fullLoadSampleContest(sampleName);
+        assertNotNull(contest);
+
+        Problem[] problems = contest.getProblems();
+        assertEquals("Num problems ",10, problems.length);
+        
+        for (Problem problem : problems) {
+            assertTrue(problem.getShortName()+" stop on first ", problem.isStopOnFirstFailedTestCase());
+        }
+        
+    }
+    
+    
+    
+    public void testvaltesttStopOnFirstFailedTestCase() throws Exception {
+        
+        String sampleName = "valtest";
+        IInternalContest contest  = fullLoadSampleContest(sampleName);
+ 
+        assertNotNull(contest);
+
+        Problem[] problems = contest.getProblems();
+        assertEquals("Num problems ",6, problems.length);
+        
+        for (Problem problem : problems) {
+            assertFalse(problem.getShortName()+" stop on first ", problem.isStopOnFirstFailedTestCase());
+        }
+        
+    }
+
+    private IInternalContest fullLoadSampleContest(String sampleName) throws Exception {
+        IInternalContest contest  = new InternalContest();
+        loadGroupsFromSampContest(contest, sampleName);
+        contest = loadSampleContest(contest, sampleName);
+        return contest;
+    }
+    
+    
 }
 


### PR DESCRIPTION
Add global support for stop-on-first-failed-test-case in
contest.yaml.
problem.yaml stop-on-first-failed-test-case can override the
settings in contest.yaml

### Description of what the PR does

Add yaml support for stop-on-first-failed-test-case in contest.yaml

### Issue which the PR fixes

#31 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Add the following line to contest.yaml as a global setting.
```
stop-on-first-failed-test-case: true
```

By default the value is false.

Start  server loading the CDP/contest.yaml.
Start admin and check problem Test Data Files checkbox: Stop execution on first filed test case.

