### PR TITLE
I259 shadow compare npe

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/CLICSJudgementType.java
+++ b/src/edu/csus/ecs/pc2/clics/CLICSJudgementType.java
@@ -185,6 +185,8 @@ public class CLICSJudgementType {
      */
     private static ArrayList<JudgementMapping> judgementStringMappings = new ArrayList<JudgementMapping>() {
  
+        private static final long serialVersionUID = 1L;
+
         {
             add(new JudgementMapping("Accepted",CLICS_JUDGEMENT_ACRONYM.AC));
             
@@ -413,7 +415,7 @@ public class CLICSJudgementType {
      * specification at https://clics.ecs.baylor.edu/index.php?title=Contest_API#Judgement_Types), or null
      * if there is no recommended mapping for the acronym defined in this judgement type.
      * 
-     * @return the CLICS "Big 5" judgement 
+     * @return the CLICS "Big 5" judgement corresponding to this CLICS judgement, or null if there is no Big5 equivalent defined.
      */
     public String getBig5EquivalentAcronym() {
         return big5Mapping.get(this.id);
@@ -421,11 +423,11 @@ public class CLICSJudgementType {
     
     /**
      * Returns the {@link CLICS_JUDGEMENT_ACRONYM} element which corresponds to the specified text string, or null
-     * ff there is no CLICS_JUDGEMENT_ACRONYM whose text string matches the specified text.
+     * if there is no CLICS_JUDGEMENT_ACRONYM whose text string matches the specified text.
      * 
      * @param text a String giving a judgement message; for example "Wrong Answer"
      * 
-     * @return the CLICS_JUDGEMENT_ACRONYM element corresponding to the received text (e.g. CLICS_JUDGEMENT_ACRONYM.WA), or null 
+     * @return the CLICS_JUDGEMENT_ACRONYM element corresponding to the received text (e.g. CLICS_JUDGEMENT_ACRONYM.WA), or null. 
      */
     public static CLICS_JUDGEMENT_ACRONYM getCLICSAcronym (String text) {
           

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -143,8 +143,8 @@ public class RemoteEventFeedMonitor implements Runnable {
                     //skip blank lines and any that do not start/end with "{...}"
                     if ( event.length()>0 && event.trim().startsWith("{") && event.trim().endsWith("}") ) {
                         
-                        System.out.println("Got event string: " + event);
-//                        log.log(Level.INFO, "Got event string: " + event);
+//                        System.out.println("Got event string: " + event);
+                        log.log(Level.INFO, "Got event string: " + event);
                         try {
 
                             /**
@@ -208,8 +208,8 @@ public class RemoteEventFeedMonitor implements Runnable {
                                             throw new Exception("Error parsing submission data " + event);
                                         } else {
 
-//                                            log.log(Level.INFO, "Found run " + runSubmission.getId() + " from team " + runSubmission.getTeam_id());
-                                            System.out.println("Found run " + runSubmission.getId() + " from team " + runSubmission.getTeam_id());
+                                            log.log(Level.INFO, "Found run " + runSubmission.getId() + " from team " + runSubmission.getTeam_id());
+//                                            System.out.println("Found run " + runSubmission.getId() + " from team " + runSubmission.getTeam_id());
 
                                             //construct the override values to be used for the shadow submission
                                             long overrideTimeMS = Utilities.convertCLICSContestTimeToMS(runSubmission.getContest_time());
@@ -284,7 +284,7 @@ public class RemoteEventFeedMonitor implements Runnable {
 
                                             //this block is a temporary substitute for the above commented-out block
                                             List<IFile> files = null;
-                                            System.out.println("debug 22 get files using id "+overrideSubmissionID);
+//                                            System.out.println("debug 22 get files using id "+overrideSubmissionID);
                                             files = remoteContestAPIAdapter.getRemoteSubmissionFiles("" + overrideSubmissionID);
 
                                             IFile mainFile = null;
@@ -319,8 +319,8 @@ public class RemoteEventFeedMonitor implements Runnable {
 
                                 } else if ("judgements".equals(eventType)) {
                                     
-                                    System.out.println("debug 22 recognized judgement event");
-//                                    log.log(Level.INFO, "Found " + eventType + " event");
+//                                    System.out.println("debug 22 recognized judgement event");
+                                    log.log(Level.INFO, "Found " + eventType + " event");
 
                                     //process a judgement event
                                     try {
@@ -360,7 +360,7 @@ public class RemoteEventFeedMonitor implements Runnable {
      
                                                 // this is a judgement we want; save it in the global judgements map under a key of
                                                 // the judgement ID with value "submissionID:judgement"
-                                                System.out.println ("Adding judgement " + judgementID + " for submission " + submissionID + " with judgement " + judgement + " to RemoteJudgements Map");                                                
+//                                                System.out.println ("Adding judgement " + judgementID + " for submission " + submissionID + " with judgement " + judgement + " to RemoteJudgements Map");                                                
                                                 synchronized (remoteJudgementsMapLock) {
                                                     getRemoteJudgementsMap().put(judgementID, submissionID + ":" + judgement);
                                                 }

--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 
 import edu.csus.ecs.pc2.clics.CLICSJudgementType;
@@ -306,225 +305,197 @@ public class ShadowController {
             return null;
         } else {
             log.info("Constructing Shadow Judgement comparisons");
-            
-            //get a Map of the judgements assigned by the remote CCS to each submission; note that this map uses "remote event id"
-            // as the key and combines the submission ID with the Judgement acronym, separated by a colon, as the value
-            Map<String,String> remoteJudgementsMap = RemoteEventFeedMonitor.getRemoteJudgementsMapSnapshot();
-            
-            //convert the Map to one with submission ID as key and acronym (judgement) as value
-            Map<String,String> remoteSubmissionsJudgementMap = new HashMap<String,String>();
-            for (String key : remoteJudgementsMap.keySet()) {
-                String value = remoteJudgementsMap.get(key) ;
-                String submissionID = value.substring(0, value.lastIndexOf(':'));
-                String judgementAcronym = value.substring(value.lastIndexOf(':')+1);
-                remoteSubmissionsJudgementMap.put(submissionID, judgementAcronym);
-            }
-            
-            //if specified, convert remote judgements to "Big 5"
-            if (isConvertJudgementsToBig5()) {
-                log.info("Converting remote judgements to CLICS 'Big 5'");
-                convertMapToBig5(remoteSubmissionsJudgementMap);
-            }
-            
-            //get the runs (submissions) currently in PC2 (i.e. runs already obtained from the remote CCS and submitted to the PC2 server)
+                       
+            //get the runs (submissions) currently in PC2 (i.e. runs already received from the remote CCS and submitted to the PC2 server)
             Run[] pc2Runs = localContest.getRuns();
-            
-//            //debug loop
-//            for (Run run : runs) {
-//                if (!run.isJudged()) {
-//                    log.warning("Found unjudged run in PC2 Shadow system: " + run);
-//                    System.err.println ("Found unjudged run in PC2 Shadow system: ");
-//                    System.err.println ("  " + run);
-//                }
-//            }
-            
-            //build a map of PC2 run judgements, mapping submissionID to judgement acronym for each submission
-            Map<String,String> pc2JudgementsMap = new HashMap<String,String>();
-            for (Run run : pc2Runs) {
-                
-                //avoid any "null" runs which might be returned in the RunList
-                if (run != null) {
-                    
-                    if (run.isJudged()) {
-
-                        JudgementRecord jr = run.getJudgementRecord();
-
-                        if (jr != null) {
-
-                            String judgementString;
-
-                            if (jr.isUsedValidator() && jr.getValidatorResultString() != null) {
-                                judgementString = jr.getValidatorResultString();
-                            } else {
-                                //no validator result; fall back to using judgementId (remembering that this
-                                // defaults to "RTE" for all "no" judgements -- see V9 bug list)
-                                ElementId judgementId = jr.getJudgementId();
-                                Judgement judgement = localContest.getJudgement(judgementId);
-                                judgementString = judgement.getDisplayName();
-                                if (judgementString.startsWith("No - ")) {
-                                    judgementString = judgementString.substring(5); //strip off the "No - "
-                                }
-                            }
-
-                            if (judgementString == null) {
-                                log.warning("Null judgement string for run " + run.getNumber());
-                            }
-
-                            //at this point we have the judgement string text; try to convert it to a corresponding acronym
-                            CLICS_JUDGEMENT_ACRONYM acronym = CLICSJudgementType.getCLICSAcronym(judgementString);
-
-                            if (acronym == null) {
-                                //we couldn't find a CLICS judgement matching the string; 
-                                //try to use the judgement record (which may be incorrect; see V9 bug list regarding defaulting to RTE)
-                                ElementId judgementId = jr.getJudgementId();
-                                Judgement judgement = localContest.getJudgement(judgementId);
-                                judgementString = judgement.getDisplayName();
-                                if (judgementString.startsWith("No - ")) {
-                                    judgementString = judgementString.substring(5); //strip off the "No - "
-                                }
-
-                                acronym = CLICSJudgementType.getCLICSAcronym(judgementString);
-
-                            }
-
-                            if (acronym != null) {
-                                //put the judgement acronym into the pc2Judgements map under the submissionID
-                                String submissionID = String.valueOf(run.getNumber());
-                                pc2JudgementsMap.put(submissionID, acronym.name());
-
-                            } else {
-                                //we've exhausted methods of obtaining an acronym
-                                log.warning("Null acronym for run " + run.getNumber() + ", judgement string " + judgementString);
-                            }
-
-                        } else {
-                            //we got a null judgment record from the run, but it's supposedly been judged -- error!
-                            log.severe("Error: found a (supposedly) judged run with no JudgementRecord!");
-                        }
-
-                    } else {
-                        //we have an as-yet unjudged run
-                        String submissionID = String.valueOf(run.getNumber());
-                        pc2JudgementsMap.put(submissionID, "<pending>");
-                    } 
-                    
-                } else {
-                    log.warning("Encountered null run in RunList; skipping"); 
-                }
-                
-            }//end for each run
-
-            //if specified, convert PC2 judgements to "Big 5"
-            if (isConvertJudgementsToBig5()) {
-                log.info("Converting PC2 judgements to 'CLICS Big 5'");
-                convertMapToBig5(pc2JudgementsMap);
-            }
-            
-            //verify that we have corresponding maps (from the remote vs. the local systems)
-            Set<String> remoteKeys = remoteSubmissionsJudgementMap.keySet();
-            Set<String> localKeys = pc2JudgementsMap.keySet();
-            if (!remoteKeys.equals(localKeys)) {
-//                log.warning("Contents of remote judgements map does not match that of local PC2 judgements map"
-//                        + " (this could happen if PC2 is not keeping up with remote submissions)");
-                System.err.println("Note: contents of remote judgements map does not match that of local PC2 judgements map"
-                        + " (this could happen if PC2 is not keeping up with remote submissions)");
-            }
-            
-            //construct a single map containing the ShadowJudgementInfo for each submission ("run" in PC2 terms)
-            Map<String,ShadowJudgementInfo> judgementsMap = new HashMap<String,ShadowJudgementInfo>();
-            
-            //first put into the combined map the judgements from the remote system, with the corresponding PC2 value
-            //   (which could be null if PC2 doesn't have a judgement for the corresponding submission)
-            String teamID;
-            String problemID;
-            String languageID;
-            
-            for (String submissionID : remoteKeys) {
-                
-                //get the run corresponding to the current submissionID
-                Run run = getRun(pc2Runs,submissionID);
-                
-                //get the team/problem/language info corresponding to the run
-                teamID = new Integer(run.getSubmitter().getClientNumber()).toString();
-                
-                ElementId probElementID = run.getProblemId();
-                problemID = localContest.getProblem(probElementID).getShortName();
-                
-                ElementId langElementID = run.getLanguageId();
-                languageID = localContest.getLanguage(langElementID).getID();
-
-                ShadowJudgementPair pair = new ShadowJudgementPair(submissionID, pc2JudgementsMap.get(submissionID), 
-                                                    remoteSubmissionsJudgementMap.get(submissionID));
-                
-                System.out.println("Debug: adding to judgementsMap: ") ;
-                System.out.println ("  submissionID=" + submissionID + " teamID=" + teamID + " problemID=" 
-                        + problemID + " languageID=" + languageID + " pc2Judgement=" + pc2JudgementsMap.get(submissionID)
-                        + " remoteJudgement=" + remoteSubmissionsJudgementMap.get(submissionID));
-                
-                ShadowJudgementInfo info = new ShadowJudgementInfo(submissionID, teamID, problemID, languageID, pair);
-                
-                judgementsMap.put(submissionID, info);
-            }
-            
-            //now add judgements from the PC2 map that might not have existed in the remote map
-            for (String submissionID : localKeys) {
-                if (!remoteSubmissionsJudgementMap.containsKey(submissionID)) {
-                    
-                    //get the run corresponding to the current submissionID
-                    Run run = getRun(pc2Runs,submissionID);
-                                       
-//                    teamID = run.getSubmitter().toString();
-//                    problemID = run.getProblemId().toString();
-//                    languageID = run.getLanguageId().toString();
-                    
-                    //get the team/problem/language info corresponding to the run
-                    teamID = new Integer(run.getSubmitter().getClientNumber()).toString();
-                    
-                    ElementId probElementID = run.getProblemId();
-                    problemID = localContest.getProblem(probElementID).getShortName();
-                    
-                    ElementId langElementID = run.getLanguageId();
-                    languageID = localContest.getLanguage(langElementID).getID();
-                    
-                    ShadowJudgementPair pair = new ShadowJudgementPair(submissionID, pc2JudgementsMap.get(submissionID), 
-                                 remoteSubmissionsJudgementMap.get(submissionID)); //the remote map will always return null
-                    
-                    System.out.println("Debug: adding to judgementsMap: ") ;
-                    System.out.println ("  submissionID=" + submissionID + " teamID=" + teamID + " problemID=" 
-                            + problemID + " languageID=" + languageID + " pc2Judgement=" + pc2JudgementsMap.get(submissionID)
-                            + " remoteJudgement=" + remoteSubmissionsJudgementMap.get(submissionID));
-                    
-                    
-                    ShadowJudgementInfo info = new ShadowJudgementInfo(submissionID, teamID, problemID, languageID, pair);
-                                        
-                    judgementsMap.put(submissionID, info);
-                }
-            }
                         
+            //get a map from submissionID to ShadowJudgementInfo for each submission which PC2 knows about
+            Map<String,ShadowJudgementInfo> judgementsMap = getJudgementsMap(pc2Runs);
+            
+            //At this point we have a Map ("judgementsMap") which maps every submissionId that PC2 knows about to a ShadowJudgementInfo object
+                        
+            //get the submission judgements which have been reported by the remote CCS
+            Map<String,String> remoteSubmissionsToJudgementsMap = getRemoteSubmissionsToJudgementsMap();
+                        
+            //check every submission reported to have a judgement by the remote CCS
+            for (String key : remoteSubmissionsToJudgementsMap.keySet()) {
+                
+                //check if PC2 has seen this submission (it might not have yet due to lags with RemoteEventFeedMonitor submitting to PC2)
+                if (judgementsMap.containsKey(key)) {
+                    
+                    //we found a submission, known to PC2, for which the remote CCS has reported a judgement; update the remote judgement info under that key
+                    ShadowJudgementInfo info = judgementsMap.get(key);
+                    ShadowJudgementPair pair = info.getShadowJudgementPair();
+                    pair.setRemoteCCSJudgement(remoteSubmissionsToJudgementsMap.get(key));
+                }
+            }
+ 
+            //we now have a complete map from submissions known to PC2 to ShadowJudgementInfo objects containing known PC2 judgements and known remote CCS judgements
+            
+            //if specified, convert judgements to "Big 5"
+            if (isConvertJudgementsToBig5()) {
+                log.info("Converting judgements to 'CLICS Big 5'");
+                convertMapToBig5(judgementsMap);
+            }
+            
             return judgementsMap;
         }
         
     }
     
+ 
     /**
-     * Searches the given array of Runs and returns the run, if any, whose run number matches the specified
-     * submissionId; otherwise returns null.
+     * Returns a Map which maps submissionIds to the acronym assigned to that submission by the Remote CCS.
+     * Note that the returned map does NOT necessarily contain entries for all known submissions; it contains
+     * only entries for submissions for which a judgement has been received from the Remote CCS.
      * 
-     * @param runs an array of Runs to be searched
-     * @param submissionID the id of the desired run
+     * Any judgements from the Remote CCS which are null, which have values which are null or empty, which 
+     * have submissionIds which are null or empty, or which have judgement acronyms which are null or empty,
+     * are silently ignored (not represented in the map returned by this method).
      * 
-     * @return the Run matching the specified submissionID, or null if no Run matches
+     * @return a Map with entries mapping a submissionId String to an acronym String.
      */
-    private Run getRun(Run[] runs, String submissionID) {
+    private Map<String, String> getRemoteSubmissionsToJudgementsMap() {
         
-        for (Run nextRun : runs) {
-            String runNumberString = new Integer(nextRun.getNumber()).toString();
-            if (runNumberString.equalsIgnoreCase(submissionID)) {
-                return nextRun;
+        //get a copy of the RemoteEventFeedMonitor's Judgements map, which maps "judgementIds" to a String of the form "submissionId:acronym"
+        Map<String, String> remoteJudgementsMap = RemoteEventFeedMonitor.getRemoteJudgementsMapSnapshot();
+
+        // convert the RemoteEFMonitor Map to one with submission ID as key and acronym (judgement) as value
+        Map<String, String> remoteSubmissionsToJudgementsMap = new HashMap<String, String>();
+        for (String key : remoteJudgementsMap.keySet()) {
+            if (key != null) {
+                String value = remoteJudgementsMap.get(key);
+                if (value != null) {
+                    String submissionID = value.substring(0, value.lastIndexOf(':'));
+                    if (submissionID != null && !submissionID.contentEquals("")) {
+                        String judgementAcronym = value.substring(value.lastIndexOf(':') + 1);
+                        if (judgementAcronym != null && !judgementAcronym.contentEquals("")) {
+                            remoteSubmissionsToJudgementsMap.put(submissionID, judgementAcronym);
+                        }
+                    }
+                }
             }
         }
-        return null;
+        return remoteSubmissionsToJudgementsMap;
     }
+    
+    
+    /**
+     * Returns a Map which maps submissionIds to {@link ShadowJudgementInfo} objects for every submission (run) in the
+     * specified array of PC2 Runs.
+     */
+    private Map<String, ShadowJudgementInfo> getJudgementsMap(Run[] pc2Runs) {
+
+        Map<String, ShadowJudgementInfo> pc2JudgementInfoMap = new HashMap<String, ShadowJudgementInfo>();
+
+        // check each PC2 run (submission)
+        for (Run run : pc2Runs) {
+
+            // avoid any "null" runs which might be returned in the PC2 RunList
+            if (run != null) {
+
+                //get the submissionId of the run (basically, the Run number)
+                String submissionId = String.valueOf(run.getNumber());
+
+                // get the team/problem/language info corresponding to the run
+                String teamID = new Integer(run.getSubmitter().getClientNumber()).toString();
+
+                ElementId probElementID = run.getProblemId();
+                String problemID = localContest.getProblem(probElementID).getShortName();
+
+                ElementId langElementID = run.getLanguageId();
+                String languageID = localContest.getLanguage(langElementID).getID();
+
+                if (run.isJudged()) {
+
+                    // get the judgement assigned to the run by PC2
+                    JudgementRecord jr = run.getJudgementRecord();
+
+                    if (jr != null) {
+
+                        // try to determine the judgement string assigned to the run
+                        String judgementString;
+
+                        if (jr.isUsedValidator() && jr.getValidatorResultString() != null) {
+                            judgementString = jr.getValidatorResultString();
+                        } else {
+                            // no validator result; fall back to using judgementId (remembering that this
+                            // defaults to "RTE" for all "no" judgements -- see V9 bug list)
+                            ElementId judgementId = jr.getJudgementId();
+                            Judgement judgement = localContest.getJudgement(judgementId);
+                            judgementString = judgement.getDisplayName();
+                            if (judgementString.startsWith("No - ")) {
+                                judgementString = judgementString.substring(5); // strip off the "No - "
+                            }
+                        }
+
+                        if (judgementString == null) {
+                            log.warning("Null judgement string for run " + run.getNumber());
+                        }
+
+                        // try to convert the judgement string text to a corresponding acronym (returns null if judgementString is null or not found)
+                        CLICS_JUDGEMENT_ACRONYM acronym = CLICSJudgementType.getCLICSAcronym(judgementString);
+
+                        if (acronym == null) {
+                            // we couldn't find a CLICS judgement matching the string;
+                            // try to use the judgement record (which may be incorrect; see V9 bug list regarding defaulting to RTE)
+                            ElementId judgementId = jr.getJudgementId();
+                            Judgement judgement = localContest.getJudgement(judgementId);
+                            judgementString = judgement.getDisplayName();
+                            if (judgementString.startsWith("No - ")) {
+                                judgementString = judgementString.substring(5); // strip off the "No - "
+                            }
+
+                            acronym = CLICSJudgementType.getCLICSAcronym(judgementString);
+
+                        }
+
+                        if (acronym != null) {
+
+                            // assign PC2 judgement, plus a "pending" for remote judgement (to be filled in later)
+                            ShadowJudgementPair pair = new ShadowJudgementPair(submissionId, acronym.name(), "<pending>");
+
+//                            System.out.print("Debug: adding to judgementsMap: ");
+//                            System.out.println("  submissionID=" + submissionId + " teamID=" + teamID + " problemID=" + problemID + " languageID=" + languageID 
+//                                    + " pc2Judgement=" + acronym.name() + " remoteJudgement=" + "<pending>");
+
+                            ShadowJudgementInfo info = new ShadowJudgementInfo(submissionId, teamID, problemID, languageID, pair);
+
+                            pc2JudgementInfoMap.put(submissionId, info);
+
+                        } else {
+                            // we've exhausted methods of obtaining an acronym
+                            log.warning("Null judgement acronym for run " + run.getNumber() + ", judgement string " + judgementString + "; skipping");
+                        }
+
+                    } else {
+                        // we got a null judgment record from the run, but it's supposedly been judged -- error!
+                        log.severe("Error: found a (supposedly) judged PC2 run with no PC2 JudgementRecord!" + " (Submission id = " + run.getNumber() + ")");
+                    }
+
+                } else {
+                    
+                    // we have a run which has not yet been judged by PC2; assign "pending" for both the PC2 and remote judgement
+                    ShadowJudgementPair pair = new ShadowJudgementPair(submissionId, "<pending>", "<pending>");
+                    ShadowJudgementInfo info = new ShadowJudgementInfo(submissionId, teamID, problemID, languageID, pair);
+                    
+//                    System.out.print("Debug: adding to judgementsMap: ");
+//                    System.out.println("  submissionID=" + submissionId + " teamID=" + teamID + " problemID=" + problemID + " languageID=" + languageID 
+//                            + " pc2Judgement=" + "<pending>" + " remoteJudgement=" + "<pending>");
+                    
+                    pc2JudgementInfoMap.put(submissionId, info);
+                }
+
+            } else {
+                log.warning("Encountered null run in PC2 RunList; skipping");
+            }
+
+        } // end for each PC2 run
+        
+        return pc2JudgementInfoMap ;
+
+    }
+
     
     /**
      * Returns a list of differences between the currently-configured remote contest
@@ -604,37 +575,115 @@ public class ShadowController {
         return convertJudgementsToBig5 ;
     }
     
+//    /**
+//     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms if a corresponding CLICS Big 5 acronym 
+//     * can be found.  If no corresponding acronym can be found, then a check is made to see if the initial acronym contains the
+//     * substring "pending"; if so, the original acronym is retained, if not then the acronym is replaced with a string of the form
+//     * "<NoBig5:xxx>" where "xxx" is the original acronym.
+//     * 
+//     * @param map the map to be converted
+//     */
+//    private void convertMapToBig5 (Map<String,String> map) {
+//        //process each submission in the specified map
+//        for (String submissionID : map.keySet()) {
+//            String judgementAcronym = map.get(submissionID) ;
+//            //construct a CLICSJudgement for the acronym
+//            CLICSJudgementType clicsJudgement = new CLICSJudgementType(judgementAcronym, "dummy", false, false);
+//            //check if the judgement is already a "Big 5"
+//            if (!clicsJudgement.isBig5()) {
+//                //no it's not a Big 5; get a corresponding Big 5 acronym in the map
+//                String newAcronym = clicsJudgement.getBig5EquivalentAcronym();
+//                //the above method returns null if there is no matching Big 5 acronym
+//                if (newAcronym==null) {
+//                    //there's no Big5 for the judgement acronym; see if it's "pending"
+//                    if (!judgementAcronym.toLowerCase().contains("pending")) {
+//                        //not pending; replace with message
+//                        newAcronym = "<NoBig5:" + judgementAcronym + ">";
+//                    } else {
+//                        //it does contain pending; keep the original acronym
+//                        newAcronym = judgementAcronym ;
+//                    }
+//                }
+//                map.put(submissionID, newAcronym);
+//            }
+//        }
+//
+//    }
+
     /**
-     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms.
+     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms if a corresponding CLICS Big 5 acronym 
+     * can be found.  If no corresponding acronym can be found, then a check is made to see if the initial acronym contains the
+     * substring "pending"; if so, the original acronym is retained, if not then the acronym is replaced with a string of the form
+     * "<NoBig5:xxx>" where "xxx" is the original acronym.
      * 
      * @param map the map to be converted
      */
-    private void convertMapToBig5 (Map<String,String> map) {
-        //process each submission judgement from the remote CCS
+    private void convertMapToBig5 (Map<String,ShadowJudgementInfo> map) {
+        
+        //process each submission in the specified map
         for (String submissionID : map.keySet()) {
-            String judgementAcronym = map.get(submissionID) ;
-            //construct a CLICSJudgement for the acronym
-            CLICSJudgementType clicsJudgement = new CLICSJudgementType(judgementAcronym, "dummy", false, false);
-            //check if the judgement is already a "Big 5"
-            if (!clicsJudgement.isBig5()) {
-                //no it's not a Big 5; get a corresponding Big 5 acronym in the map
-                String newAcronym = clicsJudgement.getBig5EquivalentAcronym();
-                //the above method returns null if there is no matching Big 5 acronym
-                if (newAcronym==null) {
-                    //there's no Big5 for the judgement acronym; see if it's "pending"
-                    if (!judgementAcronym.toLowerCase().contains("pending")) {
-                        //not pending; replace with message
-                        newAcronym = "<NoBig5:" + judgementAcronym + ">";
-                    } else {
-                        //it does contain pending; keep the original acronym
-                        newAcronym = judgementAcronym ;
-                    }
-                }
-                map.put(submissionID, newAcronym);
+            
+            //get the judgement info out of the submission
+            ShadowJudgementInfo info = map.get(submissionID) ;
+            
+            //get the ShadowJudgementPair out of the judgement info
+            ShadowJudgementPair pair = info.getShadowJudgementPair();
+            
+            String judgementAcronym = pair.getPc2Judgement();
+            pair.setPc2Judgement(convertJudgementToCLICSBig5(judgementAcronym));
+            
+            judgementAcronym = pair.getRemoteCCSJudgement();
+            pair.setRemoteCCSJudgement(convertJudgementToCLICSBig5(judgementAcronym));
+            
+        }
+    }
+    
+    /**
+     * Returns a String representing the "CLICS Big5 acronym" (one of WA/RTE/TLE/CE/AC) corresponding to the specified judgement acronym tring.
+     * If there is no corresponding conversion (as defined by {@link CLICSJudgementType#getBig5EquivalentAcronym()},
+     * then if the specified judgement string contains the substring "pending" then the specified judgement string is returned,
+     * otherwise a String of the form "<NoBig5:xxx>" (where xxx is the input string) is returned.
+     * 
+     * @param judgementAcronym the string to be converted to its "CLICS Big 5" equivalent.
+     * 
+     * @return a String containing a CLICS Big5 acronym if there is such an acronym matching the input judgement; otherwise 
+     *              returns the input judgement or a string containing the input judgement.
+     */
+    private String convertJudgementToCLICSBig5(String judgementAcronym) {
+
+        String retStr ;
+
+        //construct dummy "JudgementType" representing the input judgement string
+        CLICSJudgementType judgement = new CLICSJudgementType (judgementAcronym, "dummy", false, false) ;
+        
+        //try to get a "BIG5" acronym string corresponding to the input acronym judgement string
+        String big5AcronymString = judgement.getBig5EquivalentAcronym();
+
+        // the above method returns null if there is no matching Big 5 acronym string
+        if (big5AcronymString == null) {
+
+            // there's no Big5 for the input judgement string; see if it's "pending"
+            if (!judgementAcronym.toLowerCase().contains("pending")) {
+
+                // not pending; replace with message
+                retStr = "<NoBig5:" + judgementAcronym + ">";
+
+            } else {
+                // it does contain pending; keep the original judgement string
+                retStr = judgementAcronym;
             }
+            
+        } else {
+            //there was a CLICS Big5 acronym matching the input string; return the CLICS Big5 string
+            retStr = big5AcronymString;
         }
 
+        return retStr;
     }
+    
+
+
+
 
     public Log getLog() {
         if (log == null) {

--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -309,7 +309,7 @@ public class ShadowController {
             
             //get a Map of the judgements assigned by the remote CCS to each submission; note that this map uses "remote event id"
             // as the key and combines the submission ID with the Judgement acronym, separated by a colon, as the value
-            Map<String,String> remoteJudgementsMap = RemoteEventFeedMonitor.getRemoteJudgementsMap();
+            Map<String,String> remoteJudgementsMap = RemoteEventFeedMonitor.getRemoteJudgementsMapSnapshot();
             
             //convert the Map to one with submission ID as key and acronym (judgement) as value
             Map<String,String> remoteSubmissionsJudgementMap = new HashMap<String,String>();
@@ -322,12 +322,12 @@ public class ShadowController {
             
             //if specified, convert remote judgements to "Big 5"
             if (isConvertJudgementsToBig5()) {
-//                log.info("Converting remote judgements to CLICS 'Big 5'");
+                log.info("Converting remote judgements to CLICS 'Big 5'");
                 convertMapToBig5(remoteSubmissionsJudgementMap);
             }
             
-            //create a Map of the judgements assigned by PC2
-            Run[] runs = localContest.getRuns();
+            //get the runs (submissions) currently in PC2 (i.e. runs already obtained from the remote CCS and submitted to the PC2 server)
+            Run[] pc2Runs = localContest.getRuns();
             
 //            //debug loop
 //            for (Run run : runs) {
@@ -338,9 +338,9 @@ public class ShadowController {
 //                }
 //            }
             
-            //build a map of PC2 Shadow judgements, mapping submissionID to judgement acronym for each submission
+            //build a map of PC2 run judgements, mapping submissionID to judgement acronym for each submission
             Map<String,String> pc2JudgementsMap = new HashMap<String,String>();
-            for (Run run : runs) {
+            for (Run run : pc2Runs) {
                 
                 //avoid any "null" runs which might be returned in the RunList
                 if (run != null) {
@@ -416,7 +416,7 @@ public class ShadowController {
 
             //if specified, convert PC2 judgements to "Big 5"
             if (isConvertJudgementsToBig5()) {
-//                log.info("Converting PC2 judgements to 'CLICS Big 5'");
+                log.info("Converting PC2 judgements to 'CLICS Big 5'");
                 convertMapToBig5(pc2JudgementsMap);
             }
             
@@ -442,7 +442,7 @@ public class ShadowController {
             for (String submissionID : remoteKeys) {
                 
                 //get the run corresponding to the current submissionID
-                Run run = getRun(runs,submissionID);
+                Run run = getRun(pc2Runs,submissionID);
                 
                 //get the team/problem/language info corresponding to the run
                 teamID = new Integer(run.getSubmitter().getClientNumber()).toString();
@@ -471,7 +471,7 @@ public class ShadowController {
                 if (!remoteSubmissionsJudgementMap.containsKey(submissionID)) {
                     
                     //get the run corresponding to the current submissionID
-                    Run run = getRun(runs,submissionID);
+                    Run run = getRun(pc2Runs,submissionID);
                                        
 //                    teamID = run.getSubmitter().toString();
 //                    problemID = run.getProblemId().toString();

--- a/src/edu/csus/ecs/pc2/ui/ShadowComparePane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowComparePane.java
@@ -139,9 +139,11 @@ public class ShadowComparePane extends JPanePlugin {
                 if ("N".equalsIgnoreCase(matches))
                     c.setBackground(new Color(255, 153, 153));
 
-                // override color with yellow if PC2 judgement is pending
+                // override color with yellow if either PC2 or Remote judgement is pending
                 String pc2Judgement = (String) getModel().getValueAt(modelRow, 4);
-                if (pc2Judgement != null && pc2Judgement.toLowerCase().contains("pending")) {
+                String remoteJudgement = (String) getModel().getValueAt(modelRow, 5);
+                if ( (pc2Judgement != null && pc2Judgement.toLowerCase().contains("pending")) || 
+                     (remoteJudgement != null && remoteJudgement.toLowerCase().contains("pending"))) {
                     c.setBackground(new Color(255, 255, 153));
                 }
 
@@ -200,7 +202,9 @@ public class ShadowComparePane extends JPanePlugin {
             }
             data[row][6] = "---";
             if (data[row][4]!=null && data[row][5]!=null) {
-                if (!((String)data[row][4]).toLowerCase().contains("pending")) {
+                if (!((String)data[row][4]).toLowerCase().contains("pending") &&
+                    !((String)data[row][5]).toLowerCase().contains("pending") ) {
+                    
                     data[row][6] = ((String) data[row][4]).equalsIgnoreCase((String) data[row][5]) ? "Y" : "N";
                 }
             }

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareSummaryPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareSummaryPane.java
@@ -88,12 +88,14 @@ public class ShadowCompareSummaryPane extends JPanel {
 
                 String pc2Judgement = currentJudgementMap.get(submissionID).getShadowJudgementPair().getPc2Judgement();
                 String remoteJudgement = currentJudgementMap.get(submissionID).getShadowJudgementPair().getRemoteCCSJudgement();
-                if (pc2Judgement != null && remoteJudgement != null && (pc2Judgement.equalsIgnoreCase(remoteJudgement))) {
+                if (pc2Judgement != null && remoteJudgement != null && 
+                        !(pc2Judgement.contains("pending")) && !(remoteJudgement.contains("pending")) &&
+                         (pc2Judgement.equalsIgnoreCase(remoteJudgement))) {
                     match++;
                 } else {
-                    //it's not a match; separate out "pendings" and ones for which no remote judgement has yet been received
-                    if ( (pc2Judgement!=null && pc2Judgement.contains("pending")) 
-                            || (remoteJudgement==null || remoteJudgement.equals(""))) {
+                    //it's not a match; separate out "pendings"
+                    if (   (pc2Judgement!=null && pc2Judgement.contains("pending")) ||
+                           (remoteJudgement!=null && remoteJudgement.contains("pending")) ) {
                         pending++;
                     } else {
                         //it can't be counted "pending" either by virtue of the PC2 status or the Remote status; count as "noMatch"

--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -171,7 +171,11 @@ public class ShadowControlPane extends JPanePlugin {
             startButton.setToolTipText("Start shadowing operations on the specified remote CCS");
             startButton.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    startShadowing();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        public void run() {
+                            startShadowing();
+                        }
+                    });
                 }
             });
         }
@@ -294,7 +298,11 @@ public class ShadowControlPane extends JPanePlugin {
             stopButton.setToolTipText("Stop shadowing operations");
             stopButton.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    stopShadowing();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        public void run() {
+                            stopShadowing();
+                        }
+                    });
                 }
             });
         }
@@ -581,27 +589,41 @@ public class ShadowControlPane extends JPanePlugin {
 
     }
 
+    /**
+     * Displays a new @link {@link ShadowCompareFrame} containing a {@link ShadowComparePane} with "Refresh" and "Save as .csv" buttons.
+     * The ShadowComparePane contains a scrollable table of rows where each row compares one remote CCS submission with the corresponding
+     * PC2 submission.
+     * 
+     * @return a "Compare" JButton with an ActionListener that does the above.  The operations of the ActionListener are spun off to the
+     *          AWT Event Queue thread using {@link SwingUtilities#invokeLater(Runnable)}.
+     */
     private JButton getCompareButton() {
         if (compareButton == null) {
         	compareButton = new JButton("Compare");
         	compareButton.setMnemonic(KeyEvent.VK_C);
         	compareButton.setToolTipText("Display comparison results");
         	compareButton.addActionListener(new java.awt.event.ActionListener() {
+        	    
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    if (shadowController==null) {
-                        showErrorMessage("No shadow controller available; cannot show comparison", "Missing Controller"); 
-                    } else {
-                        JFrame shadowCompareFrame = new ShadowCompareFrame(shadowController);
-                        shadowCompareFrame.setLocationRelativeTo(null); // centers frame
-                        shadowCompareFrame.setSize(600,700);
-                        shadowCompareFrame.setTitle("Shadow Comparison");
-                        shadowCompareFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-                        shadowCompareFrame.setVisible(true);
-                    }
-                    
-                }
-            });
 
+                    SwingUtilities.invokeLater(new Runnable() {
+                        
+                        public void run() {
+
+                            if (shadowController==null) {
+                                showErrorMessage("No shadow controller available; cannot show comparison", "Missing Controller"); 
+                            } else {
+                                JFrame shadowCompareFrame = new ShadowCompareFrame(shadowController);
+                                shadowCompareFrame.setLocationRelativeTo(null); // centers frame
+                                shadowCompareFrame.setSize(600,700);
+                                shadowCompareFrame.setTitle("Shadow Comparison");
+                                shadowCompareFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                                shadowCompareFrame.setVisible(true);
+                            }
+                        }
+                    });
+                };
+        	});
         }
         return compareButton;
     }


### PR DESCRIPTION
### Description of what the PR does
Restructures the handling of remote CCS events in `RemoteEventFeedMonitor` and `ShadowController` (plus related classes) so that the situations which were causing the NPEs no longer exist.

Specifically, avoids building maps which have null entries, insures that iterators on maps used by the ShadowController operate on copies, and adds synchronization around access to maps where needed.  Also introduces a brief `sleep()` in the `RemoteEventFeedMonitor` event-processing loop to insure this thread does not starve the AWT thread (see Issue #267 for details).

### Issue which the PR fixes
Fixes #259 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10, Eclipse 2019-12 with Java 1.8.0_201

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

- Download the code for the PR
- Start a PC2 server configured with the NADC21 contest, including shadowing the remote CCS (Kattis) at `https://nadc21.kattis.com/clics-api/contests/nadc21`.  Insure there is an EF client account defined in the server.
- Start an EF client using the PR code.
- Select the `Shadow Mode` tab on the EF client
- Press the `Test Connection` button, insure that the connection to the remote CCS works.
- Press the `Start Shadowing` button.
- Press the `Compare` button to display the `Shadow Compare` pane.
- Repeatedly press the `Refresh` button on the `Shadow Compare` pane.
- Verify that no `NullPointException`s appear on the EF client console.

Previously, it only took a few presses of `Refresh` to generate an NPE; now, there should not be any NPEs.
