### PR TITLE
i325: fix ended date/time string in Event Feed JSON

### DIFF
--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -10,7 +10,7 @@
 [client]
 
 # Site 1
-server=pc2.icpc-vcss.org
+server=localhost:50002
 # Site 2
 #server=localhost:51002
 # Site 3

--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -10,7 +10,7 @@
 [client]
 
 # Site 1
-server=localhost:50002
+server=pc2.icpc-vcss.org
 # Site 2
 #server=localhost:51002
 # Site 3

--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.util;
 
 import java.util.Calendar;
@@ -212,7 +212,7 @@ public class JSONTool {
             startTime = Utilities.getIso8601formatterWithMS().format(model.getContestTime().getContestStartTime().getTime());
             element.put("started", startTime);
             if (model.getContestTime().isPastEndOfContest()) {
-                Calendar endedDate = calculateElapsedWalltime(model, model.getContestTime().getContestStartTime().getTimeInMillis() + model.getContestTime().getContestLengthMS());
+                Calendar endedDate = calculateElapsedWalltime(model, model.getContestTime().getContestLengthMS());
                 if (endedDate != null) {
                     element.put("ended", Utilities.getIso8601formatterWithMS().format(endedDate.getTimeInMillis()));
                 }

--- a/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
@@ -1,11 +1,13 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.core;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.Vector;
@@ -15,7 +17,9 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.list.AccountComparator;
 import edu.csus.ecs.pc2.core.list.ClarificationComparator;
@@ -28,6 +32,8 @@ import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.model.ClientType.Type;
 import edu.csus.ecs.pc2.core.model.ContestInformation;
+import edu.csus.ecs.pc2.core.model.ContestTime;
+import edu.csus.ecs.pc2.core.model.FinalizeData;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Judgement;
@@ -1021,4 +1027,67 @@ public class JSONToolTest extends AbstractTestCase {
 //        fail();
     }
 
+    
+    protected FinalizeData createFinalizeData(int numberGolds, int numberSilvers, int numberBronzes) {
+        FinalizeData data = new FinalizeData();
+        data.setGoldRank(numberGolds);
+        data.setSilverRank(numberSilvers);
+        data.setBronzeRank(numberBronzes);
+        data.setComment("Finalized by Director of Operations, no, really!");
+        return data;
+    }
+    
+    /**
+     * Test "ended" calculation.
+     * 
+     * Tests: https://github.com/pc2ccs/pc2v9/issues/325
+     * 
+     * @throws Exception
+     */
+
+    public void testtoStateJSONEnded() throws Exception {
+
+        SampleContest sampleContest = new SampleContest();
+        IInternalContest contest = sampleContest.createStandardContest();
+        IInternalController controller = sampleContest.createController(contest, true, false);
+
+        contest.getContestTime().startContestClock();
+        contest.getContestTime().stopContestClock();
+        contest.getContestTime().setRemainingSecs(0);
+
+        FinalizeData data = createFinalizeData(4, 4, 5);
+        data.setCertified(true);
+        contest.setFinalizeData(data);
+
+        JSONTool tool = new JSONTool(contest, controller);
+
+        ObjectNode rootNode = tool.toStateJSON(contest.getContestInformation());
+
+        assertNotNull(rootNode);
+
+        String json = rootNode.toString();
+
+        JsonNode endNode = rootNode.get("ended");
+        assertNotNull("Did not find ended element in json: " + json, endNode);
+
+        // check ended value
+
+        ContestTime contestTime = contest.getContestTime();
+
+        Date date = contestTime.getContestStartTime().getTime();
+        SimpleDateFormat iso8601formatterWithMS = new SimpleDateFormat(Utilities.ISO_8601_TIMEDATE_FORMAT_WITH_MS);
+        String iso8601DateString = iso8601formatterWithMS.format(date);
+
+        String endValue = endNode.textValue();
+
+        /**
+         * Compare dates but not the times.
+         */
+        String actual = iso8601DateString.substring(0, 10); // only YYYY-MM-DD
+        String expected = endValue.substring(0, 10); // only YYYY-MM-DD
+
+        // before fix, failed with date like: 2074-05-03 on 2022-03-02
+        assertEquals("Expected ended value", expected, actual);
+
+    }
 }


### PR DESCRIPTION
### Description of what the PR does

Fixes the ended date/time in the Event Feed to be in the current year, 
rather than a date many years in the future like: 2074-05-03 on 2022-03-02

### Issue which the PR fixes

#325 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start a sever 
Start an admin
On Time tab set remaining to 0 seconds and elapsed to contest length
Start contest time
Stop contest time
Finalize contest
View Event Feed JSON Report
Review the state element ended date/time

Before fix ended was like this date 2074-05-03  (many years in the future)

Expected for ended is a date and time today

{"type":"state", "id":"pc2-2", "op":"create", "data": {"started":"2022-02-22T00:01:00.005-08","ended":"2022-03-02T00:01:00.005-08","frozen":"2022-03-01T00:01:00.005-08","finalized":"2022-03-02T00:17:01.180-08"}}