### PR TITLE
Fix null client ID used in exception report and spelling errors, fixes #437

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -1493,7 +1493,7 @@ public class InternalContest implements IInternalContest {
                 runList.updateRun(newRun);
                 return runList.get(run.getElementId());
             } else {
-                throw new RunUnavailableException("Client " + clientId + " can not checked out run " + run.getNumber() + " (site " + run.getSiteNumber() + ")");
+                throw new RunUnavailableException("Client " + whoChangedRun + " can not check out run " + run.getNumber() + " (site " + run.getSiteNumber() + ")");
             }
         
         }
@@ -2258,7 +2258,7 @@ public class InternalContest implements IInternalContest {
                 clarificationList.updateClarification(newClar);
                 return clarificationList.get(clar.getElementId());
             } else {
-                throw new ClarificationUnavailableException("Client " + clientId + " can not checked out clar " + clar.getNumber() + " (site " + clar.getSiteNumber() + ")");
+                throw new ClarificationUnavailableException("Client " + whoChangedClar + " can not check out clar " + clar.getNumber() + " (site " + clar.getSiteNumber() + ")");
             }
         
         }


### PR DESCRIPTION
At the point the exception is thrown, the original clientId variable was always null.  It should have been the client who requested the checkout of the run, namely, whoChangedRun.  The same problem existed for checking out Clarifications, and that too has been fixed (in the same module).
In addition, there was a wrong word used in the string text that was thrown:  "can not checked out" changed to "can not check out".

Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Corrects incorrect variable usage in a "throw" which would cause "null" to be part of the exception string when the intent was to show the information for the client making the checkout request. 
Corrects the spelling/wrong word usage in the exception strings.

### Issue which the PR fixes
#437 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
This fix can not easily be tested without "breaking" the code to cause the exception to be thrown.  The code was recently fixed to prevent this very exception.  In order to test, in InternalContest.checkoutRun(), change the "if(canBeCheckedOut)" to "if(!canBeCheckedOut)".  This will force the exception.  The log message shown is now:

**220613 133956.215|INFO|Thread-9|checkoutRun|runUnavailableException Client ADMINISTRATOR1 @ site 1 can not check out run 1359 (site 1)**

(Be sure to undo the "breaking" of the code to test this!)