### PR TITLE
I 335 add option for raw report contents export

### DIFF
--- a/src/edu/csus/ecs/pc2/core/report/Reports.java
+++ b/src/edu/csus/ecs/pc2/core/report/Reports.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Vector;
@@ -53,6 +54,8 @@ public final class Reports {
     private static final String FILE_OPTION_STRING = "-F";
     
     private static final String DIR_OPTION_STRING = "--dir";
+    
+    private static final String RAW_OPTION_STRING = "--raw";
 
     public Reports(String profileName, char[] charArray) {
         super();
@@ -186,6 +189,7 @@ public final class Reports {
                 "-F filename    - specify command line options in filename", //
                 "--profile name - profile name, default uses current profile.  name may be a ## from --listp listing", //
                 "--contestPassword padd  - password needed to decrypt pc2 data", //
+                "--raw          - suppress footer and header \"raw\" report content", //
                 "--xml          - output only XML for report", //
                 "--list         - list names of reports (and the report numbers)", //
                 "--dir name     - alternate base directory name, by default uses profile dir name", //
@@ -307,7 +311,7 @@ public final class Reports {
      *            either number or name for the report
      * @param outputXML
      */
-    private void printReport(String arg, boolean outputXML) {
+    private void printReport(String arg, boolean suppressHeaderAndFooter, boolean outputXML) {
 
         String dirName = getInstallDirectory();
 
@@ -347,7 +351,7 @@ public final class Reports {
             contest.setClientId(clientId);
 
             IReport report = getReport(arg);
-
+            
             if (report == null) {
                 System.out.println("Unable to match/find report " + arg);
             } else {
@@ -355,15 +359,27 @@ public final class Reports {
                 controller.setLog(log);
                 String filename = getReportFileName(report);
                 report.setContestAndController(contest, controller);
+                
+                
                 if (outputXML) {
                     String xml = report.createReportXML(new Filter());
                     writeFile(filename, xml);
                 } else {
-                    report.createReportFile(filename, new Filter());
+                    
+                    if (suppressHeaderAndFooter) {
+                        // Wrap Report and suppress header and footer
+                        writeReportNoHeaderFooter(report, filename, new Filter());
+                    } else {
+                        report.createReportFile(filename, new Filter());
+                    }
+                    
                 }
                 catfile(filename);
+                
+              
 
             }
+            
         } catch (FileNotFoundException fnfe) {
             System.err.println("ERROR nothing to print, no pc2 files/profiles found under " + getInstallDirectory());
             fnfe.printStackTrace(); // debug 22
@@ -372,6 +388,18 @@ public final class Reports {
             System.err.println("For directory " + dirName);
         } catch (Exception e) {
             System.err.println("ERROR " + e.getMessage());
+        }
+    }
+
+    private void writeReportNoHeaderFooter(IReport report, String filename, Filter filter) {
+
+        PrintWriter printWriter = null;
+        try {
+            printWriter = new PrintWriter(new FileOutputStream(filename, false), true);
+            report.writeReport(printWriter);
+        } catch (Exception e) {
+            printWriter.println("Exception in report: " + e.getMessage());
+            e.printStackTrace(printWriter);
         }
     }
 
@@ -546,6 +574,11 @@ public final class Reports {
             }
             setInstallDirectory(dir);
         }
+        
+        /**
+         * Raw - do not output header or footer, just contents.
+         */
+        boolean rawOutput = arguments.isOptPresent(RAW_OPTION_STRING);
 
         if (arguments.isOptPresent("--list")) {
             listReports();
@@ -584,7 +617,7 @@ public final class Reports {
 
         for (int i = 0; i < arguments.getArgCount(); i++) {
             String arg = arguments.getArg(i);
-            reports.printReport(arg, xmlOutputOption);
+            reports.printReport(arg, rawOutput, xmlOutputOption);
         }
 
     }

--- a/src/edu/csus/ecs/pc2/ui/ReportPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ReportPane.java
@@ -107,6 +107,8 @@ import edu.csus.ecs.pc2.core.security.Permission.Type;
 import edu.csus.ecs.pc2.core.util.IMemento;
 import edu.csus.ecs.pc2.core.util.XMLMemento;
 import edu.csus.ecs.pc2.ui.EditFilterPane.ListNames;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
 
 /**
  * Report Pane, allows picking and viewing reports.
@@ -163,6 +165,7 @@ public class ReportPane extends JPanePlugin {
     private JCheckBox xmlOutputCheckbox = null;
 
     private JButton generateSummaryButton = null;
+    private JButton exportDataButton;
 
     public String getReportDirectory() {
         return reportDirectory;
@@ -398,6 +401,7 @@ public class ReportPane extends JPanePlugin {
             buttonPane = new JPanel();
             buttonPane.setLayout(flowLayout);
             buttonPane.setPreferredSize(new java.awt.Dimension(45, 45));
+            buttonPane.add(getExportDataButton());
             buttonPane.add(getViewReportButton(), null);
             buttonPane.add(getGenerateSummaryButton(), null);
         }
@@ -438,7 +442,7 @@ public class ReportPane extends JPanePlugin {
                     if (getBreakdownBySiteCheckbox().isSelected()) {
                         generateSelectedReportBySite();
                     } else {
-                        generateSelectedReport();
+                        generateSelectedReport(true);
                     }
                 }
             });
@@ -553,7 +557,7 @@ public class ReportPane extends JPanePlugin {
         }
     }
 
-    protected void generateSelectedReport() {
+    protected void generateSelectedReport(boolean includeHeaderFooter) {
 
         try {
 
@@ -576,6 +580,11 @@ public class ReportPane extends JPanePlugin {
             if (writeXML) {
                 extension = "xml";
             }
+            
+            if (selectedReport.getReportTitle().toLowerCase().indexOf("json") != -1) {
+                extension = "json";
+            }
+            
             String filename = getFileName(selectedReport, extension);
 
             File reportDirectoryFile = new File(getReportDirectory());
@@ -603,6 +612,10 @@ public class ReportPane extends JPanePlugin {
                 if (selectedReport instanceof IReportFile) {
                     IReportFile reportFile = (IReportFile) selectedReport;
                     suppressHeaderFooter = reportFile.suppressHeaderFooter();
+                }
+                
+                if (! includeHeaderFooter) {
+                    suppressHeaderFooter = true;
                 }
                 createReportFile(selectedReport, suppressHeaderFooter, filename, filter);
             }
@@ -842,7 +855,7 @@ public class ReportPane extends JPanePlugin {
                         if (getBreakdownBySiteCheckbox().isSelected()) {
                             generateSelectedReportBySite();
                         } else {
-                            generateSelectedReport();
+                            generateSelectedReport(true);
                         }
                     }
                 }
@@ -1084,4 +1097,17 @@ public class ReportPane extends JPanePlugin {
         }
     }
 
+    private JButton getExportDataButton() {
+        if (exportDataButton == null) {
+        	exportDataButton = new JButton("Export Report Contents");
+        	exportDataButton.addActionListener(new ActionListener() {
+        	    public void actionPerformed(ActionEvent e) {
+        	        generateSelectedReport(false);
+        	    }
+        	});
+        	exportDataButton.setToolTipText("Export and View Report with no header or footer");
+        	exportDataButton.setMnemonic('X');
+        }
+        return exportDataButton;
+    }
 } // @jve:decl-index=0:visual-constraint="10,10"


### PR DESCRIPTION
### Description of what the PR does

In the PacNW contest the JSON had to be stripped of a standard
pc2 report header and footer.   This feature providea a way to
avoid that extra step.

Adds a way to output report content without header and footers ("raw" content output).
The pc2reports has a new option --raw to support the new feature
On Reports tab added a new Export Reports Contents button 

### Issue which the PR fixes

#335 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

All.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

On Reports tab (server or admin) select: Event Feed JSON

Create a report file using Reports tab "Export Reports Contents" button 

Expected

No  header or footer output