### PR TITLE
i401: updated shadow classes to support highlighting of mismatched

### DIFF
--- a/src/edu/csus/ecs/pc2/core/standings/json/TeamScoreRow.java
+++ b/src/edu/csus/ecs/pc2/core/standings/json/TeamScoreRow.java
@@ -16,6 +16,8 @@ public class TeamScoreRow implements Comparable<TeamScoreRow> {
     //    {"rank":1, 
     //     "team_id":325958,
 
+    public enum TeamScoreRowFields {RANK, NAME, SOLVED, TIME};
+    
     @JsonProperty
     private int rank;
     

--- a/src/edu/csus/ecs/pc2/shadow/ShadowScoreboardRowComparison.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowScoreboardRowComparison.java
@@ -1,14 +1,19 @@
 package edu.csus.ecs.pc2.shadow;
 
+import java.util.ArrayList;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.csus.ecs.pc2.core.standings.json.StandingScore;
 import edu.csus.ecs.pc2.core.standings.json.TeamScoreRow;
 
 /**
  * This class encapsulates the "matching" status between two {@link TeamScoreRow} objects.
  * It provides a method {@link #isMatch()} indicating whether the two contained TeamScoreRows
  * match.  
+ * 
+ * The class also supports obtaining a List of the fields which do not match (see {@link #getMismatchedFields(TeamScoreRow, TeamScoreRow)}.
  * 
  * Note that the definition of "match" is determined by first requiring that both contained
  * TeamScoreRows be non-null, and then by the value returned by {@link TeamScoreRow#matches(TeamScoreRow)}.
@@ -21,7 +26,7 @@ public class ShadowScoreboardRowComparison {
     private TeamScoreRow sb1Row ;
     private TeamScoreRow sb2Row ;
     private boolean match ;
-    
+    private ArrayList<Integer> mismatchedFieldList = new ArrayList<Integer>();
     
     public TeamScoreRow getSb1Row() {
         return sb1Row;
@@ -49,18 +54,71 @@ public class ShadowScoreboardRowComparison {
      * Updates the status of the "match" variable in this ScoreboardRowComparison object indicating whether 
      * the two scoreboard rows in this ScoreboardRowComparison object match each other. 
      * 
-     * Note that the definition of mathching is that both scoreboard row objects are non-null
+     * Note that the definition of matching is that both scoreboard row objects are non-null
      * and then that {@link TeamScoreRow#matches(TeamScoreRow)} is true.
      */
     private void updateMatch() {
         if (sb1Row!=null && sb2Row!=null) {
             this.match = sb1Row.matches(sb2Row);
+            setMismatchedFieldList(getMismatchedFields(sb1Row, sb2Row));
         } else {
             //one or both rows are null; define that as non-matching
             this.match = false;
         }
     }
     
+    /**
+     * Returns a List of Integers giving the ordinal numbers of the fields which do not match between the two specified TeamScoreRows.
+     * 
+     * @param sb1Row the first TeamScoreRow to be compared.
+     * @param sb2Row the second TeamScoreRow to be compared.
+     * 
+     * @return an ArrayList containing the ordinal numbers of any fields which do not match between the specified {@link TeamScoreRow}s.
+     *          If either of the supplied TeamScoreRows is null, an empty (but not null) List is returned.
+     */
+    private ArrayList<Integer> getMismatchedFields(TeamScoreRow sb1Row, TeamScoreRow sb2Row) {
+        
+        //start with an empty list (no mismatched fields)
+        ArrayList<Integer> mismatchedFields = new ArrayList<Integer>();
+
+        if (sb2Row!=null && sb2Row!=null) {
+            
+            if (sb1Row.getRank() != sb2Row.getRank()) {
+                mismatchedFields.add(TeamScoreRow.TeamScoreRowFields.RANK.ordinal());
+            }
+            if (!(sb1Row.getTeamName().contentEquals(sb2Row.getTeamName()))) {
+                mismatchedFields.add(TeamScoreRow.TeamScoreRowFields.NAME.ordinal());
+            }
+            StandingScore sb1RowScore = sb1Row.getScore();
+            StandingScore sb2RowScore = sb2Row.getScore();
+            if (sb1RowScore.getNum_solved() != sb2RowScore.getNum_solved()) {
+                mismatchedFields.add(TeamScoreRow.TeamScoreRowFields.SOLVED.ordinal());
+            }
+            if (sb1RowScore.getTotal_time() != sb2RowScore.getTotal_time()) {
+                mismatchedFields.add(TeamScoreRow.TeamScoreRowFields.TIME.ordinal());
+            } 
+        }
+        
+        return mismatchedFields;
+
+    }
+
+    /**
+     * Returns a List of the fields in this ShadowScoreboardRowComparison which do not match.
+     * The returned list may be empty, meaning either there are no mismatched fields or else
+     * one or the other (or both) of the {@link TeamScoreRow}s in this {@link ShadowScoreboardRowComparison}
+     * are null, but the returned list will never be null.
+     * 
+     * @return an ArrayList<Integer> of the ordinal numbers of mismatched fields between the two {@link TeamScoreRow}s in this object.
+     */
+    public ArrayList<Integer> getMismatchedFieldList() {
+        return mismatchedFieldList;
+    }
+
+    private void setMismatchedFieldList(ArrayList<Integer> mismatchedFieldList) {
+        this.mismatchedFieldList = mismatchedFieldList;
+    }
+
     /**
      * Returns a JSON string representation of this ShadowScoreboardRowComparison object.
      */

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -483,7 +483,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
                 String client = clientId.getName();
                 String msg = "";
                 msg += "Your login account (" + client + ") does not have permission to edit (update) runs.\n\n" ;
-                msg += "You will need to have an Administrator update your account permissions in order to be able to update runs.";
+                msg += "You will need to have an Administrator update your account permissions (by adding the \"Edit a Run\" permission) in order to be able to update runs.";
                 
                 JOptionPane.showMessageDialog(this, msg, "Missing Edit Permission", JOptionPane.WARNING_MESSAGE);
                 log.log (Log.WARNING, "Client attempted to update run without having Edit Run permission");


### PR DESCRIPTION
### Description of what the PR does:

Fixes highlighting in Shadow Scoreboard Compare so that individual mismatched _fields_ are highlighted (red), rather than just every mismatched _row_ being highlighted.  Also demonstrates that generating Scoreboard comparisons does not throw JAXB exceptions, at least on the platform on which it was tested.

### Issue which the PR fixes

Fixes #401 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.1; Eclipse Version: 2019-12 (4.14.0) Build id: 20191212-1212;  Java 1.8_201.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

- Start a server configured with a contest identical to one which is configured in a Remote CCS which is able to generate an Event Feed and for which the final scoreboard is available for comparison.
- Start (at least one) AJ configured to judge the contest problems.
- Start an EF Client, log in as ef1.
- Ensure the Shadow "configuration" points to the correct Remote CCS and has valid credentials.
- Select "Shadow Mode".
- Click "Start Shadowing".
- Click "Compare Runs".  This will display a grid comparing runs (submissions) between PC2 and the Remote CCS.  (Note:  there is currently a serious refresh-delay before Shadow grids update; see Issue #267.)
- Click "Scoreboard Compare".  This will display a grid comparing PC2 and Remote CCS scoreboards (again, potentially with a significant "refresh delay"

If the Shadow has not yet finished pulling the Event Feed from the Remote CCS, the Scoreboard Compare display will show a comparison between the PC2 and Remote scoreboards with fields that do not matched highlighted RED.  Clicking the "Refresh" button will update the display (again, with the issue of significant delay).

If the Shadow has finished pulling all Remote events and the PC2 scoreboard does not completely match the Remote CCS scoreboard (i.e., all fields in all rows are green), examine the "Compare Runs" grid.  If there are any runs where PC2 and the Remote CCS disagree, select those runs and click "Resolve Selected".  Reexamine the Scoreboard Compare grid; it should now be completely green.