### PR TITLE
i314: update load messages, add confirm dialog

### DIFF
--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 /**
@@ -165,5 +165,10 @@ public final class Constants {
     
     public static final int INPUT_VALIDATOR_EXECUTION_ERROR_CODE = -39;
     
-    public static final String ACCOUNTS_LOAD_FILENAME = "accounts_load.tsv";   
+    public static final String ACCOUNTS_LOAD_FILENAME = "accounts_load.tsv";
+    
+    /**
+     * New line constant (OS specific).
+     */
+    public static final String NL = System.getProperty("line.separator");
 }

--- a/src/edu/csus/ecs/pc2/core/imports/LoadICPCTSVData.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadICPCTSVData.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.imports;
 
 import java.io.File;
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javax.swing.JOptionPane;
 
+import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.Group;
@@ -29,6 +30,8 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
 // $HeadURL$
 public class LoadICPCTSVData implements UIPlugin {
 
+    private static String NL = Constants.NL;
+    
     public static final String TEAMS2_TSV = "teams2.tsv";
 
     /**
@@ -112,8 +115,8 @@ public class LoadICPCTSVData implements UIPlugin {
 
             if (useConfirmGUI){
                 
-                String nl = System.getProperty("line.separator");
-                String message = "Add " + nl + accounts.length + " accounts and " + nl + groups.length + " groups?";
+                String NL = System.getProperty("line.separator");
+                String message = "Update/Add " + NL + accounts.length + " team accounts and " + NL + groups.length + " groups?";
 
                 result = FrameUtilities.yesNoCancelDialog(null, message, "Load TSV files");
             }
@@ -165,7 +168,13 @@ public class LoadICPCTSVData implements UIPlugin {
                 info("Load from file " + groupsFilename);
                 info("Load from file " + teamsFilename);
                 
-                info("Added " + accounts.length + " accounts and " + groups.length + " groups.");
+                info("There are now " + accounts.length + " team accounts and " + groups.length + " groups.");
+                
+                if(useConfirmGUI)
+                {
+                    String message = "Updated/Added " + NL + accounts.length + " team accounts and " + NL + groups.length + " groups?";
+                    FrameUtilities.showMessage(null,"TSV Files loaded", message);
+                }
 
                 return true;
             } else {


### PR DESCRIPTION
### Description of what the PR does

Updated messages for prompt and confirmation.
Added confirmation dialog that confirms load.

### Issue which the PR fixes

#314 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

The import code has not changed, only the prompt and new confirmation changed

Start server with mini sample
On admin use ** ICPC -> Import CMS tsv files ** 
Select teams.tsv from  samps\contests\mini\config\teams.tsv
Review prompt
Yes to load file(s)
Review the new dialog

Extra is a minimal test.   Before loading teams.tsv modify the teams.tsv
fields and confirm the team info change(s).

Expected

Prompt before load has text has changed to:
Update/Add
151 team accounts and
12 groups?
Yes/No/Cancel

Dialog on load has changed to
Updated/Added
151 team accounts and
12 groups?
Yes/No/Cancel