### PR TITLE
i387: remove invalid judgements from JSON event feed

### DIFF
--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -14,8 +14,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import edu.csus.ecs.pc2.clics.CLICSJudgementType;
-import edu.csus.ecs.pc2.clics.CLICSJudgementType.CLICS_JUDGEMENT_ACRONYM;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.Utilities;
@@ -26,6 +24,7 @@ import edu.csus.ecs.pc2.core.model.ClarificationAnswer;
 import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.model.ContestInformation;
 import edu.csus.ecs.pc2.core.model.ContestTime;
+import edu.csus.ecs.pc2.core.model.ElementId;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Judgement;
@@ -476,55 +475,12 @@ public class JSONTool {
 
             JudgementRecord judgementRecord = submission.getJudgementRecord();
             
-            //commented out; only fetch the judgement if it's needed (see below)
-//            Judgement judgement = model.getJudgement(judgementRecord.getJudgementId());
-            
             // only output its judgement and end times if this is the final judgement
             if (!judgementRecord.isPreliminaryJudgement()) {
 
-                //****************
-                //new code, copied from RunsPane.getJudgementResultString().  
-                //This code has the effect of attempting to use the Validator Result String, 
-                // if it exists, to determine what judgement type (acronym) to put into the JSON Event Feed
-                // rather than defaulting to using the JudgementType out of the Judgement Record directly.  
-                // This was added because PC2 assigns a default judgement type
-                // of "RTE" to any run which is neither a Yes nor a CE.  See Bug xxx.
-                //
-                //Note that this change does not take into account the possibility that a judge changed the judgement
-                //  manually but didn't cause the validator judgement to change.  If there is a validator
-                //  result in the judgementRecord, this code will put into the returned JSON the judgement type corresponding to 
-                //  the validator (not that from the current judgement result).
-                
-                String resultString = null;
-                boolean usingValidator = false;
-                
-                //check if there's a validator result
-                if (judgementRecord.isUsedValidator() && judgementRecord.getValidatorResultString() != null) {
-                    
-                    resultString = judgementRecord.getValidatorResultString();
-                    if (resultString!=null) {
-                        //try to convert the validator string to a known acronym
-                        CLICS_JUDGEMENT_ACRONYM acronym = CLICSJudgementType.getCLICSAcronymFromDisplayText(resultString);
-                        //check if we got back a judgement acronym
-                        if (acronym!=null) {
-                            resultString = acronym.name();
-                            usingValidator = true;
-                        }
-                    }
-                } 
-                
-                if (!usingValidator) {
-                    //no validator result; get the string representation of the judgement itself
-                    Judgement judgement = model.getJudgement(judgementRecord.getJudgementId());
-                    if (judgement != null) {
-                        resultString = judgement.getAcronym();
-                    }
-                }
-                //***************
-                
-                
-//                element.put("judgement_type_id", getJudgementType(judgement));
-                element.put("judgement_type_id", resultString);
+                // Fetch judgement_type_id from judgement acronym
+                String judgmentAcronym = getJudgementAcronymn(judgementRecord);
+                element.put("judgement_type_id", judgmentAcronym);
                 
                 Calendar wallElapsed = calculateElapsedWalltime(model, judgementRecord.getWhenJudgedTime() * 60000);
                 if (wallElapsed != null) {
@@ -536,6 +492,19 @@ public class JSONTool {
         }
         
         return element;
+    }
+
+    /**
+     * Fetch Judgement Acronym for run judgement.
+     * 
+     * @param judgementRecord
+     * @return judgement acronym.
+     */
+    private String getJudgementAcronymn(JudgementRecord judgementRecord) {
+        
+        ElementId judgementId = judgementRecord.getJudgementId();
+        Judgement judgement = model.getJudgement(judgementId);
+        return judgement.getAcronym();
     }
 
     public String getSubmissionId(Run submission) {

--- a/test/edu/csus/ecs/pc2/core/model/SampleContest.java
+++ b/test/edu/csus/ecs/pc2/core/model/SampleContest.java
@@ -1892,12 +1892,13 @@ public class SampleContest {
      * 
      * @param contest
      * @param runInfoLine
+     * @param computerJudged 
      * @throws Exception 
      * @throws FileSecurityException 
      * @throws ClassNotFoundException 
      * @throws IOException 
      */
-    public static void addRunFromInfo(IInternalContest contest, String runInfoLine) throws Exception {
+    public static void addRunFromInfo(IInternalContest contest, String runInfoLine, boolean computerJudged) throws Exception {
 
         // get 5th judge
         ClientId judgeId = contest.getAccounts(Type.JUDGE).elementAt(4).getClientId();
@@ -1945,7 +1946,7 @@ public class SampleContest {
         if (solved) {
             judgementId = yesJudgement.getElementId();
         }
-        JudgementRecord judgementRecord = new JudgementRecord(judgementId, judgeId, solved, false);
+        JudgementRecord judgementRecord = new JudgementRecord(judgementId, judgeId, solved, computerJudged);
         judgementRecord.setSendToTeam(sendToTeams);
 
         try {
@@ -1962,9 +1963,14 @@ public class SampleContest {
 
     }
 
+    public static void addRunFromInfo(IInternalContest contest, String runInfoLine) throws Exception {
+        addRunFromInfo(contest, runInfoLine, false);
+    }
+    
+    
     public static void addRunFromInfo(IInternalContest contest, String[] runInfoLines) throws Exception {
         for (String runInfoLine  : runInfoLines) {
-            addRunFromInfo(contest, runInfoLine);
+            addRunFromInfo(contest, runInfoLine, false);
         }
     }
 

--- a/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/JSONToolTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import edu.csus.ecs.pc2.clics.CLICSJudgementType;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.list.AccountComparator;
@@ -1099,5 +1100,186 @@ public class JSONToolTest extends AbstractTestCase {
         // compare full date string, ex. 2022-04-17T00:03:29.280-07
         assertEquals("Expected contest end date value", iso8601DateString, endValue);
 
+    }
+    
+    
+    /**
+     * List of override judgements from CLICSJudgementType.
+     * 
+     * @return list of override judgements from {@link CLICSJudgementType} judgementStringMappings
+     */
+    String [] getJudgementMappingList() {
+        
+        String[] JudgementMappingList = {
+                "Accepted", //
+                "Yes", //
+                "Correct", //
+                "Rejected", //
+                "Incorrect", //
+                "No", //
+                "Wrong Answer", //
+                "No - Wrong Answer", //
+                "Time Limit Exceeded", //
+                "Time-Limit Exceeded", //
+                "No - Time Limit Exceeded", //
+                "No - Time-Limit Exceeded", //
+                "Run Time Error", //
+                "Runtime Error", //
+                "Run-Time Error", //
+                "No - Run Time Error", //
+                "No - Runtime Error", //
+                "No - Run-Time Error", //
+                "Compile Error", //
+                "Compiler Error", //
+                "Compilation Error", //
+                "No - Compile Error", //
+                "No - Compiler Error", //
+                "No - Compilation Error", //
+                "Accepted - Presentation Error", //
+                "Output Limit Exceeded", //
+                "No - Output Limit Exceeded", //
+                "Presentation Error", //
+                "Output Format Error", //
+                "Incorrect Output Format", //
+                "No - Presentation Error", //
+                "No - Output Format Error", //
+                "No - Incorrect Output Format", //
+                "Excessive Output", //
+                "Incomplete Output", //
+                "No Output", //
+                "Presentation Error", //
+                "No - Excessive Output", //
+                "No - Incomplete Output", //
+                "No - No Output", //
+                "No - Presentation Error", //
+                "Wallclock Time Limit Exceeded", //
+                "Wall-clock Time Limit Exceeded", //
+                "Wall Clock Time Limit Exceeded", //
+                "No - Wallclock Time Limit Exceeded", //
+                "No - Wall-clock Time Limit Exceeded", //
+                "No - Wall Clock Time Limit Exceeded", //
+                "Idleness Limit Exceeded", //
+                "Idle Limit Exceeded", //
+                "No - Idleness Limit Exceeded", //
+                "No - Idle Limit Exceeded", //
+                "Time Limit Exceeded - Correct Output", //
+                "Time-Limit Exceeded - Correct Output", //
+                "Time Limit Exceeded - Wrong Answer", //
+                "Time-Limit Exceeded - Wrong Answer", //
+                "Time Limit Exceeded - Presentation Error", //
+                "Time-Limit Exceeded - Presentation Error", //
+                "Time Limit Exceeded - Excessive Output", //
+                "Time-Limit Exceeded - Excessive Output", //
+                "Time Limit Exceeded - Incomplete Output", //
+                "Time-Limit Exceeded - Incomplete Output", //
+                "Time Limit Exceeded - No Output", //
+                "Time-Limit Exceeded - No Output", //
+                "Memory Limit Exceeded", //
+                "Memory-Limit Exceeded", //
+                "No - Memory Limit Exceeded", //
+                "No - Memory-Limit Exceeded", //
+                "Runtime Error - Correct Output", //
+                "Run-time Error - Correct Output", //
+                "Run Time Error - Correct Output", //
+                "Runtime Error - Wrong Answer", //
+                "Run-time Error - Wrong Answer", //
+                "Run Time Error - Wrong Answer", //
+                "Runtime Error - Presentation Error", //
+                "Run-time Error - Presentation Error", //
+                "Run Time Error - Presentation Error", //
+                "Runtime Error - Excessive Output", //
+                "Run-time Error - Excessive Output", //
+                "Run Time Error - Excessive Output", //
+                "Runtime Error - Incomplete Output", //
+                "Run-time Error - Incomplete Output", //
+                "Run Time Error - Incomplete Output", //
+                "Runtime Error - No Output", //
+                "Run-time Error - No Output", //
+                "Run Time Error - No Output", //
+                "Compile Time Limit Exceeded", //
+                "Compile Time-Limit Exceeded", //
+                "No - Compile Time Limit Exceeded", //
+                "No - Compile Time-Limit Exceeded", //
+                "Security Violation", //
+                "Illegal Function", //
+                "Judging Error", //
+                "Submission Error", //
+                "Contact Staff", //
+                "Other Contact Staff", //
+                "Other - Contact Staff", //
+        };
+        
+        return JudgementMappingList;
+    }
+    
+    /**
+     * A single test where the judgement acronym from JSON does not match run from model judgement acronym.
+     * 
+     * @throws Exception
+     */
+    public void testForInvalidAcronym() throws Exception {
+        
+        SampleContest sampleContest = new SampleContest();
+        
+        IInternalContest contest = sampleContest.createStandardContest();
+        
+        String runInfoLine = "1,1,A,1,No,No,4"; // 0 (a No before first yes Security Violation)
+        SampleContest.addRunFromInfo(contest, runInfoLine, true);
+        
+        IInternalController conroller = null;
+        JSONTool jsonTool = new JSONTool(contest,conroller);
+
+        Run firstRun = contest.getRuns()[0];
+        assertTrue(firstRun.isJudged());
+        Judgement judgement = contest.getJudgement(firstRun.getJudgementRecord().getJudgementId());
+        String expectedJudgementAcroynym = judgement.getAcronym();
+
+        //        add(new JudgementMapping("Incomplete Output",CLICS_JUDGEMENT_ACRONYM.IO));
+        firstRun.getJudgementRecord().setValidatorResultString("Incomplete Output");
+
+        ObjectNode node = jsonTool.convertJudgementToJSON(firstRun);
+
+        String judgementAcronym = node.get("judgement_type_id").toString();
+
+        judgementAcronym = judgementAcronym.replaceAll("\"", "");   // strip off " around judgement acronym, "RTE" to RTE
+
+        assertEquals("Expected run judgement acronym ", expectedJudgementAcroynym, judgementAcronym);
+        
+    }
+    
+    /**
+     * Test very JudgementMapping udgement acronym from JSON does not match run from model judgement acronym.
+     * 
+     * @throws Exception
+     */
+    public void testForInvalidAcronymFromMappgingList() throws Exception {
+        
+        SampleContest sampleContest = new SampleContest();
+        
+        IInternalContest contest = sampleContest.createStandardContest();
+        
+        String runInfoLine = "1,1,A,1,No,No,4"; // 0 (a No before first yes Security Violation)
+        SampleContest.addRunFromInfo(contest, runInfoLine, true);
+        
+        IInternalController conroller = null;
+        JSONTool jsonTool = new JSONTool(contest,conroller);
+
+        Run firstRun = contest.getRuns()[0];
+        assertTrue(firstRun.isJudged());
+        Judgement judgement = contest.getJudgement(firstRun.getJudgementRecord().getJudgementId());
+        String expectedJudgementAcroynym = judgement.getAcronym();
+
+        String [] overRideJudgements =getJudgementMappingList();
+        for (String overrideString : overRideJudgements) {
+            
+            firstRun.getJudgementRecord().setValidatorResultString(overrideString);
+            ObjectNode node = jsonTool.convertJudgementToJSON(firstRun);
+            
+            String judgementAcronym = node.get("judgement_type_id").toString();
+            
+            judgementAcronym = judgementAcronym.replaceAll("\"", "");   // strip off " around judgement acronym, "RTE" to RTE
+            
+            assertEquals("Expected run judgement acronym ", expectedJudgementAcroynym, judgementAcronym);
+        }
     }
 }


### PR DESCRIPTION
### Description of what the PR does

Removes invalid judgement acronyms (judgements) from event feed JSON.

remove judgement (acronym) mapping from JSONTool to fix invalid
judgement acronyms (acronyms not found in model).

This is the first step in standardizing and formalizing judgement mapping.
More details/step can be found in #373 (only one place to assign judgement and acronym)
and #187 (manage mapping)

### Issue which the PR fixes

#387

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1645]
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start a server, loading samps/contests/SumitHello.
Submit a program which produces no output for the problem (samps/src/nooutput.c or samps/src/NoOutput.java will work).
Generate an EventFeedJSON report; examine the listed "judgement_types" and the "judgement_type_id" for the submitted run in the report.

Expected behavior:
The submission should have an acronym ("judgement_type_id") which exists in the list of "judgement_types" in the Event Feed.

Actual behavior:
The submission has a "judgement_type_id" of "IO", which is not defined in the "judgement_types" for the contest.