### PR TITLE
i274 Correct bad EDIT_PERMISSIONS description.

### DIFF
--- a/src/edu/csus/ecs/pc2/core/security/Permission.java
+++ b/src/edu/csus/ecs/pc2/core/security/Permission.java
@@ -338,7 +338,6 @@ public class Permission implements Serializable {
         hash.put(Type.ADD_ACCOUNT, "Add Accounts");
         hash.put(Type.EDIT_ACCOUNT, "Edit Accounts");
         hash.put(Type.EDIT_PERMISSIONS, "Edit Permissions");
-        hash.put(Type.EDIT_PERMISSIONS, "Edit Runs");
         hash.put(Type.EXECUTE_RUN, "Execute but not judge runs");
         hash.put(Type.JUDGE_RUN, "Judge runs");
         hash.put(Type.LOGIN, "Login");


### PR DESCRIPTION
### Description of what the PR does
Removes the bad line of code in class `Permission` which incorrectly overwrote the description of the "EDIT_PERMISSION" permission, causing its name to be displayed as "Edit Runs".  See #274 for a detailed description of the issue.

### Issue which the PR fixes
Fixes #274

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10, Eclipse 2019-12, Java 1.8_201.

### Precise steps for _testing_ the PR

Use "Method 2" as described in Issue #274:

- Start a PC2 server using **--load sumithello**  (or any test contest)
- Start a PC2 Admin.  On the Admin:
  - If there is not already an Event Feeder account in the contest, add one EF account.
  - Select the EF account and click "Edit".
  - Verify that the list of permissions in the "Permissions/Abilities" list DOES include a checkbox for "Edit Permissions", DOES include a checkbox for "Edit a run", and does NOT include a checkbox for "Edit Runs"  (it was this last entry which erroneously appeared in the list prior to this fix; see #274 for details).
  - Click "Close" to close the Edit dialog without making any changes.
- Start a PC2 Event Feed client.
- Hold down the control key and double-click on the main frame background of the EF client to invoke the "Developer Pane"; enter the Developer password.
- Select the "Check Permissions" tab, then click "Display Permissions".  This will display a list of all permissions assigned to the current client.
- Verify that the client does NOT have the "Edit a run" permission and also does NOT have the "Edit Permissions" permission, then click "OK".
- On the Admin, select the Event Feeder Account, then click "Edit".
- Check the "Edit a run" checkbox to add the "Edit a run" permission to the account; click "Update".
- On the EF client, again open the Developer Pane and select the "Check Permissions" tab and then click "Display Permissions".
- Verify that the client now has the "Edit a run" permission.
- Repeat the above for the "Edit Permissions" permission:  verify the client does NOT have this permission, then add the permission to the EF account, then verify that the client now has the permission.

### Additional Notes:
   This PR consists entirely of deleting a _single line_ of code from the `Permission` class.  The deleted line was the line which incorrectly overwrote the value which had been assigned in the permission-name hashtable for the EDIT_PERMISSIONS permission -- the second of the following two lines:
```
        hash.put(Type.EDIT_PERMISSIONS, "Edit Permissions");
        hash.put(Type.EDIT_PERMISSIONS, "Edit Runs");
```
Note that the code _already_ contains a line further down in the class which (correctly) assigns a name to the EDIT_RUN permission:
```
        hash.put(Type.EDIT_RUN, "Edit a run");
```
This line was not changed, so now the hashtable has just one entry for EDIT_PERMISSIONS and just one entry for EDIT_RUN.

