### PR TITLE
i318: merge rather than replace group list on load of teams.tsv

### DIFF
--- a/src/edu/csus/ecs/pc2/core/imports/LoadICPCTSVData.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadICPCTSVData.java
@@ -23,10 +23,8 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * Read input .tsv files, validate then if valid load into contest.
  * 
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
 
-// $HeadURL$
 public class LoadICPCTSVData implements UIPlugin {
 
     public static final String TEAMS2_TSV = "teams2.tsv";
@@ -87,13 +85,13 @@ public class LoadICPCTSVData implements UIPlugin {
             String instFilename = groupsFilename.replaceFirst(GROUPS_FILENAME,"institutions.tsv");
             // this must be loaded before accounts, and no harm before groups
             ICPCTSVLoader.loadInstitutions(instFilename);
-            Group[] groups = ICPCTSVLoader.loadGroups(groupsFilename);
+            Group[] groups = ICPCTSVLoader.loadGroups(groupsFilename, contest.getGroups());
             
-//            for (Group group : groups) {
-//                group.setSite(getContest().getSites()[0].getElementId());
-//            }
-            
+//          for (Group group : groups) {
+//              group.setSite(getContest().getSites()[0].getElementId());
+//          }
             Account[] accounts = ICPCTSVLoader.loadAccounts(teamsFilename);
+            
             if (!accountsFilename.equals("")) {
                 HashMap<Integer, String> passwordMap = ICPCTSVLoader.loadPasswordsFromAccountsTSV(accountsFilename);
                 if (!passwordMap.isEmpty()) {
@@ -144,7 +142,6 @@ public class LoadICPCTSVData implements UIPlugin {
                      * UpdateAccounts
                      */
                     Account[] updatedAccounts = (Account[]) accountList.toArray(new Account[accountList.size()]);
-
                     getController().updateAccounts(updatedAccounts);
                     info("Sent accounts from " + teamsFilename + " to server");
                 } else {
@@ -152,6 +149,7 @@ public class LoadICPCTSVData implements UIPlugin {
                     // since not sending to server, add to existing contest.
                     
                     Group[] updatedGroups = (Group[]) groupList.toArray(new Group[groupList.size()]);
+                    
                     for (Group group : updatedGroups) {
                         contest.updateGroup(group);
                     }
@@ -227,6 +225,8 @@ public class LoadICPCTSVData implements UIPlugin {
             
             accountList.set(i, existingAccount);
             i ++;
+            
+            
         }
         
     }

--- a/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
@@ -259,7 +259,7 @@ public final class ICPCTSVLoader {
     }
     
     /**
-     * Load groups into this class.
+     * Merge/Add group data from filename and authoritativeGroups.
      * 
      * @param filename name of groups.tsv file.
      * @return list of groups 
@@ -270,10 +270,11 @@ public final class ICPCTSVLoader {
     }
     
     /**
-     * Merge/Load groups into this class
+     * Merge/Add group data from filename and authoritativeGroups.
+     * 
      * @param filename name of groups.tsv file.
      * @param authoritativeGroups an array of groups (from contest/model)
-     * @return list of groups
+     * @return unique groups from authoritativeGroups and filename's group list.
      * @throws Exception
      */
     public static Group[] loadGroups(String filename, Group[] authoritativeGroups) throws Exception {
@@ -295,11 +296,6 @@ public final class ICPCTSVLoader {
 
         // 1 Label groups fixed string (always same value)
         // 2 Version number 1 integer
-
-        // TODO CCS do check for 'groups' when tsv file contains that field.
-//        if (!fields[0].trim().equals("groups")) {
-//            throw new InvalidValueException("Expecting 'groups' got '" + fields[0] + "' in " + filename);
-//        }
 
         i++;
 

--- a/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
@@ -341,18 +341,10 @@ public final class ICPCTSVLoader {
          * Add groups from authoritativeGroups if missing from groupList.
          */
         for (Group aGroup : authoritativeGroups) {
-            
-            Group missingGroup = null; 
-            
-            for (Group glGroup : groupList) {
-                if (aGroup.getGroupId() == glGroup.getGroupId()) {
-                    missingGroup = glGroup;
-                }
-            }
-            
-            if (missingGroup == null) {
-                groupList.add(aGroup);
-            }
+            if (! groupList.contains(aGroup)) {
+               groupList.add(aGroup);
+               break;
+           }
         }
         
         groups = (Group[]) groupList.toArray(new Group[groupList.size()]);

--- a/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
@@ -364,7 +364,7 @@ public final class ICPCTSVLoader {
      * Search and return group if found.
      * 
      * @param authoritativeGroups list of groups
-     * @param groupCMSId group (CMS
+     * @param groupCMSId CMS group id
      * @return null if not found, else the group
      */
     private static Group findGroupById(Group[] authoritativeGroups, int groupCMSId) {

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
@@ -140,7 +140,7 @@ public class LoadICPCTSVDataTest extends AbstractTestCase {
      * Test loading a teams.tsv twice.
      * 
      * The 2nd load of teams and groups, in particular groups, caused all accounts' groups to be "empty"
-     * on the Accounts tab.  See 
+     * on the Accounts tab.  See https://github.com/pc2ccs/pc2v9/issues/318 for details.
      * 
      * @throws Exception
      */

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
@@ -165,10 +165,6 @@ public class LoadICPCTSVDataTest extends AbstractTestCase {
 
         loader.checkFiles(groupsFilename);
 
-        /**
-         * Second load of groups from groups.tsv
-         */
-        Group[] loadedGroups = ICPCTSVLoader.loadGroups(loader.getGroupsFilename());
         Account[] accounts = ICPCTSVLoader.loadAccounts(loader.getTeamsFilename());
 
         /**
@@ -179,9 +175,6 @@ public class LoadICPCTSVDataTest extends AbstractTestCase {
         assertEquals("Number of groups", 12, modelGroups.length);
         assertEquals("Number of accounts", 151, accounts.length);
 
-        /**
-         * Second load of groups from groups.tsv
-         */
         // Load groups from file, merge with modelGroups list.
         Group[] mergedGroups = ICPCTSVLoader.loadGroups(loader.getGroupsFilename(), modelGroups);
 

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.imports;
 
 import java.io.File;
@@ -146,10 +146,11 @@ public class LoadICPCTSVDataTest extends AbstractTestCase {
      */
     public void testReLoadTSV() throws Exception {
 
-        String groupsFilename = getTestSampleContestConfigFile("mini", LoadICPCTSVData.GROUPS_FILENAME);
+        String contestName = "mini";
+        String groupsFilename = getTestSampleContestConfigFile(contestName, LoadICPCTSVData.GROUPS_FILENAME);
         assertFileExists(groupsFilename);
 
-        IInternalContest contest = loadSampleContest(null, "mini");
+        IInternalContest contest = loadSampleContest(null, contestName);
         assertNotNull(contest);
         IInternalController controller = new SampleContest().createController(contest, true, false);
         
@@ -157,7 +158,7 @@ public class LoadICPCTSVDataTest extends AbstractTestCase {
         loader.setContestAndController(contest, controller);
         
         boolean loaded = loader.loadFiles(groupsFilename, false, false);
-        assertTrue("Expecting min contest loaded", loaded);
+        assertTrue("Expecting "+contestName+" contest loaded", loaded);
 
         assertEquals("Number of groups", 12, contest.getGroups().length);
         assertEquals("Number of accounts", 167, contest.getAccounts().length);

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
@@ -1,9 +1,11 @@
 // Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.imports;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
+import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientType.Type;
 import edu.csus.ecs.pc2.core.model.ElementId;
@@ -11,7 +13,9 @@ import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.SampleContest;
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
+import edu.csus.ecs.pc2.imports.ccs.ContestSnakeYAMLLoader;
 import edu.csus.ecs.pc2.imports.ccs.ICPCTSVLoader;
+import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 
 /**
  * Unit Tests for LoadICPCTSVData.
@@ -111,5 +115,88 @@ public class LoadICPCTSVDataTest extends AbstractTestCase {
             }
         }
     }
+    
+    private IInternalContest loadSampleContest(IInternalContest contest, String sampleName) throws Exception {
+        IContestLoader loader = new ContestSnakeYAMLLoader();
+        String configDir = getTestSampleContestConfigDirectory(sampleName);
 
+        try {
+            return loader.fromYaml(contest, configDir);
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+            throw e;
+        }
+    }
+
+    private String getTestSampleContestConfigDirectory(String contestName) {
+        return getTestSampleContestDirectory(contestName) + File.separator + IContestLoader.CONFIG_DIRNAME;
+    }
+
+    private String getTestSampleContestConfigFile(String contestName, String filename) {
+        return getTestSampleContestDirectory(contestName) + File.separator + IContestLoader.CONFIG_DIRNAME + File.separator + filename;
+    }
+
+    /**
+     * Test loading a teams.tsv twice.
+     * 
+     * The 2nd load of teams and groups, in particular groups, caused all accounts' groups to be "empty"
+     * on the Accounts tab.  See 
+     * 
+     * @throws Exception
+     */
+    public void testReLoadTSV() throws Exception {
+
+        String groupsFilename = getTestSampleContestConfigFile("mini", LoadICPCTSVData.GROUPS_FILENAME);
+        assertFileExists(groupsFilename);
+
+        IInternalContest contest = loadSampleContest(null, "mini");
+        assertNotNull(contest);
+        IInternalController controller = new SampleContest().createController(contest, true, false);
+        
+        LoadICPCTSVData loader = new LoadICPCTSVData();
+        loader.setContestAndController(contest, controller);
+        
+        boolean loaded = loader.loadFiles(groupsFilename, false, false);
+        assertTrue("Expecting min contest loaded", loaded);
+
+        assertEquals("Number of groups", 12, contest.getGroups().length);
+        assertEquals("Number of accounts", 167, contest.getAccounts().length);
+
+        loader.checkFiles(groupsFilename);
+
+        /**
+         * Second load of groups from groups.tsv
+         */
+        Group[] loadedGroups = ICPCTSVLoader.loadGroups(loader.getGroupsFilename());
+        Account[] accounts = ICPCTSVLoader.loadAccounts(loader.getTeamsFilename());
+
+        /**
+         * Groups from contest/model, the authoritative groups from model.
+         */
+        Group[] modelGroups = contest.getGroups();
+
+        assertEquals("Number of groups", 12, modelGroups.length);
+        assertEquals("Number of accounts", 151, accounts.length);
+
+        /**
+         * Second load of groups from groups.tsv
+         */
+        // Load groups from file, merge with modelGroups list.
+        Group[] mergedGroups = ICPCTSVLoader.loadGroups(loader.getGroupsFilename(), modelGroups);
+
+        Account[] accounts2 = ICPCTSVLoader.loadAccounts(loader.getTeamsFilename());
+
+        assertEquals("Number of groups", 12, mergedGroups.length);
+        assertEquals("Number of accounts", 151, accounts2.length);
+
+        for (int i = 0; i < modelGroups.length; i++) {
+            assertEquals("(" + i + ") Expecting same group element id for group " + modelGroups[i], modelGroups[i].getElementId(), mergedGroups[i].getElementId());
+        }
+
+        // check that all accounts assigned groups in the model/contest
+        for (Account account : accounts2) {
+            Group group = contest.getGroup(account.getGroupId());
+            assertNotNull("Expecting group to exist in contest/model " + account.getGroupId(), group);
+        }
+    }
 }


### PR DESCRIPTION
### Description of what the PR does

Groups were being blanked out on Accounts list on load  of teams.tsv and groups.tsv.
Now merges model's groups and loaded groups from groups.tsv.

### Issue which the PR fixes

#318 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1586]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

tldr;   Start server with sample contest that has teams.tsv, groups.tsv, 
   load the same teams.tsv using ICPC tab -> Import CMS tsv files
   view Accounts, and confirm that groups are blanked out.

Load sample contest mini
 pc2server --login s --contestpassword contest  --load mini
Start Admin 
note that groups are populated for accounts
ICPC tab -> Import CMS tsv files 
load either groups.tsv or teams.tsv from samps\contests\mini\config
 
Expected

In Accounts tab, groups are present.

Actual:

All team groups are blank.
