### PR TITLE
i420: added logging with various reasons for skipping event feed lines.

### DIFF
--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -573,6 +573,18 @@ public class RemoteEventFeedMonitor implements Runnable {
                             log.log(Level.SEVERE, "Exception processing event: " + event, e);
                             e.printStackTrace();
                         } 
+                    } else {
+                        
+                        //we're skipping an event feed input line -- log the reason
+                        if (event.length()<=0) {
+                            log.log(Level.INFO, "Skipping event feed input line (length is " + event.length() + ")");
+                        } else if (!event.trim().startsWith("{")) {
+                            log.log(Level.INFO, "Skipping event feed input line (does not start with \"{\"): " + event.toString());
+                        } else if (!event.trim().endsWith("}")) {
+                            log.log(Level.INFO, "Skipping event feed input line (does not end with \"}\"): " + event.toString());                            
+                        } else {
+                            log.log(Level.WARNING, "Skipping event feed input line (sorry - no explanation for why): " + event.toString());
+                        }
                     }
                     
                     event = reader.readLine();


### PR DESCRIPTION
Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Adds logging when the RemoteEventFeedMonitor skips an input line.

### Issue which the PR fixes
Partial fix for #420 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10; Java 8
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Read an event feed which contains blank and/or illegal lines (not starting with "{" or "}"