### PR TITLE
i406: convert Scoreboard classes to use Jackson instead of JAXB.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -54,5 +54,8 @@
 	<classpathentry kind="lib" path="vendor/lib/yasson-1.0.jar"/>
 	<classpathentry kind="lib" path="vendor/lib/javax.ws.rs-api-2.1.jar"/>
 	<classpathentry kind="lib" path="vendor/lib/viva.jar"/>
+	<classpathentry kind="lib" path="vendor/lib/jackson-dataformat-xml-2.5.4.jar"/>
+	<classpathentry kind="lib" path="vendor/lib/stax2-api-4.2.1.jar"/>
+	<classpathentry kind="lib" path="vendor/lib/jackson-module-jaxb-annotations-2.5.4.jar"/>
 	<classpathentry kind="output" path=".classes"/>
 </classpath>

--- a/src/edu/csus/ecs/pc2/core/standings/ContestStandings.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ContestStandings.java
@@ -10,11 +10,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
- * Root for the Default Scoring Algorithm XML maraling from XML into POJOs. contestStanding element.
+ * This class encapsulates a collection of data representing the current contest standings.  
+ * A ContestStandings consists of a single {@link StandingsHeader} along with a List of {@link TeamStanding}s.)
+ * This class is used as a target during conversion (deserialization) of an XML representation of contest standings into a POJO.
+ * Such deserialization is commonly applied to the XML contest standing string produced by {@link DefaultScoringAlgorithm#getStandings()}.
  * 
- * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ * @author Douglas A. Lane, John Clevenger <pc2@ecs.csus.edu>
  *
  */
 @XmlRootElement(name = "contestStandings")
@@ -25,6 +30,8 @@ public class ContestStandings {
     private StandingsHeader standingsHeader;
 
     @XmlElement(name = "teamStanding")
+    @JacksonXmlProperty(localName = "teamStanding")
+    @JacksonXmlElementWrapper(useWrapping = false)
     private List<TeamStanding> teamStandings = null;
 
     public StandingsHeader getStandingsHeader() {

--- a/src/edu/csus/ecs/pc2/core/standings/ProblemSummaryInfo.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ProblemSummaryInfo.java
@@ -12,7 +12,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @author Douglas A. Lane <pc2@ecs.csus.edu>
  *
  */
-@XmlRootElement(name = "c")
+@XmlRootElement(name = "problemSummaryInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ProblemSummaryInfo {
 

--- a/src/edu/csus/ecs/pc2/core/standings/ScoreboardUtilites.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ScoreboardUtilites.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
@@ -42,13 +43,20 @@ public class ScoreboardUtilites {
      * @param xmlString
      * @return
      * @throws JAXBException
+     * @throws IOException 
+     * @throws JsonMappingException 
+     * @throws JsonParseException 
      */
-    public static ContestStandings createContestStandings(String xmlString) throws JAXBException {
+    public static ContestStandings createContestStandings(String xmlString) throws JAXBException, JsonParseException, JsonMappingException, IOException {
 
-        JAXBContext jaxbContext = JAXBContext.newInstance(ContestStandings.class);
-        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-        ContestStandings contestStandings = (ContestStandings) jaxbUnmarshaller.unmarshal(new InputSource(new StringReader(xmlString)));
-        return contestStandings;
+        //JAXB was deprecated in Java 9 and removed entirely in Java 11; don't use it...
+//        JAXBContext jaxbContext = JAXBContext.newInstance(ContestStandings.class);
+//        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+//        ContestStandings contestStandings = (ContestStandings) jaxbUnmarshaller.unmarshal(new InputSource(new StringReader(xmlString)));
+        
+        XmlMapper xmlMapper = new XmlMapper();
+        ContestStandings standings = xmlMapper.readValue(xmlString, ContestStandings.class);
+        return standings;
     }
 
     /**
@@ -74,7 +82,7 @@ public class ScoreboardUtilites {
         return xml;
     }
     
-    public static ContestStandings createContestStandings(IInternalContest contest) throws JAXBException, IllegalContestState {
+    public static ContestStandings createContestStandings(IInternalContest contest) throws JAXBException, IllegalContestState, JsonParseException, JsonMappingException, IOException {
         String xmlString = ScoreboardUtilites.createScoreboardXML(contest);
         return createContestStandings(xmlString);
     }

--- a/src/edu/csus/ecs/pc2/core/standings/StandingsHeader.java
+++ b/src/edu/csus/ecs/pc2/core/standings/StandingsHeader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings;
 
 import java.io.Serializable;
@@ -10,9 +10,23 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * This class defines the header which appears at the top of a {@link ContestStandings} object.  
+ * (A {@link ContestStandings} consists of a single {@link StandingsHeader} followed by a List of {@link TeamStanding}s.)
+ * This class is used as a target during conversion (deserialization) of an XML representation of a StandingsHeader into a POJO.
+ * 
+ * Note that the @JsonIgnoreProperties(ignoreUnknown=true) annotation is necessary because the XML returned by the 
+ * DefaultScoringAlgorithm class (which is frequently converted to a StandingsHeader object using, for example, 
+ * the Jackson XMLMapper class), contains an attribute "CurrentDate" which this class doesn't define.
+ * 
+ * @author John Clevenger, PC2 Development Team (pc2@ecs.csus.edu)
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown=true)  
 @XmlRootElement(name = "standingsHeader")
 @XmlAccessorType (XmlAccessType.FIELD)
 public class StandingsHeader implements Serializable {

--- a/src/edu/csus/ecs/pc2/core/standings/TeamStanding.java
+++ b/src/edu/csus/ecs/pc2/core/standings/TeamStanding.java
@@ -9,17 +9,30 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
 /**
- * teamStanding element.
+ * This class defines an entry (one for each team) which appears in a List of TeamStandings in a {@link ContestStandings} object.  
+ * (A {@link ContestStandings} consists of a single {@link StandingsHeader} followed by a List of {@link TeamStanding}s.)
+ * This class is used as a target during conversion (deserialization) of an XML representation of a TeamStanding into a POJO.
  * 
- * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ * Note that the @JsonIgnoreProperties(ignoreUnknown=true) annotation is supplied in the event the XML returned by the 
+ * DefaultScoringAlgorithm class (which is frequently converted to a ContestStandings object using, for example, 
+ * the Jackson XMLMapper class), contains attributes which this class doesn't define.
+ *
+ * @author Douglas A. Lane, John Clevenger, <pc2@ecs.csus.edu>
  *
  */
+@JsonIgnoreProperties(ignoreUnknown=true)
 @XmlRootElement(name = "teamStanding")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TeamStanding {
 
     @XmlElement(name = "problemSummaryInfo")
+    @JacksonXmlProperty(localName = "problemSummaryInfo")
+    @JacksonXmlElementWrapper(useWrapping = false)
     private List<ProblemSummaryInfo> problemSummaryInfos = null;
 
     @XmlAttribute
@@ -82,6 +95,10 @@ public class TeamStanding {
     @XmlAttribute
     private String totalAttempts;
 
+//    @XmlAttribute
+//    @XmlElement(name = "problemSummaryInfos")
+//    @JacksonXmlProperty(localName = "problemSummaryInfos")
+//    @JacksonXmlElementWrapper(useWrapping = false)
     public List<ProblemSummaryInfo> getProblemSummaryInfos() {
         return problemSummaryInfos;
     }

--- a/src/edu/csus/ecs/pc2/services/core/ScoreboardJson.java
+++ b/src/edu/csus/ecs/pc2/services/core/ScoreboardJson.java
@@ -9,8 +9,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.xml.sax.SAXException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.StaticLog;
@@ -36,9 +34,9 @@ public class ScoreboardJson {
      * @return
      * @throws IllegalContestState
      * @throws JAXBException
-     * @throws JsonProcessingException 
+     * @throws IOException 
      */
-    public String createJSON(IInternalContest contest) throws IllegalContestState, JAXBException, JsonProcessingException {
+    public String createJSON(IInternalContest contest) throws IllegalContestState, JAXBException, IOException {
         return createJSON(contest, null);
     }
 
@@ -50,9 +48,9 @@ public class ScoreboardJson {
      * @throws IllegalContestState
      * @return
      * @throws JAXBException
-     * @throws JsonProcessingException 
+     * @throws IOException 
      */
-    public String createJSON(IInternalContest contest, Log log) throws IllegalContestState, JAXBException, JsonProcessingException {
+    public String createJSON(IInternalContest contest, Log log) throws IllegalContestState, JAXBException, IOException {
 
         DefaultScoringAlgorithm scoringAlgorithm = new DefaultScoringAlgorithm();
 
@@ -73,12 +71,11 @@ public class ScoreboardJson {
      * @param xml
      * @return
      * @throws JAXBException
-     * @throws JsonProcessingException 
      * @throws ParserConfigurationException
      * @throws SAXException
      * @throws IOException
      */
-    public String createJSON(String xml) throws JAXBException, JsonProcessingException {
+    public String createJSON(String xml) throws JAXBException, IOException {
         ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(xml);
         String json = ScoreboardJsonUtility.createScoreboardJSON(contestStandings);
         return json;

--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -1,6 +1,7 @@
 // Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Date;
@@ -11,8 +12,6 @@ import java.util.Vector;
 import java.util.logging.Level;
 
 import javax.xml.bind.JAXBException;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.csus.ecs.pc2.clics.CLICSJudgementType;
 import edu.csus.ecs.pc2.clics.CLICSJudgementType.CLICS_JUDGEMENT_ACRONYM;
@@ -420,7 +419,7 @@ public class ShadowController {
         String pc2Json ;
         try {
             pc2Json = sbJsonObject.createJSON(localContest, log);
-        } catch (JsonProcessingException | IllegalContestState | JAXBException e) {
+        } catch (IllegalContestState | JAXBException | IOException e) {
             log.log(Log.WARNING,"Exception creating PC2 scoreboard JSON: " + e.getMessage(), e);
             return null;
         }


### PR DESCRIPTION

### Description of what the PR does
Removes use of JAXB routines to convert DefaultScoringAlgorithm XML output, replacing them with equivalent routines using the Jackson XML library.    JAXB was removed from Java 11; Jackson is a separate library included
with PC2 distributions.

The changes basically involved switching from using JAXB to Jackson XMLMapper, plus tagging all XML-scoreboard-related
classes with Jackson annotations so that the Jackson XMLMapper can properly deserialize XML ContestStandings from the
DefaultScoringAlgorithm.

### Issue which the PR fixes
Fixes #406.


### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.1; Eclipse Version: 2019-12 (4.14.0) Build id: 20191212-1212; Java 1.8_201.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- On a system using Java 11 or greater:
  -  start a Server configured with a contest matching the configuration of a Remote CCS which can serve and Event Feed.
  - Start an Event Feed client.
  - Select "Shadow Mode"
  - Click "Start Shadowing"
  - Click "Compare Scoreboards".
- Verify that the scoreboards for both PC2 and the Remote CCS are displayed, showing differences (if any) highlighted in red.

Note that prior to this fix, the Scoreboard Compare operation would work on a Java 8 system but would fail when using Java 11.
