### PR TITLE
i279: fix unit test failure

### DIFF
--- a/test/edu/csus/ecs/pc2/services/core/ScoreboardJsonTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/ScoreboardJsonTest.java
@@ -134,7 +134,7 @@ public class ScoreboardJsonTest extends AbstractTestCase {
         /**
          * pc2 Standings XML for NADC Practice 2.
          */
-        String xmlFilename = "testdata\\ScoreboardJSONTest\\testNADC21Prac2EF\\nadcPractice-event-feed.xml";
+        String xmlFilename = "testdata/ScoreboardJSONTest/testNADC21Prac2EF/nadcPractice-event-feed.xml";
 
         ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(new File(xmlFilename));
 


### PR DESCRIPTION
### Description of what the PR does

Fixes java.io.FileNotFoundException under Unix so build will complete unit tests without error.
Specific fix : change \ in unit test filename to /

### Issue which the PR fixes

#279 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows with target of Unix

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

merge this change into develop branch to trigger new build
and unit tests.