### PR TITLE
i374: fix upper-case typo in SumitMTC (should have been sumitMTC).

### DIFF
--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3679,7 +3679,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         /**
          * Contest to use as input
          */
-        String sampleContestDirName = "SumitMTC";
+        String sampleContestDirName = "sumitMTC";
         
         IInternalContest contest = new InternalContest();
         


### PR DESCRIPTION
### Description of what the PR does
 Corrects a typo in ContestSnakeYAMLLoaderTest.testLoadSandboxAndMemoryLimit():  "SumitMTC" should have been "sumitMTC".

### Issue which the PR fixes
Fixes #374 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.0, Eclipse Version: 2019-12 (4.14.0), java 1.8.0_201.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Examine the build job on GitLab; it should now build successfully (whereas previously the above JUnit method failed).
