### PR TITLE
i438: Autojudges hang if a run's related files are missing

### DIFF
--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -3545,11 +3545,11 @@ public class PacketHandler {
                     } catch (Exception e) {
                         controller.getLog().warning("contest.getRunFiles (R/O) can not get files for run " + run.getNumber() + ": " + e.getMessage());
                         
-                        try {
-                            contest.cancelRunCheckOut(run, whoRequestsRunId);
-                        } catch (Exception e1) {
-                            controller.getLog().severe("Problem canceling run checkout after error getting run " + run.getNumber() + " files." + e1);
-                        }
+                        // set status to NEW indicating there was a failure and it has to be manually taken care of
+                        // the judges will be notifed of a new run.
+                        theRun.setStatus(Run.RunStates.NEW);
+                        Packet availableRunPacket = PacketFactory.createRunAvailable(contest.getClientId(), whoRequestsRunId, theRun);
+                        controller.sendToJudgesAndOthers(availableRunPacket, true);
                         
                         Packet notAvailableRunPacket = PacketFactory.createRunNotAvailable(contest.getClientId(), whoRequestsRunId, theRun);
                         controller.sendToClient(notAvailableRunPacket);
@@ -3579,12 +3579,13 @@ public class PacketHandler {
                             controller.getLog().warning("contest.getRunFiles can not get files for run " + run.getNumber() + " (settng to status NEW): " + e.getMessage());
                             
                             try {
+                                // cancel the checkout and set run state to NEW to notify judges
                                 contest.cancelRunCheckOut(run, whoRequestsRunId);
                                 theRun.setStatus(Run.RunStates.NEW);
                                 Packet availableRunPacket = PacketFactory.createRunAvailable(contest.getClientId(), whoRequestsRunId, theRun);
                                 controller.sendToJudgesAndOthers(availableRunPacket, true);
                             } catch (Exception e1) {
-                                controller.getLog().severe("Problem canceling run checkout after error getting run " + run.getNumber() + " files." + e1);
+                                controller.getLog().severe("Problem cancelling run checkout after error getting run " + run.getNumber() + " files." + e1);
                             }
                             
                             Packet notAvailableRunPacket = PacketFactory.createRunNotAvailable(contest.getClientId(), whoRequestsRunId, theRun);
@@ -3597,7 +3598,7 @@ public class PacketHandler {
                             try {
                                 contest.cancelRunCheckOut(run, whoRequestsRunId);
                             } catch (UnableToUncheckoutRunException e) {
-                                controller.getLog().severe("Problem canceling run checkout after error getting run files.");
+                                controller.getLog().severe("Problem cancelling run checkout after error getting run files.");
                             }
                             throw new RunUnavailableException("Error retrieving files.");
                         }

--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -3543,7 +3543,7 @@ public class PacketHandler {
                     try {
                         runFiles = contest.getRunFiles(run);  
                     } catch (Exception e) {
-                        controller.getLog().info("contest.getRunFiles (R/O) can not get files for run " + run.getNumber() + ": " + e.getMessage());
+                        controller.getLog().warning("contest.getRunFiles (R/O) can not get files for run " + run.getNumber() + ": " + e.getMessage());
                         
                         try {
                             contest.cancelRunCheckOut(run, whoRequestsRunId);
@@ -3576,7 +3576,7 @@ public class PacketHandler {
                         try {
                             runFiles = contest.getRunFiles(run);  
                         } catch (Exception e) {
-                            controller.getLog().info("contest.getRunFiles can not get files for run " + run.getNumber() + " (settng to status NEW): " + e.getMessage());
+                            controller.getLog().warning("contest.getRunFiles can not get files for run " + run.getNumber() + " (settng to status NEW): " + e.getMessage());
                             
                             try {
                                 contest.cancelRunCheckOut(run, whoRequestsRunId);


### PR DESCRIPTION
If an exception occurs fetching a run's files, then set the run's status to "NEW" so AJ will not pick it up again.  Also notify the the client that requested the run that it is unavailable.

Handle the read-only case for this as well.

Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Catches any exception that getRunFiles() may throw (like file not found) and changes the run status to NEW (so no AJ's
will pick it up), and then notifies the client that the run is unavailable.
### Issue which the PR fixes
Autojudge's hang fetching run files for runs that don't have any since the status is QUEUED_FOR_COMPUTER_JUDGEMENT, 
all AJ's will attempt to check out the run, but hang, waiting for the files if they  don't exist.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321



### Precise steps for _testing_ the PR 
(From @ashoos72 ):
Start a server
Start admin
Configure a few teams/judges
Configure 1 hello world problem with an answer file and computer judging (using pc2 diff or whatever)
Configure java
Configure 1 aj for the problem
start the contest

Start a team
submit three hello world solutions

go to a server db.1 folder and delete s1r2.files (the run files for submission 2)

start the AJ
You will see the AJ judge the first submission and then not hang on submission 2 but mark it as NEW, and continue on to submission 3.