### PR TITLE
i348: added halt at end in ccs1 sample and unit test

### DIFF
--- a/samps/contests/ccs1/config/contest.yaml
+++ b/samps/contests/ccs1/config/contest.yaml
@@ -12,6 +12,8 @@ scoreboard-freeze: 4:00:00
 output-private-score-dir: super_secret
 output-public-score-dir: public_html_dir
 
+auto-stop-clock-at-end: true
+
 default-clars:
   - No comment, read problem statement.
   - This will be answered during the answers to questions session.

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3674,5 +3674,34 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         return contest;
     }
     
+    
+    /**
+     * Test halt-contest-clock-at-set to true.
+     * 
+     * @throws Exception
+     */
+    public void testisHaltContestAtTimeZero() throws Exception {
+        String sampleContestDirName = "ccs1";
+        String dirname = getContestSampleCDPConfigDirname(sampleContestDirName);
+        
+        IInternalContest contest = snake.fromYaml(null, dirname, false);
+        assertNotNull("Expecting to load ccs1 contest",contest);
+        assertTrue("Expected halt at end of contest ", contest.getContestInformation().isAutoStartContest());
+    }
+    
+    /** 
+     * Test halt-contest-clock-at-end value, for when missing key/value
+     * @throws Exception
+     */
+    public void testisHaltContestAtTimeZeroNegative() throws Exception {
+        String sampleContestDirName = "ccs2";
+        String dirname = getContestSampleCDPConfigDirname(sampleContestDirName);
+        
+        IInternalContest contest = snake.fromYaml(null, dirname, false);
+        assertNotNull("Expecting to load ccs2 contest",contest);
+        assertFalse("Expected NO halt at end of contest ", contest.getContestInformation().isAutoStartContest());
+    }
+   
+    
 }
 

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3686,7 +3686,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         
         IInternalContest contest = snake.fromYaml(null, dirname, false);
         assertNotNull("Expecting to load ccs1 contest",contest);
-        assertTrue("Expected halt at end of contest ", contest.getContestInformation().isAutoStartContest());
+        assertTrue("Expected halt at end of contest ", contest.getContestInformation().isAutoStopContest());
     }
     
     /** 
@@ -3699,7 +3699,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         
         IInternalContest contest = snake.fromYaml(null, dirname, false);
         assertNotNull("Expecting to load ccs2 contest",contest);
-        assertFalse("Expected NO halt at end of contest ", contest.getContestInformation().isAutoStartContest());
+        assertFalse("Expected NO halt at end of contest ", contest.getContestInformation().isAutoStopContest());
     }
    
     


### PR DESCRIPTION
Code was already in place to load key: auto-stop-clock-at-end
Added key into sample contest ccs1 (also for data for unit test)

### Description of what the PR does

Adds test data for auto-stop-clock-at-end in ccs1 sample contest

### Issue which the PR fixes

#348 
Key is present, missing test data and unit tests.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1586]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Either use ccs1 sample or add auto-stop-clock-at-end: true   (to contest.yaml)

start server, --load ccs1
start admin
navigate to Time tab, Edit Contest Time for site 1

Expected: 

The checkbox stop contest automatically should be checked
