### PR TITLE
i302: update core-js version in package.json to "~3.4.0".

### DIFF
--- a/projects/WTI-UI/package.json
+++ b/projects/WTI-UI/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~7.2.0",
     "@angular/platform-browser-dynamic": "~7.2.0",
     "@angular/router": "~7.2.0",
-    "core-js": "^2.5.4",
+    "core-js": "~3.4.0",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"


### PR DESCRIPTION
### Description of what the PR does
  Updates the version of core-js in WTI-UI/package.json from "^2.5.4" (which means 2.x.y where x is the highest minor release of  version 2) to "~3.4.0", which means 3.4.x where x is the highest patch number for version 3.4.  

### Issue which the PR fixes
It MAY fix issue #302; the only way to know is to merge the change and check GitLab.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.1

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Go to GitLab.com/pc2ccs and check the status of the latest build.
