### PR TITLE
I 332 edit run should not always select yes judgement

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/EditRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditRunPane.java
@@ -434,10 +434,26 @@ public class EditRunPane extends JPanePlugin {
 
         ElementId judgementId = null;
 
-        if (run.isJudged()) {
-            judgementId = run.getJudgementRecord().getJudgementId();
-        }
+        judgementLabel.setText("Judgement");
 
+        if (run.isJudged()) {
+            JudgementRecord jr = run.getJudgementRecord();
+            judgementId = jr.getJudgementId();
+
+            // Add judgement description to judgement tool tip
+            Judgement judgement = getContest().getJudgement(judgementId);
+            String judgementDescription = judgement.getAcronym() + " " + judgement.getDisplayName();
+
+            String valString = jr.getValidatorResultString();
+            if (valString != null) {
+                judgementDescription += " Validator returns '" + valString + "'";
+            }
+
+            log.info("Edit Run " + run.getNumber() + " judgement is " + judgementDescription);
+            judgementLabel.setToolTipText(judgementDescription);
+            judgementLabel.setText("Judgement*");
+        }
+        
         for (Judgement judgement : getContest().getJudgements()) {
             getJudgementComboBox().addItem(judgement);
             if (judgement.getElementId().equals(judgementId)) {
@@ -445,6 +461,9 @@ public class EditRunPane extends JPanePlugin {
             }
             index++;
         }
+        
+        // Select judgement in combo box
+        judgementComboBox.setSelectedIndex(selectedIndex);
         
         selectedIndex = -1;
         index = 0;

--- a/src/edu/csus/ecs/pc2/ui/EditRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditRunPane.java
@@ -447,11 +447,11 @@ public class EditRunPane extends JPanePlugin {
             String valString = jr.getValidatorResultString();
             if (valString != null) {
                 judgementDescription += " Validator returns '" + valString + "'";
+                judgementLabel.setText("Judgement*");
             }
 
             log.info("Edit Run " + run.getNumber() + " judgement is " + judgementDescription);
             judgementLabel.setToolTipText(judgementDescription);
-            judgementLabel.setText("Judgement*");
         }
         
         for (Judgement judgement : getContest().getJudgements()) {


### PR DESCRIPTION
### Description of what the PR does

Fixed bug where edit run always showed judgement as Yes.
Now edit run (if run judged) will show judgement.

Sometimes a validated run judgement, status on the Runs Tab, will
be different than the judgement displayed/selected in edit run.
In this case hover over the Judgement label to reveal the tool tip
which will show the judgement in edit run and the judgement in the Run Tab status column.

### Issue which the PR fixes

#332 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

The bug is edit run for every run regardless of judgement selects the judgement Yes.

Add/submit runs to the system both with Yes and No judgements.

Edit the "No" runs and edit run will select a No judgement, before always selected Yes.
  (Note if judgement different than on Run tab, hover over the Judgement combo box tab 
to view both the judgement assigned (usually RTE) and the Validator result string.

For every edit run will log the initial judgement (with validator result string too).