### PR TITLE
I397 shadow exception logging

### DIFF
--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -464,9 +464,9 @@ public class RemoteEventFeedMonitor implements Runnable {
                                             } catch (Exception e) {
                                                 // TODO design error handling reporting
                                                 if (Utilities.isDebugMode()) {
-                                                    System.err.println("Exception submitting run for: " + event + e);
+                                                    System.err.println("Exception submitting run for event: " + event + ": " + e);
                                                 }
-                                                log.log(Level.WARNING, "Exception submitting run for: " + event, e);
+                                                log.log(Level.WARNING, "Exception submitting run for event: " + event + ": ", e);
                                                 e.printStackTrace();
                                             }
                                         }

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -464,10 +464,9 @@ public class RemoteEventFeedMonitor implements Runnable {
                                             } catch (Exception e) {
                                                 // TODO design error handling reporting
                                                 if (Utilities.isDebugMode()) {
-                                                    System.err.println("Exception submitting run for: " + event);
+                                                    System.err.println("Exception submitting run for: " + event + e);
                                                 }
-                                                log.log(Level.WARNING, "Exception submitting run for: \\" + event);
-                                                
+                                                log.log(Level.WARNING, "Exception submitting run for: " + event, e);
                                                 e.printStackTrace();
                                             }
                                         }
@@ -475,9 +474,9 @@ public class RemoteEventFeedMonitor implements Runnable {
                                     } catch (Exception e) {
                                         // TODO design error handling reporting (logging?)
                                         if (Utilities.isDebugMode()) {
-                                            System.err.println("Exception processing event: " + e.toString() + ": event = " + event);
+                                            System.err.println("Exception processing event: " + event + "\n " + e.toString());
                                         }
-                                        log.log(Level.WARNING, "Exception processing event: " + e.toString() + ": event = " + event);
+                                        log.log(Level.WARNING, "Exception processing event: " + event, e);
 
                                         e.printStackTrace();
                                     }
@@ -548,9 +547,9 @@ public class RemoteEventFeedMonitor implements Runnable {
                                     } catch (Exception e) {
                                         // TODO design error handling reporting (logging?)
                                         if (Utilities.isDebugMode()) {
-                                            System.err.println("Exception processing event: " + event);
+                                            System.err.println("Exception processing event: " + event + "\n" + e.toString());
                                         }
-                                        log.log(Level.SEVERE, "Exception processing event: " + event);
+                                        log.log(Level.SEVERE, "Exception processing event: " + event, e);
                                         e.printStackTrace();
                                     }
 
@@ -566,9 +565,9 @@ public class RemoteEventFeedMonitor implements Runnable {
                         } catch (Exception e) {
                             // TODO design error handling reporting (logging?)
                             if (Utilities.isDebugMode()) {
-                                System.err.println("Exception processing event: " + e.toString() + ": event = " + event);
+                                System.err.println("Exception processing event: " + event + "\n" + e.toString());
                             }
-                            log.log(Level.SEVERE, "Exception processing event: " + e.toString() + ": event = " + event);
+                            log.log(Level.SEVERE, "Exception processing event: " + event, e);
                             e.printStackTrace();
                         } 
                     }
@@ -581,7 +580,7 @@ public class RemoteEventFeedMonitor implements Runnable {
                 if (Utilities.isDebugMode()) {
                     System.err.println("Exception reading event from stream: " + e.toString() + ": event = " + event);
                 }
-                log.log(Level.SEVERE, "Exception reading event from stream: " + e.toString() + ": event = " + event);
+                log.log(Level.SEVERE, "Exception reading event from stream: " + event, e);
                 e.printStackTrace();
             }
         } // end else


### PR DESCRIPTION
### Description of what the PR does
Adds logging of exceptions in catch clauses where previously only a text message was logged.

### Issue which the PR fixes
Fixes #397 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.0, Eclipse Version: 2019-12 (4.14.0) Build id: 20191212-1212; Java 1.8_201

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Obtain access to a Primary CCS capable of generating an Event Feed containing submissions.
  - For example, https://open.kattis.com/clics-api/contests/prognova20/ can be used, along with the PC2 credentials allowing access to Kattis.  Alternatively, a separate PC2 Primary could be set up, including ensuring there are submissions in the Primary CCS and also including running an Event Feed generator on the Primary.
- Start a Shadow PC2 server configured for a contest which has NO teams.
  - Ensure the server is configured with a CDP matching the Primary.
- Start an Admin
  - On the Settings tab, configure Shadow Mode to connect to the Primary CCS:
    - Enable CCS Test mode (required for Shadow to work).
    - Enable Shadow Mode.
    - Enter the Primary CCS URL along with Login and Password information .
  - On the Accounts tab, ensure that a Feeder1 account is defined.
- Start an Event Feeder client (pc2ef)
- Select "Shadow Mode" on the EF client.
- Click "Start Shadowing".

The Shadow system should begin fetching the Primary CCS Event Feed,  finding submissions in the Event Feed.  Since there are no teams in the Shadow CCS (see above), the call to `RemoteRunSubmitter.submitRun` will throw an exception.

Examine the Shadow FEEDER1 log; verify that the exception itself is shown in the log.
