### PR TITLE
detect 64-Bit based on the -version

### DIFF
--- a/bin/pc2server
+++ b/bin/pc2server
@@ -25,7 +25,7 @@ fi
 HEAPPARAM=$JAVA64BIT_HEAPSIZE
 JAVA32=0
 # if we are not running a 64bit java reduce to 1.6G
-java -Djdk.crypto.KeyAgreement.legacyKDF=true -d64 -version 2>&1 | grep -q "Error" && JAVA32=1
+java -version 2>&1 | grep -qi 64-bit || JAVA32=1
 # found a 32bit java
 if [ $JAVA32 = "1" ]; then
 # reduce the heap size


### PR DESCRIPTION
eg on MacOS it looks like:
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment Homebrew (build 17.0.1+1)
OpenJDK 64-Bit Server VM Homebrew (build 17.0.1+1, mixed mode, sharing)

with openjdk on Ubuntu 20.04 it looks like:
openjdk version "11.0.9.1" 2020-11-04
OpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.20.04)
OpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.20.04, mixed mode, sharing)

fixes #299

### Description of what the PR does
stop using the -d64 which is more supported in recent openjdk builds.

### Issue which the PR fixes

This fixes #299

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
This was tested on MacOS 12.1

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
run pc2server on MacOS or linux,  it should not error out or throw the 
WARNING: We detected a 32 bit java running on a 64 bit OS.
warning.