### PR TITLE
I432 command line suppress connections and logins grids

### DIFF
--- a/src/edu/csus/ecs/pc2/core/IInternalController.java
+++ b/src/edu/csus/ecs/pc2/core/IInternalController.java
@@ -292,6 +292,18 @@ public interface IInternalController {
      * @return true if using GUI, false if using text only
      */
     boolean isUsingGUI();
+    
+    /**
+     * Is this controller suppressing display of Connections grids.
+     * @return true if GUIs using this controller should suppress display of Connections grids.
+     */
+    boolean isSuppressConnectionsPaneDisplay();
+
+    /**
+     * Is this controller suppressing display of Logins grids.
+     * @return true if GUIs using this controller should suppress display of Logins grids.
+     */
+    boolean isSuppressLoginsPaneDisplay();
 
     /**
      * Update site in contest, send site update packet to other servers and admins.

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -182,6 +182,14 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
 //    private static final String LOAD_YAML_OPTION_STRING = "--loadyaml";
 
     private static final String PASSWORD_OPTION_STRING = "--password";
+    
+    //the following are used to support suppression of loading specific large grids
+    // which seem to cause problems
+    private static final String NO_CONNECTIONS_PANE_OPTION_STRING = "--noconnectionspane";
+    private static final String NO_LOGINS_PANE_OPTION_STRING = "--nologinspane";
+    
+    private boolean suppressConnectionsPaneDisplay = false;
+    private boolean suppressLoginsPaneDisplay = false;
 
     /**
      * The port that the server will listen on.
@@ -3347,6 +3355,18 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             overRideUIName = overrideClassName;
         }
 
+        if (parseArguments.isOptPresent(NO_CONNECTIONS_PANE_OPTION_STRING)) {
+            suppressConnectionsPaneDisplay = true;
+        } else {
+            suppressConnectionsPaneDisplay = false;
+        }
+
+        if (parseArguments.isOptPresent(NO_LOGINS_PANE_OPTION_STRING)) {
+            suppressLoginsPaneDisplay = true;
+        } else {
+            suppressLoginsPaneDisplay = false;
+        }
+
     }
 
     private boolean isEventFeeder(ClientId clientId) {
@@ -4271,6 +4291,14 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
 
     public boolean isUsingGUI() {
         return usingGUI;
+    }
+
+    public boolean isSuppressConnectionsPaneDisplay() {
+        return suppressConnectionsPaneDisplay;
+    }
+
+    public boolean isSuppressLoginsPaneDisplay() {
+        return suppressLoginsPaneDisplay;
     }
 
     public ILogWindow startLogWindow(IInternalContest inContest) {

--- a/src/edu/csus/ecs/pc2/core/MockController.java
+++ b/src/edu/csus/ecs/pc2/core/MockController.java
@@ -600,4 +600,14 @@ public class MockController implements IInternalController {
         return s;
     }
 
+    @Override
+    public boolean isSuppressConnectionsPaneDisplay() {
+        return false;
+    }
+
+    @Override
+    public boolean isSuppressLoginsPaneDisplay() {
+        return false;
+    }
+
 }

--- a/src/edu/csus/ecs/pc2/core/NullController.java
+++ b/src/edu/csus/ecs/pc2/core/NullController.java
@@ -549,4 +549,14 @@ public class NullController implements IInternalController {
         // TODO Auto-generated method stub
         
     }
+
+    @Override
+    public boolean isSuppressConnectionsPaneDisplay() {
+        return false;
+    }
+
+    @Override
+    public boolean isSuppressLoginsPaneDisplay() {
+        return false;
+    }
 }

--- a/src/edu/csus/ecs/pc2/core/model/IFileImpl.java
+++ b/src/edu/csus/ecs/pc2/core/model/IFileImpl.java
@@ -2,8 +2,6 @@ package edu.csus.ecs.pc2.core.model;
 
 import java.util.Base64;
 
-import edu.csus.ecs.pc2.core.model.IFile;
-
 /**
  * This class is a concrete implementation of a file from the point of view of the PC<sup>2</sup> API.
  * 

--- a/src/edu/csus/ecs/pc2/ui/admin/AdministratorLegacyView.java
+++ b/src/edu/csus/ecs/pc2/ui/admin/AdministratorLegacyView.java
@@ -297,9 +297,11 @@ public class AdministratorLegacyView extends JFrame implements UIPlugin, ChangeL
                  * add UI components involved with Running the contest to the RunContest tabbed pane
                  */
 
-                ConnectionsPane connectionsPane = new ConnectionsPane();
-                addUIPlugin(getRunContestTabbedPane(), "Connections", connectionsPane);
-
+                if (!controller.isSuppressConnectionsPaneDisplay()) {
+                    ConnectionsPane connectionsPane = new ConnectionsPane();
+                    addUIPlugin(getRunContestTabbedPane(), "Connections", connectionsPane);
+                }
+                
                 ClarificationsPane clarificationsPane = new ClarificationsPane();
                 addUIPlugin(getRunContestTabbedPane(), "Clarifications", clarificationsPane);
 
@@ -321,9 +323,11 @@ public class AdministratorLegacyView extends JFrame implements UIPlugin, ChangeL
                 FinalizePane finalizePane = new FinalizePane();
                 addUIPlugin(getRunContestTabbedPane(), "Finalize", finalizePane);
 
-                LoginsPane loginsPane = new LoginsPane();
-                addUIPlugin(getRunContestTabbedPane(), "Logins", loginsPane);
-             
+                if (!controller.isSuppressLoginsPaneDisplay()) {
+                    LoginsPane loginsPane = new LoginsPane();
+                    addUIPlugin(getRunContestTabbedPane(), "Logins", loginsPane);
+                }
+                
                 if (Utilities.isDebugMode()) {
                     try {
                         MessageMonitorPane messageMonitorPane = new MessageMonitorPane();

--- a/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
+++ b/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
@@ -299,9 +299,11 @@ public class AdministratorView extends JFrame implements UIPlugin, ChangeListene
                  * add UI components involved with Running the contest to the RunContest tabbed pane
                  */
 
-                ConnectionsTablePane connectionsPane = new ConnectionsTablePane();
-                addUIPlugin(getRunContestTabbedPane(), "Connections", connectionsPane);
-
+                if (!controller.isSuppressConnectionsPaneDisplay()) {
+                    ConnectionsTablePane connectionsPane = new ConnectionsTablePane();
+                    addUIPlugin(getRunContestTabbedPane(), "Connections", connectionsPane);
+                }
+                
                 ClarificationsTablePane clarificationsTablePane = new ClarificationsTablePane();
                 addUIPlugin(getRunContestTabbedPane(), "Clarifications", clarificationsTablePane);
 
@@ -323,9 +325,11 @@ public class AdministratorView extends JFrame implements UIPlugin, ChangeListene
                 FinalizePane finalizePane = new FinalizePane();
                 addUIPlugin(getRunContestTabbedPane(), "Finalize", finalizePane);
 
-                LoginsTablePane loginsTablePane = new LoginsTablePane();
-                addUIPlugin(getRunContestTabbedPane(), "Logins", loginsTablePane);
-             
+                if (!controller.isSuppressLoginsPaneDisplay()) {
+                    LoginsTablePane loginsTablePane = new LoginsTablePane();
+                    addUIPlugin(getRunContestTabbedPane(), "Logins", loginsTablePane);
+                }
+                
                 if (Utilities.isDebugMode()) {
                     try {
                         MessageMonitorPane messageMonitorPane = new MessageMonitorPane();

--- a/test/edu/csus/ecs/pc2/core/log/NullController.java
+++ b/test/edu/csus/ecs/pc2/core/log/NullController.java
@@ -659,4 +659,14 @@ public class NullController implements IInternalController{
         // TODO Auto-generated method stub
         
     }
+
+    @Override
+    public boolean isSuppressConnectionsPaneDisplay() {
+        return false;
+    }
+
+    @Override
+    public boolean isSuppressLoginsPaneDisplay() {
+        return false;
+    }
 }

--- a/test/edu/csus/ecs/pc2/tools/PasswordGeneratorTest.java
+++ b/test/edu/csus/ecs/pc2/tools/PasswordGeneratorTest.java
@@ -4,8 +4,6 @@ package edu.csus.ecs.pc2.tools;
 import java.util.List;
 
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
-import edu.csus.ecs.pc2.tools.PasswordGenerator;
-import edu.csus.ecs.pc2.tools.PasswordType2;
 
 /**
  * Unit test.


### PR DESCRIPTION
### Description of what the PR does
Adds two command-line options:  `--noconnectionspane` and `--nologinspane`.  When one (or both) of these options are specified on starting an Admin from the command line, the appearance of the corresponding grid (_Connections_ and _Logins_ respectively) is suppressed.  This provides a (brute-force) workaround for issues where these grids take so long to load that they effectively freeze the Admin.

Note: it is possible that PR #433, which replaces the old MCLB grids in AdminView with newer "JTable" versions, obviates the need for the fixes in this PR.  However, if it turns out that #433 does _not_ completely eliminate the problem described in Issue #432, this PR is needed to provide a rapid-response workaround for upcoming contests such as ACPC.  In any case, the PR is benign if the new options are not used.

### Issue which the PR fixes
Fixes #432, which was filed in an effort to provide the ACPC contest with a viable workaround when running extremely large contests (>3000 teams).

The code in the PR passes all JUnit tests, and a local build generated from the PR works as intended.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.1; Eclipse Version: 2020-12 (4.18.0) Build id: 20201210-1552; Java 1.8.0_271.

### Precise steps for _testing_ the PR
- Start a server loading a contest, e.g. "SumitHello".
- Login a team (e.g. team1).
- Start an Admin using defaults.
- Observe the presence of the "Connections" and "Logins" tabs on the "Run Contest" tab.
  - Note the presence of both Connection and Login information (on the respective tabs) for "team1".
- Shut down the Admin.
- Restart the Admin, specifying either `--noconnectionspane` and/or `--nologinspane` as arguments on the command line.
  - Note the _absence_ of either or both of the "Connections" and/or "Logins" tabs on the "Run Contest" tab.
