### PR TITLE
I 295 new vars yaml work

### DIFF
--- a/samps/contests/ccs1/config/contest.yaml
+++ b/samps/contests/ccs1/config/contest.yaml
@@ -12,6 +12,10 @@ scoreboard-freeze: 4:00:00
 output-private-score-dir: super_secret
 output-public-score-dir: public_html_dir
 
+memory-limit-in-Meg: 8086
+
+sandbox: 'linux_sandbox --verbose'
+
 default-clars:
   - No comment, read problem statement.
   - This will be answered during the answers to questions session.

--- a/src/edu/csus/ecs/pc2/core/export/ExportYAML.java
+++ b/src/edu/csus/ecs/pc2/core/export/ExportYAML.java
@@ -155,6 +155,14 @@ public class ExportYAML {
         contestWriter.println("elapsed: " + contestTime.getElapsedTimeStr());
         contestWriter.println("remaining: " + contestTime.getRemainingTimeStr());
         contestWriter.println("running: " + contestTime.isContestRunning());
+
+        contestWriter.println(IContestLoader.MEMORY_LIMIT_IN_MEG_KEY + ": " + info.getMemoryLimitInMeg());
+
+        String sandbox = info.getSandboxCommandLine();
+        if (sandbox == null) {
+            sandbox = "";
+        }
+        contestWriter.println(IContestLoader.SANDBOX_KEY + ": " + quote(sandbox));
         
         // PC^2 Specific
         contestWriter.println(IContestLoader.AUTO_STOP_CLOCK_AT_END_KEY + ": " + info.isAutoStopContest());

--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.Serializable;
@@ -78,6 +78,16 @@ public class ContestInformation implements Serializable{
     private String rsiCommand = null;
     
     private int lastRunNumberSubmitted = 0;
+    
+    /**
+     * Memory Limit for team's solution (application).
+     */
+    private int memoryLimitInMeg = 0;
+    
+    /**
+     * Sandbox application or application command line.
+     */
+    private String sandboxCommandLine = "";
     
     /**
      * Display string for team display on standings.
@@ -766,4 +776,22 @@ public class ContestInformation implements Serializable{
     public void setTeamScoreboardDisplayFormat(String teamScoreboardDisplayFormat) {
         this.teamScoreboardDisplayFormat = teamScoreboardDisplayFormat;
     }
+
+    public int getMemoryLimitInMeg() {
+        return memoryLimitInMeg;
+    }
+
+    public void setMemoryLimitInMeg(int memoryLimitInMeg) {
+        this.memoryLimitInMeg = memoryLimitInMeg;
+    }
+
+    public String getSandboxCommandLine() {
+        return sandboxCommandLine;
+    }
+
+    public void setSandboxCommandLine(String sandboxCommandLine) {
+        this.sandboxCommandLine = sandboxCommandLine;
+    }
+    
+    
 }

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -265,7 +265,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         contest.updateContestInformation(contestInformation);
     }
     
-    private void setMemoryLimit(IInternalContest contest, Integer memoryLimit) {
+    private void setMemoryLimit(IInternalContest contest, int memoryLimit) {
         ContestInformation contestInformation = contest.getContestInformation();
         contestInformation.setMemoryLimitInMeg(memoryLimit);
         contest.updateContestInformation(contestInformation);

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.imports.ccs;
 
 import java.io.ByteArrayInputStream;
@@ -258,6 +258,20 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
     }
 
+
+    private void setSandboxCommand(IInternalContest contest, String sandboxCommandLine) {
+        ContestInformation contestInformation = contest.getContestInformation();
+        contestInformation.setSandboxCommandLine(sandboxCommandLine);
+        contest.updateContestInformation(contestInformation);
+    }
+    
+    private void setMemoryLimit(IInternalContest contest, Integer memoryLimit) {
+        ContestInformation contestInformation = contest.getContestInformation();
+        contestInformation.setMemoryLimitInMeg(memoryLimit);
+        contest.updateContestInformation(contestInformation);
+    }
+
+
     private void setCcsTestMode(IInternalContest contest, boolean ccsTestMode) {
         ContestInformation contestInformation = contest.getContestInformation();
         contestInformation.setCcsTestMode(ccsTestMode);
@@ -451,7 +465,19 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         }
 
         Integer defaultTimeout = fetchIntValue(content, TIMEOUT_KEY, DEFAULT_TIME_OUT);
-
+        
+        Integer memoryLimit = fetchIntValue(content, MEMORY_LIMIT_IN_MEG_KEY, 0);
+        
+        if (memoryLimit != null) {
+            setMemoryLimit(contest, memoryLimit);
+        }
+        
+        String sandboxCommandLine = fetchValue(content, SANDBOX_KEY);
+        
+        if (sandboxCommandLine != null) {
+            setSandboxCommand (contest, sandboxCommandLine);
+        }
+        
         for (String line : yamlLines) {
             if (line.startsWith(CONTEST_NAME_KEY + DELIMIT)) {
                 setTitle(contest, unquoteAll(line.substring(line.indexOf(DELIMIT) + 1).trim()));
@@ -1076,6 +1102,13 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         return value;
     }
 
+    /**
+     * Fetch value from a map.
+     * 
+     * @param content
+     * @param key
+     * @return null if content does not contain a value for the key, else the value for the key.
+     */
     private String fetchValue(Map<String, Object> content, String key) {
         if (content == null) {
             return null;

--- a/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
@@ -103,6 +103,10 @@ public interface IContestLoader {
     String JUDGE_CONFIG_PATH_KEY = "judge-config-path";
 
     String TIMEOUT_KEY = "timeout";
+    
+    final String MEMORY_LIMIT_IN_MEG_KEY = "memory-limit-in-Meg";
+    
+    final String SANDBOX_KEY = "sandbox";
 
     String LIMITS_KEY = "limits";
 

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3674,7 +3674,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
      * @throws Exception
      */
     
-    public void testLodSandboxAndMemoryLimit() throws Exception {
+    public void testLoadSandboxAndMemoryLimit() throws Exception {
         
 
         /**

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.imports.ccs;
 
 import java.io.File;
@@ -3664,6 +3664,42 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         for (Problem problem : problems) {
             assertFalse(problem.getShortName()+" stop on first ", problem.isStopOnFirstFailedTestCase());
         }
+        
+    }
+    
+    
+    /**
+     * Test yaml import for memory-limit-in-Meg and sandbox.
+     * 
+     * @throws Exception
+     */
+    
+    public void testLodSandboxAndMemoryLimit() throws Exception {
+        
+
+        /**
+         * Contest to use as input
+         */
+        String sampleContestDirName = "ccs1";
+        
+        IInternalContest contest = new InternalContest();
+        
+        loadSampleContest(contest, sampleContestDirName);
+        
+        assertNotNull(contest);
+        ContestInformation info = contest.getContestInformation();
+        
+        assertEquals("title ", "ACM-ICPC CLI CCS Sample One", info.getContestTitle());
+        
+        // from ccs1 yaml
+        //        memory-limit-in-Meg: 8086
+        //        sandbox: 'linux_sandbox --verbose'
+        
+        int expectedLimit = 8086;
+        assertEquals("Memory limit", expectedLimit, info.getMemoryLimitInMeg());
+        
+        String expected = "linux_sandbox --verbose";
+        assertEquals("Sandbox command", expected, info.getSandboxCommandLine());
         
     }
 


### PR DESCRIPTION
Added variables in ContestInformation
Added code to load values from contest.yaml
Added code to write keys/values to contest.yaml via Export Contest Yaml
Updated ccs1 sample to contain new keys in contest.yaml

### Description of what the PR does

Add two variables to ContestInformation class for memory limit and sandbox

Added yaml keys into samps\contests\ccs1\config\contest.yaml
memory-limit-in-Meg: and sandbox

### Issue which the PR fixes

None, part of work for #295 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

All.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Verify that exported contest.yaml has two new keys and values
are identical to values in samps\contests\ccs1\config\contest.yaml

Start server, load sample ccs1
pc2server --login s --contestpassword contest
start admin
Run Contest -> Export
select Export contest.yaml

Expected output in viewer
memory-limit-in-Meg: 8086
sandbox: 'linux_sandbox --verbose'