### PR TITLE
i298: added fix to ensure only one set of judgements presented

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
+++ b/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
@@ -1,14 +1,16 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
 
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.LogUtilities;
+import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ElementId;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -312,6 +314,49 @@ public final class JudgementUtilites {
         return list;
     }
     
+    /**
+     * Return a single set of judgements.
+     * 
+     * If there is more than one site connected, all judgements from all other sites are in the model. 
+     * If more than one site is defined, returns the site 1 judgements.
+     * 
+     * @return a list of judgements for the judges
+     */
+    public static List<Judgement> getSingleListofJudgements(IInternalContest contest) {
+        List<Judgement> list = new ArrayList<Judgement>();
+
+        Judgement[] judgements = contest.getJudgements();
+
+        /**
+         * Is a multi site contest?
+         */
+        boolean multiSiteContest = contest.getSites().length > 1;
+
+        for (Judgement judgement : judgements) {
+
+            if (multiSiteContest) {
+                if (judgement.getSiteNumber() == 1) {
+                    // only add judgements from site 1 if there is more than one site.
+                    list.add(judgement);
+                }
+            } else {
+                // add judgements from model (if not a multiSiteContest
+                list.add(judgement);
+            }
+        }
+
+        if (list.size() == 0) {
+            /**
+             * A catch all condition. If a rare condition occurs where there are no judgements added to the list, all all model's judgements.
+             * 
+             * This should never happen.
+             */
+            list.addAll(Arrays.asList(judgements));
+            StaticLog.getLog().log(Log.WARNING, "getSingleListofJudgements, note in multi site did not find judgements from site 1");
+        }
+
+        return list;
+    }
     
 
 }

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -596,8 +596,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             judgementId = run.getJudgementRecord().getJudgementId();
         }
 
-        for (Judgement judgement : getContest().getJudgements()) {
-
+        for (Judgement judgement : JudgementUtilites.getSingleListofJudgements(getContest())) {
             if (judgement.isActive()) {
                 getJudgementComboBox().addItem(judgement);
                 if (judgement.getElementId().equals(judgementId)) {

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitesTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.util.List;
@@ -320,6 +320,73 @@ public class JudgementUtilitesTest extends AbstractTestCase {
             run.addTestCase(runTestCaseResult);
         }
     }
-    
 
+    /**
+     * Test with sample contest/default judgements.
+     * 
+     * By default will use the judgements from the current site (site number 3)
+     * 
+     * @throws Exception
+     */
+    public void testgetSingleListofJudgements() throws Exception {
+
+        IInternalContest contest = sample.createStandardContest();
+        Judgement[] judgements = contest.getJudgements();
+        sample.createController(contest, true, false); // creates StaticLog instance
+
+        assertEquals("judgement count", 9, judgements.length);
+
+        List<Judgement> jList = JudgementUtilites.getSingleListofJudgements(contest);
+        assertEquals("judgement count", 9, jList.size());
+
+        assertEquals("judgement site number", 3, jList.get(0).getSiteNumber());
+        assertEquals("judgement ", "Yes.", jList.get(0).toString());
+        assertEquals("judgement ", "You have no clue", jList.get(4).toString());
+        assertEquals("judgement ", "Contact Staff - you have no hope", jList.get(jList.size() - 1).toString());
+
+    }
+
+    /**
+     * Test to ensure that all judgements found are on site 1.
+     * 
+     * When there are judgements from site 1, use those judgements.
+     * 
+     * @throws Exception
+     */
+    public void testgetSingleListofJudgementsWithSite1Judgements() throws Exception {
+
+        IInternalContest contest = sample.createStandardContest();
+        Judgement[] judgements = contest.getJudgements();
+        sample.createController(contest, true, false); // creates StaticLog instance
+
+        assertEquals("judgement count", 9, judgements.length);
+        assertEquals("site count", 3, contest.getSites().length);
+
+        addNewJudgements(1, contest, contest.getJudgements());
+
+        // Model now has 18 judgements, from site 3 and site 1
+        judgements = contest.getJudgements();
+        assertEquals("judgement count", 18, judgements.length);
+
+        List<Judgement> jList = JudgementUtilites.getSingleListofJudgements(contest);
+        assertEquals("judgement count", 9, jList.size());
+
+        assertEquals("judgement site number", 1, jList.get(0).getSiteNumber());
+        assertEquals("judgement ", "Yes.", jList.get(0).toString());
+        assertEquals("judgement ", "You have no clue", jList.get(4).toString());
+        assertEquals("judgement ", "Contact Staff - you have no hope", jList.get(jList.size() - 1).toString());
+
+        // ensure that each judgement is from site 1
+        for (Judgement judgement : jList) {
+            assertEquals("judgement site number", 1, judgement.getSiteNumber());
+        }
+    }
+
+    private void addNewJudgements(int siteNumber, IInternalContest contest, Judgement[] judgements) {
+        for (Judgement judgement : judgements) {
+            Judgement newJudgement = new Judgement(judgement.toString(), judgement.getAcronym());
+            newJudgement.setSiteNumber(siteNumber);
+            contest.addJudgement(newJudgement);
+        }
+    }
 }


### PR DESCRIPTION
### Description of what the PR does

When judging in multi site contest, only shows one set of judgements
(from site 1)

### Issue which the PR fixes

#298

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

works in all env.

Java version 1.8.0_121
OS: Windows 10 10.0 (amd64)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Test 1 - prove all judgements are on all sites.
Start 3 sites (non-GUI).
Start site 1 with samps\contests\problemflagtest CDP (creates 5 sites)
Start site 2
Start site 3 

- submit and judge a run 
Create 12 teams on site 3
Create 12 judges on site 3

Site 3 team 3 submit run for Sumit 2 problem
Site 3 judge 2 
  request run
  On Select Judgement
  Use Select Judgement pulldown
  Select the last judgement in the list
  test: ensure that there are only one set of judgements
  Judge the run

Run the Runs report
     test: for the judgement there should be a 'site=1', similar to below
     'No - Wrong Answer' site=1 by judge3/s3 at 1

Expected Results

One set of eight judgements shown to judge in Select Judgement pulldown (not 24 Judgements)

On Runs report for judged run show judgement is from site 1.

Actual Results

24 judgements judgements shown to judge in Select Judgement pulldown 

On Runs report for judged run may wil be from site 3

