### PR TITLE
i444: change AJ fetch sort order

### DIFF
--- a/src/edu/csus/ecs/pc2/core/list/RunComparatorByElapsedRunIdSite.java
+++ b/src/edu/csus/ecs/pc2/core/list/RunComparatorByElapsedRunIdSite.java
@@ -1,0 +1,35 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.list;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * Run Comparator, Order the runs by elapsed time (ms), run id, then site.
+ *
+ * @version $Id$
+ * @author pc2@ecs.csus.edu
+ */
+
+public class RunComparatorByElapsedRunIdSite implements Comparator<Run>, Serializable {
+
+    private static final long serialVersionUID = 1629965664816187817L;
+
+    public int compare(Run run1, Run run2) {
+
+        if (run1.getElapsedMS() == run2.getElapsedMS()) {
+            
+            if (run1.getNumber() == run2.getNumber()) {
+
+                return Long.compare(run1.getSiteNumber(), run2.getSiteNumber());
+
+            } else {
+                return Long.compare(run1.getNumber(), run2.getNumber());
+            }
+        } else {
+            return Long.compare(run1.getElapsedMS(), run2.getElapsedMS());
+        }
+    }
+}

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -15,7 +15,7 @@ import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.execute.Executable;
 import edu.csus.ecs.pc2.core.execute.ExecutionData;
 import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
-import edu.csus.ecs.pc2.core.list.RunComparator;
+import edu.csus.ecs.pc2.core.list.RunComparatorByElapsedRunIdSite;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientSettings;
@@ -187,7 +187,7 @@ public class AutoJudgingMonitor implements UIPlugin {
         }
 
         Run[] runs = contest.getRuns();
-        Arrays.sort(runs,new RunComparator());
+        Arrays.sort(runs,new RunComparatorByElapsedRunIdSite());
 
         for (Run run : runs) {
             if (run.getStatus() == RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT) {


### PR DESCRIPTION
### Description of what the PR does

AJ will now fetch runs ordered by run elapsed ms, then run number, then site number

### Issue which the PR fixes

#444 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

All.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start 2 servers/contest clocks.
Submit runs to site 2 first
pause for a couple of minutes
Submit runs to site 1.

Start a single AJ to judge runs

Before
Site 1 runs would be judged first.

Expected
Runs from site2 should be selected/judged first.
