### PR TITLE
I 292 Insure all judgements on all sites

### DIFF
--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -3602,11 +3602,9 @@ public class PacketHandler {
     }
 
     /**
-     * Loads only the settings from the remote server into this server.
+     * Loads only the settings from the remote server into this server's model.
      * 
-     * Loads settings from other server, submissions, etc.  Sends
-     * out a login packet to any "new" servers which this site
-     * is not logged into. 
+     * Loads settings from other server, submissions, etc. into model.
      * 
      * @param packet
      * @param connectionHandlerID
@@ -3641,6 +3639,20 @@ public class PacketHandler {
         loader.addAllConnectionIdsToModel(contest, controller, packet);
 
         loader.addRemoteLoginsToModel(contest, controller, packet, remoteSiteNumber);
+        
+        loader.addJudgementsToModel(contest, controller, packet);
+
+        if (isServer()) {
+            try {
+                contest.storeConfiguration(controller.getLog());
+            } catch (Exception e) {
+                // huh
+                Exception ex = new Exception("Server " + contest.getClientId() + " problem storing config update  " + packet);
+                controller.getLog().log(Log.WARNING, ex.getMessage(), ex);
+            }
+        }
+        
+        controller.sendToJudgesAndOthers(packet, false);
         
         info("Done loading settings from remote site "+remoteSiteNumber);
     }

--- a/src/edu/csus/ecs/pc2/core/list/JudgementSortBySiteAcronymComparator.java
+++ b/src/edu/csus/ecs/pc2/core/list/JudgementSortBySiteAcronymComparator.java
@@ -26,7 +26,7 @@ public class JudgementSortBySiteAcronymComparator implements  Comparator<Judgeme
         } else if (jOne.getAcronym().equals(j2.getAcronym())) {
             return jOne.getDisplayName().compareTo(j2.getDisplayName());
         } else {
-            return jOne.getAcronym().compareTo(jOne.getAcronym());
+            return jOne.getAcronym().compareTo(j2.getAcronym());
         }
 
     }

--- a/src/edu/csus/ecs/pc2/core/list/JudgementSortBySiteAcronymComparator.java
+++ b/src/edu/csus/ecs/pc2/core/list/JudgementSortBySiteAcronymComparator.java
@@ -1,0 +1,34 @@
+package edu.csus.ecs.pc2.core.list;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import edu.csus.ecs.pc2.core.model.Judgement;
+
+/**
+ * Sort judgemens by site, acronym, judgement text.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ *
+ */
+public class JudgementSortBySiteAcronymComparator implements  Comparator<Judgement>, Serializable {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1424848798314592182L;
+
+    @Override
+    public int compare(Judgement jOne, Judgement j2) {
+
+        if (jOne.getSiteNumber() != j2.getSiteNumber()) {
+            return jOne.getSiteNumber() - j2.getSiteNumber();
+        } else if (jOne.getAcronym().equals(j2.getAcronym())) {
+            return jOne.getDisplayName().compareTo(j2.getDisplayName());
+        } else {
+            return jOne.getAcronym().compareTo(jOne.getAcronym());
+        }
+
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -736,6 +736,9 @@ public class InternalContest implements IInternalContest {
     }
 
     public void addJudgement(Judgement judgement) {
+        if (judgement.getSiteNumber() == 0) {
+            judgement.setSiteNumber(getSiteNumber());
+        }
         judgementDisplayList.add(judgement);
         judgementList.add(judgement);
         JudgementEvent judgementEvent = new JudgementEvent(JudgementEvent.Action.ADDED, judgement);

--- a/src/edu/csus/ecs/pc2/core/report/JudgementReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/JudgementReport.java
@@ -4,10 +4,14 @@ package edu.csus.ecs.pc2.core.report;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import edu.csus.ecs.pc2.VersionInfo;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.list.JudgementSortBySiteAcronymComparator;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -52,6 +56,7 @@ public class JudgementReport implements IReport {
             printWriter.print("  '" + judgement + "'");
             printWriter.print(" acronym=" + judgement.getAcronym());
             printWriter.print(" id=" + judgement.getElementId());
+            printWriter.print(" site=" + judgement.getSiteNumber());
             printWriter.println();
         }
         
@@ -65,8 +70,62 @@ public class JudgementReport implements IReport {
             printWriter.print("' ");
             printWriter.print(" acronym=" + judgement.getAcronym());
             printWriter.print(hiddenText+" id=" + judgement.getElementId());
+            printWriter.print(" site=" + judgement.getSiteNumber());
             printWriter.println();
         }
+        
+        
+        printWriter.println();
+        printWriter.println();
+        printWriter.println("     All Judgements for all sites, " + judgements.length + " Judgements");
+        printWriter.println();
+        
+        Arrays.sort(judgements, new JudgementSortBySiteAcronymComparator());
+        
+        int lastSite = -1;
+        for (Judgement judgement : judgements) {
+
+            if (lastSite != judgement.getSiteNumber()) {
+                printWriter.println();
+                // print # judgements per site
+                List<Judgement> judgementList = getSitesJudgements(judgements, judgement.getSiteNumber());
+                int judgementPerSiteCount = judgementList.size();
+                printWriter.println("-- Site " + judgement.getSiteNumber() + " has " + judgementPerSiteCount + " Judgements --");
+                lastSite = judgement.getSiteNumber();
+            }
+        
+            
+            String hiddenText = "";
+            if (!judgement.isActive()){
+                hiddenText = "[HIDDEN] ";
+            }
+            printWriter.print(" site=" + judgement.getSiteNumber());
+            printWriter.print("  '" + judgement );
+            printWriter.print("' ");
+            printWriter.print(" acronym=" + judgement.getAcronym());
+            printWriter.print(hiddenText+" id=" + judgement.getElementId());
+            printWriter.println();
+            
+        }
+    }
+
+    /**
+     * Return a list of all judgements assigned for a site number
+     * @param judgements
+     * @param siteNumber
+     * @return list of judgements with site number siteNumber.
+     */
+    private List<Judgement> getSitesJudgements(Judgement[] judgements, int siteNumber) {
+
+        List<Judgement> list = new ArrayList<Judgement>();
+
+        for (Judgement judgement : judgements) {
+            if (siteNumber == judgement.getSiteNumber()) {
+                list.add(judgement);
+            }
+        }
+
+        return list;
     }
 
     public void printHeader(PrintWriter printWriter) {

--- a/src/edu/csus/ecs/pc2/core/report/RunsReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/RunsReport.java
@@ -177,6 +177,7 @@ public class RunsReport implements IReport {
                     printWriter.println("Judgement is null for "+run);
                 }
                 ElementId elmentId = judgementRecord.getJudgementId();
+                Judgement judgement = contest.getJudgement(elmentId);
                 String judgementText = contest.getJudgement(elmentId).toString();
                 String validatorJudgementName = judgementRecord.getValidatorResultString();
                 if (judgementRecord.isUsedValidator() && validatorJudgementName != null) {
@@ -187,7 +188,7 @@ public class RunsReport implements IReport {
                 }
 
                 printWriter.print("     ");
-                printWriter.print(" '" + judgementText + "'");
+                printWriter.print(" '" + judgementText + "' site="+judgement.getSiteNumber());
                 printWriter.print(" by " + judgementRecord.getJudgerClientId().getName()+"/s"+judgementRecord.getJudgerClientId().getSiteNumber());
                 if (judgementRecord.isComputerJudgement()){
                     printWriter.print("/Computer");

--- a/src/edu/csus/ecs/pc2/ui/ReportPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ReportPane.java
@@ -486,9 +486,9 @@ public class ReportPane extends JPanePlugin {
             resumeTime = getContest().getContestTime().getResumeTime();
         }
         if (resumeTime == null) {
-            printWriter.print("  Contest date/time: never started");
+            printWriter.print("  Contest date/time: never started on site "+getContest().getSiteNumber());
         } else {
-            printWriter.print("  Contest date/time: " + resumeTime.getTime());
+            printWriter.print("  Contest date/time: " + resumeTime.getTime()+" on site "+getContest().getSiteNumber());
 
         }
 


### PR DESCRIPTION
### Description of what the PR does

PR changes server so every judgement from every server is on every server.

This only applies to contests with more than one site.

### Issue which the PR fixes

#292 - In a multiple sites contest all judgements may not be on all sites (NPE in Contest XML report)

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Java version 1.8.0_121
OS: Windows 10 10.0 (amd64)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Test 1 - prove all judgements are on all sites.
Start 3 sites (non-GUI).
   Start site 1 with samps\contests\problemflagtest CDP (creates 5 sites)
Run Judgements Report on each site.
Each report should show all judgements are on all sites.

Test 2 - test Contest XML
Can use Test 1 
Site 2: Add team and judge accounts  
Submit runs on site 1
Judge runs on site 2
Run Contest XML report - there should be no NPE.

Note: There are also a number of test case descriptions in the issue.