### PR TITLE
i279: fix filename case so it matches repo testdata file name.

### DIFF
--- a/test/edu/csus/ecs/pc2/services/core/ScoreboardJsonTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/ScoreboardJsonTest.java
@@ -134,7 +134,7 @@ public class ScoreboardJsonTest extends AbstractTestCase {
         /**
          * pc2 Standings XML for NADC Practice 2.
          */
-        String xmlFilename = "testdata/ScoreboardJSONTest/testNADC21Prac2EF/nadcPractice-event-feed.xml";
+        String xmlFilename = "testdata/ScoreboardJsonTest/testNADC21Prac2EF/nadcPractice-event-feed.xml";
 
         ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(new File(xmlFilename));
 


### PR DESCRIPTION
### Description of what the PR does
  Changes the case of the filename string in the `ScoreboardJsonTest` JUnit so it matches the case of the test data filename in the repository which the JUnit is attempting to open/use.

### Issue which the PR fixes
Fixes #279 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10, but intended to fix a Unix file-name sensitivity problem on GitLab.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
  Approve the PR, merge, and go to GitLab (https://gitlab.com/pc2ccs/pc2v9/-/pipelines) and verify the build which results from the merge is successful.