### PR TITLE
i295: fix junit test per i377 on i_295_develop_work branch

### DIFF
--- a/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
@@ -7,9 +7,11 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
+import java.util.TimeZone;
 import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1071,10 +1073,15 @@ public class JSONToolTest extends AbstractTestCase {
         assertNotNull("Did not find ended element in json: " + json, endNode);
 
         // check ended value
-
         ContestTime contestTime = contest.getContestTime();
+        Calendar contestStart = contestTime.getContestStartTime();
 
-        Date date = contestTime.getContestStartTime().getTime();
+        long contestEndMS = contestStart.getTimeInMillis() + contestTime.getContestLengthMS(); 
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
+        calendar.setTimeInMillis(contestEndMS);
+        Date date = calendar.getTime();
+                
         SimpleDateFormat iso8601formatterWithMS = new SimpleDateFormat(Utilities.ISO_8601_TIMEDATE_FORMAT_WITH_MS);
         String iso8601DateString = iso8601formatterWithMS.format(date);
 
@@ -1086,8 +1093,12 @@ public class JSONToolTest extends AbstractTestCase {
         String actual = iso8601DateString.substring(0, 10); // only YYYY-MM-DD
         String expected = endValue.substring(0, 10); // only YYYY-MM-DD
 
-        // before fix, failed with date like: 2074-05-03 on 2022-03-02
-        assertEquals("Expected ended value", expected, actual);
+        // compare YYYY-MM-DD
+        assertEquals("Expected contest end date value", expected, actual);
+        
+        // compare full date string, ex. 2022-04-17T00:03:29.280-07
+        assertEquals("Expected contest end date value", iso8601DateString, endValue);
 
     }
+    
 }


### PR DESCRIPTION
### Description of what the PR does

Fixed unit test failure, aka #377, on i_295_develop_work branch.
 Expected ended value expected:<2022-04-1[7]> but was:<2022-04-1[6]>

Update unit tests from changes on develop branch, manual merge.   Merge/Copy fix for JSONToolTest, #377.

The  i_295_develop_work  gitLab build failed with #377 failure.

Other JUnit failure, #364 typo SumitMTC, Searched the i_295_develop_work  code did not find typo, all
were properly cased.

### Issue which the PR fixes

#377 - copies fix from develop to i_295_develop_work  branch

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1645]
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

This bug only happens when the JUnit is run less than 5 hours before midnight.

Run the JSONToolTest class/unit test.
The expected result is that all tests pass, including testtoStateJSONEnded test.