### PR TITLE
I286 shadow loses submission due to socket timeout exception

### DIFF
--- a/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
@@ -99,7 +99,7 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
     protected  HttpURLConnection createConnection(URL url2) throws IOException {
         try {
             HttpURLConnection conn = HTTPSSecurity.createConnection(url2, login, password);
-            conn.setReadTimeout(60000);
+            conn.setReadTimeout(60000); //note: it seems VERY unlikely this works; see https://github.com/pc2ccs/pc2v9/issues/286
             return conn;
         } catch (IOException e) {
             throw e;

--- a/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
@@ -98,7 +98,9 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
     
     protected  HttpURLConnection createConnection(URL url2) throws IOException {
         try {
-            return HTTPSSecurity.createConnection(url2, login, password);
+            HttpURLConnection conn = HTTPSSecurity.createConnection(url2, login, password);
+            conn.setReadTimeout(60000);
+            return conn;
         } catch (IOException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
### Description of what the PR does
Fixes the issue where the shadow was occasionally losing submitted runs.  Specifically, adds a try/catch with a "retry" loop when a `SocketTimeoutException` occurs while fetching submission files from the remote CCS; failure to catch this exception and retry the operation was what was causing the shadow to lose submissions.

### Issue which the PR fixes
Fixes #286 

### Environment in which the PR was developed:
Windows 10, Eclipse 2019-12 with Java 1.8.0_201.

### Precise steps for _testing_ the PR:
- Start a PC2 server loaded with the NAC 21 CDP (available as noted in Issue #286).
- Start a PC2 Admin; use the Admin to:
  - Edit account "Feeder1" by adding the "Edit a Run" permission (NOT the "Edit Runs" permission; see Issue #274).
  - Edit the display name for team 6529 (last four digits); add the word "Okanagan" to the end of the team name
  - Edit the display name for team 6513; add the word "Scarborough" to the end of the team name.
    - (Alternatively, edit the teams.tsv file in the CDP and fix these two team names)
  -  Start the contest
- Start several AutoJudges (there are over 700 runs in the contest; the more AJ's the faster the test will complete)
- Start an Event Feeder client; log in as "feeder1".
- Select "Shadow Mode", then click "Start Shadowing".  (If you add the `--debug` flag when starting the EF client, you'll see a bunch of debug output; otherwise, you'll have to wait a while, with no indication that anything is happening, for the shadow to skip over all the garbage output by the Kattis event feed...)
- On the Admin, select "Run Contest" and then "Runs".   Eventually, some runs should start showing up (because the shadow gets them from Kattis and submits them to PC2).
- On the Shadow, click "Compare Runs"; hit the "Refresh" button periodically until all runs have been judged and there are no more Pending Runs listed.
- Sort the Shadow Compare Runs grid on the "Match?" column, select all non-matching runs, and click "Resolve Selected".  This will update all runs in PC2 to match the corresponding Kattis judgements.
- Click "Compare Scoreboards" on the Shadow client.  If all runs have been properly received by PC2, the scoreboards should match completely (with the exception of the last six teams, which are "NAPC" teams instead of "NAC" teams; Kattis changed the names for those teams to the "empty string".
- Examine the Feeder1 log; verify that every occurrence of "Exception" is a "SocketTimeoutException", and that for every such exception there follows a log statement that fetching the submission files for that submission was retried and was successful.
- 