### PR TITLE
i377: fix date/time JSON comparison in test

### DIFF
--- a/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
@@ -7,9 +7,11 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
+import java.util.TimeZone;
 import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1071,10 +1073,15 @@ public class JSONToolTest extends AbstractTestCase {
         assertNotNull("Did not find ended element in json: " + json, endNode);
 
         // check ended value
-
         ContestTime contestTime = contest.getContestTime();
+        Calendar contestStart = contestTime.getContestStartTime();
 
-        Date date = contestTime.getContestStartTime().getTime();
+        long contestEndMS = contestStart.getTimeInMillis() + contestTime.getContestLengthMS(); 
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
+        calendar.setTimeInMillis(contestEndMS);
+        Date date = calendar.getTime();
+                
         SimpleDateFormat iso8601formatterWithMS = new SimpleDateFormat(Utilities.ISO_8601_TIMEDATE_FORMAT_WITH_MS);
         String iso8601DateString = iso8601formatterWithMS.format(date);
 
@@ -1086,8 +1093,11 @@ public class JSONToolTest extends AbstractTestCase {
         String actual = iso8601DateString.substring(0, 10); // only YYYY-MM-DD
         String expected = endValue.substring(0, 10); // only YYYY-MM-DD
 
-        // before fix, failed with date like: 2074-05-03 on 2022-03-02
-        assertEquals("Expected ended value", expected, actual);
+        // compare YYYY-MM-DD
+        assertEquals("Expected contest end date value", expected, actual);
+        
+        // compare full date string, ex. 2022-04-17T00:03:29.280-07
+        assertEquals("Expected contest end date value", iso8601DateString, endValue);
 
     }
 }


### PR DESCRIPTION
### Description of what the PR does

Fixes the calculation of end date/time that is compared
to the JSON contest end date/time.

The contest length is now added to the date/time variable.

This was a JUnit test fix where a date variable
was incorrect.   The date var did not include the contest
length time when assigning the end date/time.
The JSON generated using the toStateJSON method
has been calculating the end date/time correctly.

### Issue which the PR fixes

#377

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1586]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

This bug only happens when the JUnit is run less than 5 hours before midnight.

1. Run the JSONToolTest class/unit test.

The expected result is that all tests pass, including testtoStateJSONEnded test.