### PR TITLE
I288 admin set scoreboard display format

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -89,7 +89,6 @@ public class ContestInformation implements Serializable{
     /**
      * 
      * @author pc2@ecs.csus.edu
-     * @version $Id$
      */
     public enum TeamDisplayMask {
         /**
@@ -261,6 +260,9 @@ public class ContestInformation implements Serializable{
                 return false;
             }
             if (maxFileSize != contestInformation.getMaxFileSize()){
+                return false;
+            }
+            if (!teamScoreboardDisplayFormat.equals(contestInformation.getTeamScoreboardDisplayFormat())) {
                 return false;
             }
             if (! scoringProperties.equals(contestInformation.getScoringProperties())){

--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -7,11 +7,17 @@ import java.awt.Component;
 import java.awt.ComponentOrientation;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.Insets;
+import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.GregorianCalendar;
@@ -22,6 +28,8 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -33,6 +41,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
@@ -215,6 +224,16 @@ public class ContestInformationPane extends JPanePlugin {
     private JCheckBox allowMultipleTeamLoginsCheckbox;
 
     private Component rigidArea1;
+
+    private Component rigidArea2;
+
+    private JPanel teamScoreboardDisplayFormatPane;
+
+    private JTextField teamScoreboardDisplayFormatTextfield;
+
+    private JLabel teamScoreboardDisplayFormatLabel;
+
+    private JLabel teamDisplayFormatButton;
     
 //    private JTextField textfieldPrimaryCCSURL;
 //
@@ -518,8 +537,8 @@ public class ContestInformationPane extends JPanePlugin {
         if (teamSettingsPane == null ) {
             
             teamSettingsPane = new JPanel();
-            teamSettingsPane.setMaximumSize(new Dimension(500, 100));
-            teamSettingsPane.setPreferredSize(new Dimension(500,100));
+            teamSettingsPane.setMaximumSize(new Dimension(800, 120));
+            teamSettingsPane.setPreferredSize(new Dimension(800,120));
             teamSettingsPane.setAlignmentX(LEFT_ALIGNMENT); 
 
             if (showPaneOutlines) {
@@ -541,8 +560,97 @@ public class ContestInformationPane extends JPanePlugin {
             teamSettingsPane.add(getMaxOutputSizeInKTextField(), null);
             teamSettingsPane.add(getRigidArea1());
             teamSettingsPane.add(getAllowMultipleTeamLoginsCheckbox(), null);
+            teamSettingsPane.add(getRigidArea2());
+            teamSettingsPane.add(getTeamScoreboardDisplayFormatPane(), null);
         }
         return teamSettingsPane;
+    }
+
+    private JPanel getTeamScoreboardDisplayFormatPane() {
+
+        if (teamScoreboardDisplayFormatPane==null) {
+            teamScoreboardDisplayFormatPane = new JPanel();
+            
+            //contents of the pane:
+            
+            teamScoreboardDisplayFormatPane.add(getTeamScoreboardDisplayFormatLabel());
+            teamScoreboardDisplayFormatPane.add(getTeamScoreboardDisplayFormatTextfield());
+            teamScoreboardDisplayFormatPane.add(getTeamScoreboardDisplayFormatWhatsThisButton());
+        }
+        return teamScoreboardDisplayFormatPane;
+    }
+
+    private JLabel getTeamScoreboardDisplayFormatWhatsThisButton() {
+        
+            if (teamDisplayFormatButton == null) {
+                Icon questionIcon = UIManager.getIcon("OptionPane.questionIcon");
+                if (questionIcon == null || !(questionIcon instanceof ImageIcon)) {
+                    // the current PLAF doesn't have an OptionPane.questionIcon that's an ImageIcon
+                    teamDisplayFormatButton = new JLabel("<What's This?>");
+                    teamDisplayFormatButton.setForeground(Color.blue);
+                } else {
+                    Image image = ((ImageIcon) questionIcon).getImage();
+                    teamDisplayFormatButton = new JLabel(new ImageIcon(getScaledImage(image, 20, 20)));
+                }
+
+                teamDisplayFormatButton.setToolTipText("What's This? (click for additional information)");
+                teamDisplayFormatButton.addMouseListener(new MouseAdapter() {
+                    @Override
+                    public void mousePressed(MouseEvent e) {
+                        JOptionPane.showMessageDialog(null, displayFormatWhatsThisMessage, "About Team Scoreboard Display Format Strings", JOptionPane.INFORMATION_MESSAGE, null);
+                    }
+                });
+                teamDisplayFormatButton.setBorder(new EmptyBorder(0, 15, 0, 0));
+            }
+            return teamDisplayFormatButton;
+        }
+
+    // the string which will be displayed when the "What's This" icon in the Team Settings panel is clicked
+    private String displayFormatWhatsThisMessage = //
+            "\nThe Team Scoreboard Display Format field allows you to specify a string which defines the format in which team names " //
+            + "will be displayed on the PC^2 Scoreboard." //
+
+            + "\n\nThe format string is a pattern which (typically) contains \"substitution variables\", identified by substrings starting with \"{:\"" //
+            + " and ending with \"}\" (for example, {:teamname} )." //
+            + "\nPC^2 automatically replaces substitution variables with the corresponding value for each team" //
+            + " (for example, the substitution variable {:teamname} "  //
+            + "\ngets replaced on the scoreboard with each team's name as defined in the PC^2 Server)." //
+            + "\n\nLiteral characters (i.e., anything NOT part of a substituion variable) are displayed exactly as written in the format string." //
+
+            + "\n\nRecognized substitution variables include:" //
+            + "\n    {:teamname}        -- the name of the team (for example, \"Hot Coders\")" //
+            + "\n    {:teamloginname}   -- the account name which the team uses to login to PC^2 (e.g., \"team102\")" //
+            + "\n    {:clientnumber}    -- the PC^2 client (team) number for the team (e.g., \"102\")" //
+            + "\n    {:shortschoolname} -- the short name of the team's school (e.g., \"CSUS\" or \"UCB\")" //
+            + "\n    {:longschoolname}  -- the long name of the team's school (e.g., \"California State University, Sacramento\"" //
+            + "\n    {:groupname}       -- the name of the group (if any) to which the team is assigned (e.g., \"Upper Division\" or \"Northern Site\")" //
+            + "\n    {:groupid}         -- the id number of the group (if any) to which the team is assigned (e.g., \"1\" or \"201\")" //
+            + "\n    {:sitenumber}      -- the PC^2 site number (in a multi-site contest) to which the team logs in (e.g., \"1\" or \"5\")" //
+            + "\n    {:countrycode}     -- the ISO Country Code associated with the team (e.g. \"CAN\" or \"USA\")" //
+            + "\n    {:externalid}      -- the ICPC CMS id number (if any) associated with the team (e.g., \"309407\")" //
+            
+            + "\n\nSo for example a display format string like \"{:teamname} ({:shortschoolname}) might display the following on the scoreboard:" //
+            + "\n    Hot Coders (CSUS) " //
+            + "\n(Notice the addition of the literal parentheses around the short school name.)" //
+            
+            + "\n\nSubstitution values depend on the corresponding data having been loaded into the PC^2 Server; if there is no value defined for a" //
+            + "\nspecified substitution string then the substitution string itself appears in the result."
+
+            + "\n\n"; //
+
+    private JTextField getTeamScoreboardDisplayFormatTextfield() {
+        if (teamScoreboardDisplayFormatTextfield==null) {
+            teamScoreboardDisplayFormatTextfield = new JTextField("Developer note: replace with current setting",30);
+            
+        }
+        return teamScoreboardDisplayFormatTextfield;
+    }
+
+    private Component getTeamScoreboardDisplayFormatLabel() {
+        if (teamScoreboardDisplayFormatLabel==null) {
+            teamScoreboardDisplayFormatLabel = new JLabel("Team Scoreboard Display Format: ");
+        }
+        return teamScoreboardDisplayFormatLabel;
     }
 
     private JLabel getMaxOutputSizeLabel() {
@@ -1416,6 +1524,17 @@ public class ContestInformationPane extends JPanePlugin {
         return runSubmissionInterfaceCommandTextField;
     }
 
+    private Image getScaledImage(Image srcImg, int w, int h) {
+        BufferedImage resizedImg = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = resizedImg.createGraphics();
+
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g2.drawImage(srcImg, 0, 0, w, h, null);
+        g2.dispose();
+
+        return resizedImg;
+    }
+
     private Component getHorizontalStrut_2() {
         if (horizontalStrut_2 == null) {
         	horizontalStrut_2 = Box.createHorizontalStrut(20);
@@ -1460,5 +1579,11 @@ public class ContestInformationPane extends JPanePlugin {
             rigidArea1 = Box.createRigidArea(new Dimension(20,20));
         }
         return rigidArea1;
+    }
+    private Component getRigidArea2( ) {
+        if (rigidArea2==null) {
+            rigidArea2 = Box.createRigidArea(new Dimension(20,20));
+        }
+        return rigidArea2;
     }
 }

--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -233,7 +233,7 @@ public class ContestInformationPane extends JPanePlugin {
 
     private JLabel teamScoreboardDisplayFormatLabel;
 
-    private JLabel teamDisplayFormatButton;
+    private JLabel teamDisplayFormatWhatsThisButton;
     
 //    private JTextField textfieldPrimaryCCSURL;
 //
@@ -582,27 +582,27 @@ public class ContestInformationPane extends JPanePlugin {
 
     private JLabel getTeamScoreboardDisplayFormatWhatsThisButton() {
         
-            if (teamDisplayFormatButton == null) {
+            if (teamDisplayFormatWhatsThisButton == null) {
                 Icon questionIcon = UIManager.getIcon("OptionPane.questionIcon");
                 if (questionIcon == null || !(questionIcon instanceof ImageIcon)) {
                     // the current PLAF doesn't have an OptionPane.questionIcon that's an ImageIcon
-                    teamDisplayFormatButton = new JLabel("<What's This?>");
-                    teamDisplayFormatButton.setForeground(Color.blue);
+                    teamDisplayFormatWhatsThisButton = new JLabel("<What's This?>");
+                    teamDisplayFormatWhatsThisButton.setForeground(Color.blue);
                 } else {
                     Image image = ((ImageIcon) questionIcon).getImage();
-                    teamDisplayFormatButton = new JLabel(new ImageIcon(getScaledImage(image, 20, 20)));
+                    teamDisplayFormatWhatsThisButton = new JLabel(new ImageIcon(getScaledImage(image, 20, 20)));
                 }
 
-                teamDisplayFormatButton.setToolTipText("What's This? (click for additional information)");
-                teamDisplayFormatButton.addMouseListener(new MouseAdapter() {
+                teamDisplayFormatWhatsThisButton.setToolTipText("What's This? (click for additional information)");
+                teamDisplayFormatWhatsThisButton.addMouseListener(new MouseAdapter() {
                     @Override
                     public void mousePressed(MouseEvent e) {
                         JOptionPane.showMessageDialog(null, displayFormatWhatsThisMessage, "About Team Scoreboard Display Format Strings", JOptionPane.INFORMATION_MESSAGE, null);
                     }
                 });
-                teamDisplayFormatButton.setBorder(new EmptyBorder(0, 15, 0, 0));
+                teamDisplayFormatWhatsThisButton.setBorder(new EmptyBorder(0, 15, 0, 0));
             }
-            return teamDisplayFormatButton;
+            return teamDisplayFormatWhatsThisButton;
         }
 
     // the string which will be displayed when the "What's This" icon in the Team Settings panel is clicked
@@ -618,16 +618,16 @@ public class ContestInformationPane extends JPanePlugin {
             + "\n\nLiteral characters (i.e., anything NOT part of a substituion variable) are displayed exactly as written in the format string." //
 
             + "\n\nRecognized substitution variables include:" //
-            + "\n    {:teamname}        -- the name of the team (for example, \"Hot Coders\")" //
-            + "\n    {:teamloginname}   -- the account name which the team uses to login to PC^2 (e.g., \"team102\")" //
-            + "\n    {:clientnumber}    -- the PC^2 client (team) number for the team (e.g., \"102\")" //
-            + "\n    {:shortschoolname} -- the short name of the team's school (e.g., \"CSUS\" or \"UCB\")" //
-            + "\n    {:longschoolname}  -- the long name of the team's school (e.g., \"California State University, Sacramento\"" //
-            + "\n    {:groupname}       -- the name of the group (if any) to which the team is assigned (e.g., \"Upper Division\" or \"Northern Site\")" //
-            + "\n    {:groupid}         -- the id number of the group (if any) to which the team is assigned (e.g., \"1\" or \"201\")" //
-            + "\n    {:sitenumber}      -- the PC^2 site number (in a multi-site contest) to which the team logs in (e.g., \"1\" or \"5\")" //
-            + "\n    {:countrycode}     -- the ISO Country Code associated with the team (e.g. \"CAN\" or \"USA\")" //
-            + "\n    {:externalid}      -- the ICPC CMS id number (if any) associated with the team (e.g., \"309407\")" //
+            + "\n    {:teamname}                -- the name of the team (for example, \"Hot Coders\")" //
+            + "\n    {:teamloginname}       -- the account name which the team uses to login to PC^2 (e.g., \"team102\")" //
+            + "\n    {:clientnumber}           -- the PC^2 client (team) number for the team (e.g., \"102\")" //
+            + "\n    {:shortschoolname}  -- the short name of the team's school (e.g., \"CSUS\" or \"UCB\")" //
+            + "\n    {:longschoolname}    -- the long name of the team's school (e.g., \"California State University, Sacramento\"" //
+            + "\n    {:groupname}             -- the name of the group (if any) to which the team is assigned (e.g., \"Upper Division\" or \"Northern Site\")" //
+            + "\n    {:groupid}                     -- the id number of the group (if any) to which the team is assigned (e.g., \"1\" or \"201\")" //
+            + "\n    {:sitenumber}             -- the PC^2 site number (in a multi-site contest) to which the team logs in (e.g., \"1\" or \"5\")" //
+            + "\n    {:countrycode}           -- the ISO Country Code associated with the team (e.g. \"CAN\" or \"USA\")" //
+            + "\n    {:externalid}                -- the ICPC CMS id number (if any) associated with the team (e.g., \"309407\")" //
             
             + "\n\nSo for example a display format string like \"{:teamname} ({:shortschoolname}) might display the following on the scoreboard:" //
             + "\n    Hot Coders (CSUS) " //
@@ -635,13 +635,19 @@ public class ContestInformationPane extends JPanePlugin {
             
             + "\n\nSubstitution values depend on the corresponding data having been loaded into the PC^2 Server; if there is no value defined for a" //
             + "\nspecified substitution string then the substitution string itself appears in the result."
+            + " If the defined value is null or empty then an empty string appears in the result."
 
             + "\n\n"; //
 
     private JTextField getTeamScoreboardDisplayFormatTextfield() {
         if (teamScoreboardDisplayFormatTextfield==null) {
-            teamScoreboardDisplayFormatTextfield = new JTextField("Developer note: replace with current setting",30);
+            teamScoreboardDisplayFormatTextfield = new JTextField("Undefined",30);
             
+            teamScoreboardDisplayFormatTextfield.addKeyListener(new java.awt.event.KeyAdapter() {
+                public void keyReleased(java.awt.event.KeyEvent e) {
+                    enableUpdateButton();
+                }
+            });
         }
         return teamScoreboardDisplayFormatTextfield;
     }
@@ -965,6 +971,7 @@ public class ContestInformationPane extends JPanePlugin {
         long maximumFileSize = Long.parseLong(maxFileSizeString);
         newContestInformation.setMaxFileSize(maximumFileSize * 1000);
         newContestInformation.setAllowMultipleLoginsPerTeam(getAllowMultipleTeamLoginsCheckbox().isSelected());
+        newContestInformation.setTeamScoreboardDisplayFormat(getTeamScoreboardDisplayFormatTextfield().getText());
 
         //fill in values already saved, if any
         if (savedContestInformation != null) {
@@ -982,7 +989,6 @@ public class ContestInformationPane extends JPanePlugin {
             
             newContestInformation.setLastRunNumberSubmitted(savedContestInformation.getLastRunNumberSubmitted());
             newContestInformation.setAutoStartContest(savedContestInformation.isAutoStartContest());
-            newContestInformation.setTeamScoreboardDisplayFormat(savedContestInformation.getTeamScoreboardDisplayFormat());
         }
 
         newContestInformation.setScoringProperties(changedScoringProperties);
@@ -1043,6 +1049,7 @@ public class ContestInformationPane extends JPanePlugin {
                 
                 getMaxOutputSizeInKTextField().setText((contestInformation.getMaxFileSize() / 1000) + "");
                 getAllowMultipleTeamLoginsCheckbox().setSelected(contestInformation.isAllowMultipleLoginsPerTeam());
+                getTeamScoreboardDisplayFormatTextfield().setText(contestInformation.getTeamScoreboardDisplayFormat());
                 getContestFreezeLengthtextField().setText(contestInformation.getFreezeTime());
                 
                 getCcsTestModeCheckbox().setSelected(contestInformation.isCcsTestMode());


### PR DESCRIPTION
### Description of what the PR does
Adds to the Admin "Settings" tab the ability to interactively alter the currently-defined "Team Scoreboard Display Format" string while a contest is under way.

### Issue which the PR fixes
Fixes #288 

### Environment in which the PR was developed:
Windows 10, Eclipse 2019-12, Java 1.8_201

### Precise steps for _testing_ the PR

#### Verify PR for a contest which already has a defined Team Scoreboard Display Format:

- Start a clean Server using **--load tenprobs**.  (The "tenprobs" contest includes a `contest.yaml` file which has a predefined Team Scoreboard Display Format string.)
- Start an Admin; select the `Settings` tab.
- Verify that the `Team Settings` panel on the `Settings` tab displays the TeamScoreboardDisplayFormat string defined in the `contest.yaml` file (which as of this writing is `Team {:clientnumber}  {:teamname} and login: {:teamloginname} {:groupid}:{:groupname} long: {:longschoolname} short: {:shortschoolname} cms id: {:externalid}`).
- Click the "What's This" icon (normally, a QuestionMark) next to the Team Scoreboard Display Format textfield; verify that it displays an information dialog explaining the Team Scoreboard Display Format string usage.
- Select the Admin `Run Contest` tab, then select the `Standings` tab.  Verify that the "Name" column displays team names in the format described by the Team Scoreboard Display Format string.
- On the `Configure Contest->Settings` tab, _change_ the Team Scoreboard Display Format string.  (For example, eliminate one or more of the existing substitution variables;  add some new literal characters to the string; etc.)
- Click the `Update` button to save the new settings.
- Go back to the `Run Contest->Standings` tab and verify that the Team Names now display according to the changes made on the `Settings` tab.
- Exit the Admin, then restart the Admin.
- Verify that the changes made to the Team Scoreboard Display Format string (on the `Settings` tab) were retained on restarting.
- Verify that the `Standings` tab shows the Team Names as defined by the current Team Scoreboard Display Format string.
- Exit the Admin, then exit the Server.
- Restart the server, _without doing a pc2reset_.
- Restart the Admin.
- Verify that the changes made to the Team Scoreboard Display Format string were retained in the `Settings` tab on restarting.
- Verify that the `Standings` tab shows the Team Names as defined by the current Team Scoreboard Display Format string.

#### Verify PR for a contest which has no predefined Team Scoreboard Display Format:

- Start a clean Server using **--load sumitHello** (which, at least as of this writing, has no Team Scoreboard Display Format string defined in its `contest.yaml`).
- Start an Admin; select the `Settings` tab.
- Verify that the Team Scoreboard Display Format string in the `Team Settings` panel has the default Team Scoreboard Display Format string, which as of this writing is `{:teamname}`.
- Re-execute all of the above tests (verify the `Run Contest->Standings` display matches the current format; _change_ the format and verify the Standings tab changes correctly; restart the Admin and verify changes are retained; restart the server and admin and verify changes are retained.)

