### PR TITLE
i361 - Prevent NPE caused by uninitialized name format string

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -760,6 +760,11 @@ public class ContestInformation implements Serializable{
      * @return
      */
     public String getTeamScoreboardDisplayFormat() {
+        // Handle case where deserializing old contest objects sets teamScoreboardDisplayFormat to null.
+        // In this case, just set it to the default (i361 - DSA causes NPE)
+        if(teamScoreboardDisplayFormat == null) {
+            teamScoreboardDisplayFormat = ScoreboardVariableReplacer.TEAM_NAME;
+        }
         return teamScoreboardDisplayFormat;
     }
 


### PR DESCRIPTION
When deserializing older objects of type ContestInformation that do not contain the teamScoreboardDisplayFormat member, make sure that member gets set to the default when the accessor is called.  Before the fix, bringing up the pc2admin would cause a warning about not being able to create the Standings HTML.  This was caused by the name format string being null because it was not set during the deserialization of the old ContestInformation object.

This addresses #361 - DefaultScoringAlgorithm causes Null-pointer Exception when formatting team name on older profiles

Bringing up pc2admin no longer causes the warning or the null pointer exception.

Note: while a more "correct" approach to fixing this issue may be to change the serial number of the ContestInformation class, this would make make restoring older contests virtually impossible.  It was therefore decided to just set the missing member variable to the default value, ScoreboardVariableReplacer.TEAM_NAME, which happens to be {:teamname}
