### PR TITLE
I 388 no longer prepend no when loading reject ini

### DIFF
--- a/src/edu/csus/ecs/pc2/core/JudgementLoader.java
+++ b/src/edu/csus/ecs/pc2/core/JudgementLoader.java
@@ -39,6 +39,7 @@ public class JudgementLoader {
     /**
      * Loads reject.ini file contents into Judgements.
      * 
+     * If finds reject.ini file, reads file. Adds Yes judgement, then prepends "No - " onto each entry from the reject.ini file and returns true.
      * 
      * If file contains a AC acronym judgement, then that line and its judgment name are used/loaded.
      * 
@@ -111,7 +112,7 @@ public class JudgementLoader {
 
             // Already loaded Yes
             if (!Judgement.ACRONYM_ACCEPTED.equals(getAcronym(line))) {
-                Judgement judgement = new Judgement(judgementText, acronym);
+                Judgement judgement = new Judgement("No - " + judgementText, acronym);
                 contest.addJudgement(judgement);
             }
         }

--- a/src/edu/csus/ecs/pc2/core/JudgementLoader.java
+++ b/src/edu/csus/ecs/pc2/core/JudgementLoader.java
@@ -39,7 +39,6 @@ public class JudgementLoader {
     /**
      * Loads reject.ini file contents into Judgements.
      * 
-     * If finds reject.ini file, reads file. Adds Yes judgement, then prepends "No - " onto each entry from the reject.ini file and returns true.
      * 
      * If file contains a AC acronym judgement, then that line and its judgment name are used/loaded.
      * 
@@ -112,7 +111,7 @@ public class JudgementLoader {
 
             // Already loaded Yes
             if (!Judgement.ACRONYM_ACCEPTED.equals(getAcronym(line))) {
-                Judgement judgement = new Judgement("No - " + judgementText, acronym);
+                Judgement judgement = new Judgement(judgementText, acronym);
                 contest.addJudgement(judgement);
             }
         }

--- a/test/edu/csus/ecs/pc2/core/InternalControllerTest.java
+++ b/test/edu/csus/ecs/pc2/core/InternalControllerTest.java
@@ -126,12 +126,12 @@ public class InternalControllerTest extends AbstractTestCase {
         assertEquals("Expecting judgements ", 7, judgements.length);
 
         String[] expected = { "AC;Yes", //
-                "WA001;Compilation Error", //
-                "WA002;Run-time Error", //
-                "WA003;Time Limit Exceeded", //
-                "WA004;Wrong Answer", //
-                "WA005;Presentation Error", //
-                "WA006;Other - Contact Staff", //
+                "WA001;No - Compilation Error", //
+                "WA002;No - Run-time Error", //
+                "WA003;No - Time Limit Exceeded", //
+                "WA004;No - Wrong Answer", //
+                "WA005;No - Presentation Error", //
+                "WA006;No - Other - Contact Staff", //
         };
 
         for (int i = 0; i < expected.length; i++) {

--- a/test/edu/csus/ecs/pc2/core/InternalControllerTest.java
+++ b/test/edu/csus/ecs/pc2/core/InternalControllerTest.java
@@ -126,12 +126,12 @@ public class InternalControllerTest extends AbstractTestCase {
         assertEquals("Expecting judgements ", 7, judgements.length);
 
         String[] expected = { "AC;Yes", //
-                "WA001;No - Compilation Error", //
-                "WA002;No - Run-time Error", //
-                "WA003;No - Time Limit Exceeded", //
-                "WA004;No - Wrong Answer", //
-                "WA005;No - Presentation Error", //
-                "WA006;No - Other - Contact Staff", //
+                "WA001;Compilation Error", //
+                "WA002;Run-time Error", //
+                "WA003;Time Limit Exceeded", //
+                "WA004;Wrong Answer", //
+                "WA005;Presentation Error", //
+                "WA006;Other - Contact Staff", //
         };
 
         for (int i = 0; i < expected.length; i++) {


### PR DESCRIPTION
### Description of what the PR does

No longer prepend "No - " for non-Yes judgements on load from reject.ini

Loading judgements from reject.ini always prepends "No - " to each judgement. 
Ex. "Incomplete Output" is loaded as "No - Incomplete Output"

Change to load "Incomplete Output" as "Incomplete Output"

### Issue which the PR fixes

#388 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1645]

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

There are two tests.

Add these entries in reject.ini
Incomplete output|IO
Excessive output|EO
Incorrect output format|IOF
Wrong Answer|WA
Runtime Error|RTE

Test 1.
add reject.ini as CDP/config/reject.ini
then start server
start admin
review Judgements text in Judgements tab

Test 2
pc2reset
add reject.ini in jake directory
then start server
start admin
review Judgements text in Judgements tab

**Expected behavior**: 

Expect judgements text:
Incomplete output
Excessive output
Incorrect output format
Wrong Answer
Runtime Error

**Actual behavior**: 

Actual judgements text:
No - Incomplete output
No - Excessive output
No - Incorrect output format
No - Wrong Answer
No - Runtime Error
