### PR TITLE
i295: in Executable added var. substitutions, sandbox and memlimit

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2535,12 +2535,17 @@ public class Executable extends Plugin implements IExecutable {
             if (contestInformation.getMemoryLimitInMeg() > 0) {
                 newString = replaceString(newString, "{:memlimit}", Integer.toString(contestInformation.getMemoryLimitInMeg()));
             }
-
-            if (!StringUtilities.isEmpty(contestInformation.getSandboxCommandLine())) {
-                if (newString.indexOf("{:sandbox}") > -1) {
+            
+            if (newString.indexOf("{:sandbox}") > -1) {
+                if (!StringUtilities.isEmpty(contestInformation.getSandboxCommandLine())) {
+                    
                     newString = replaceString(newString, "{:sandbox}", contestInformation.getSandboxCommandLine());
                     newString = substituteAllStrings(inRun, newString);
+                } else {
+                    // remove {:sandbox} if no sandbox defined in pc2
+                    newString = replaceString(newString, "{:sandbox}", "");
                 }
+                
             }
 
         } catch (Exception e) {

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.BufferedInputStream;
@@ -2396,7 +2396,8 @@ public class Executable extends Plugin implements IExecutable {
         String afterString = new Integer(afterInt).toString();
         return replaceString(origString, beforeString, afterString);
     }
-
+    
+    
     /**
      * return string with all field variables filled with values.
      * 
@@ -2512,7 +2513,7 @@ public class Executable extends Plugin implements IExecutable {
             } else {
                 log.config("substituteAllStrings() problem is undefined (null)");
             }
-
+            
             if (executionData != null) {
                 if (executionData.getExecuteProgramOutput() != null) {
                     if (executionData.getExecuteProgramOutput().getName() != null) {
@@ -2524,10 +2525,24 @@ public class Executable extends Plugin implements IExecutable {
                 newString = replaceString(newString, "{:exitvalue}", Integer.toString(executionData.getExecuteExitValue()));
                 newString = replaceString(newString, "{:executetime}", Long.toString(executionData.getExecuteTimeMS()));
             }
+            
             String pc2home = new VersionInfo().locateHome();
             if (pc2home != null && pc2home.length() > 0) {
                 newString = replaceString(newString, "{:pc2home}", pc2home);
             }
+            
+            ContestInformation contestInformation = contest.getContestInformation();
+            if (contestInformation.getMemoryLimitInMeg() > 0) {
+                newString = replaceString(newString, "{:memlimit}", Integer.toString(contestInformation.getMemoryLimitInMeg()));
+            }
+
+            if (!StringUtilities.isEmpty(contestInformation.getSandboxCommandLine())) {
+                if (newString.indexOf("{:sandbox}") > -1) {
+                    newString = replaceString(newString, "{:sandbox}", contestInformation.getSandboxCommandLine());
+                    newString = substituteAllStrings(inRun, newString);
+                }
+            }
+
         } catch (Exception e) {
             log.log(Log.CONFIG, "Exception substituting strings ", e);
             // carrying on not required to save exception

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1957,7 +1957,7 @@ public class ExecutableTest extends AbstractTestCase {
 
         // No sandbox in ContestInfo, substitue empty string
         String datain = "{:sandbox} ./a.out";
-        String expected = "./a.out";
+        String expected = " ./a.out";
         String actual = executable.substituteAllStrings(run, datain);
 
         assertEquals("Expected substitute string for " + datain, expected, actual);

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1955,9 +1955,9 @@ public class ExecutableTest extends AbstractTestCase {
 
         Executable executable = new Executable(contest, controller, run, runFiles);
 
-        // No sandbox in ContestInfo, no substitution
+        // No sandbox in ContestInfo, substitue empty string
         String datain = "{:sandbox} ./a.out";
-        String expected = "{:sandbox} ./a.out";
+        String expected = "./a.out";
         String actual = executable.substituteAllStrings(run, datain);
 
         assertEquals("Expected substitute string for " + datain, expected, actual);


### PR DESCRIPTION
### Description of what the PR does

Adds two new variables to variable substitution for sandbox program and memory limit value

replace {:memlimit} with contestInformation.getMemoryLimitInMeg()

replace {:sandbox} with contestInformation.getSandboxCommandLine()
  If there are variables like {:memlimit} in the sandbox, e.g. {:sandbox}--mem={:memlimit}
  those variables (including any variable substitution) will be substituted.

### Issue which the PR fixes

#215
Executable var substitutions.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1586]
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Examples of yaml to add to contest.yaml from samps/contests/ccs1/config/contest.yaml 
sandbox: 'linux_sandbox --verbose'
memory-limit-in-Meg: 8086
or edit and load ccs1 sample contest 

1. Add variables into contest.yaml
2.  Admin: Prepend Program Execution Command Line with {:sandbox}
3. team: submit a run for that language
4.  judge:  execute the run

Expected:

The log should show the substitution.  Whether the substitution works or
not depends on the implementation of the program specified in the
yaml field sandbox.

For the example above here is the before and after substitution

220316 195927.424|DEBUG|Thread-18|executeProgram|before substitution: {:sandbox} a.out
220316 195927.431|DEBUG|Thread-18|executeProgram|after  substitution: linux_sandbox --verbose a.out