### PR TITLE
I 463 add and enforce shadow properties

### DIFF
--- a/src/edu/csus/ecs/pc2/core/LoadContest.java
+++ b/src/edu/csus/ecs/pc2/core/LoadContest.java
@@ -393,6 +393,9 @@ public class LoadContest {
             PermissionList permissionList = permissionGroup.getPermissionList (account.getClientId().getClientType());
             if (permissionList != null){
                 account.clearListAndLoadPermissions(permissionList);
+                if (account.getClientId().getClientNumber() == 1 && account.getClientId().getClientType().equals(ClientType.Type.FEEDER)) {
+                    permissionGroup.addShadowPermissions(account);
+                }
             } else {
                 account.addPermission(Permission.Type.LOGIN);
                 account.addPermission(Permission.Type.DISPLAY_ON_SCOREBOARD);

--- a/src/edu/csus/ecs/pc2/core/PermissionGroup.java
+++ b/src/edu/csus/ecs/pc2/core/PermissionGroup.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import edu.csus.ecs.pc2.core.model.Account;
@@ -153,6 +153,8 @@ public class PermissionGroup {
         
         feederPermissionList.addPermission(Type.COMPARE_RUNS_SCOREBOARD);
         feederPermissionList.addPermission(Type.START_STOP_SHADOWING);
+        feederPermissionList.addPermission(Type.ENABLE_SHADOW_MODE);
+        
 
     }
 
@@ -195,7 +197,6 @@ public class PermissionGroup {
      */
     public void addShadowPermissions(Account account) {
 
-        account.addPermission(Type.ENABLE_SHADOW_MODE);
         account.addPermission(Type.MODIFY_SHADOW_SETTINGS);
 
     }

--- a/src/edu/csus/ecs/pc2/core/PermissionGroup.java
+++ b/src/edu/csus/ecs/pc2/core/PermissionGroup.java
@@ -1,10 +1,11 @@
 // Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
+import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.security.Permission;
-import edu.csus.ecs.pc2.core.security.PermissionList;
 import edu.csus.ecs.pc2.core.security.Permission.Type;
+import edu.csus.ecs.pc2.core.security.PermissionList;
 
 /**
  * Holds Default Permissions for users.
@@ -149,7 +150,8 @@ public class PermissionGroup {
         feederPermissionList.addPermission(Type.VIEW_SUMMARY_ATTEMPTS_GRID);
         feederPermissionList.addPermission(Type.VIEW_RUN_JUDGEMENT_HISTORIES);
         feederPermissionList.addPermission(Type.ALLOWED_TO_FETCH_RUN);
-
+        
+        feederPermissionList.addPermission(Type.COMPARE_RUNS_SCOREBOARD);
 
     }
 
@@ -182,6 +184,22 @@ public class PermissionGroup {
         }
     }
 
+    
+    /**
+     * Add Shadow start/stop and other permissions to certain accounts.
+     * 
+     * Add permissions to any Admin and FEEEDER1.
+     * 
+     * @param account
+     */
+    public void addShadowPermissions(Account account) {
+
+        account.addPermission(Type.ENABLE_SHADOW_MODE);
+        account.addPermission(Type.START_STOP_SHADOWING);
+        account.addPermission(Type.MODIFY_SHADOW_SETTINGS);
+
+    }
+    
     // for (Type type : Permission.Type.values()) {
     // System.out.println("foo.addPermission(Type." + type + ");");
     // }

--- a/src/edu/csus/ecs/pc2/core/PermissionGroup.java
+++ b/src/edu/csus/ecs/pc2/core/PermissionGroup.java
@@ -152,6 +152,7 @@ public class PermissionGroup {
         feederPermissionList.addPermission(Type.ALLOWED_TO_FETCH_RUN);
         
         feederPermissionList.addPermission(Type.COMPARE_RUNS_SCOREBOARD);
+        feederPermissionList.addPermission(Type.START_STOP_SHADOWING);
 
     }
 
@@ -195,7 +196,6 @@ public class PermissionGroup {
     public void addShadowPermissions(Account account) {
 
         account.addPermission(Type.ENABLE_SHADOW_MODE);
-        account.addPermission(Type.START_STOP_SHADOWING);
         account.addPermission(Type.MODIFY_SHADOW_SETTINGS);
 
     }

--- a/src/edu/csus/ecs/pc2/core/list/AccountList.java
+++ b/src/edu/csus/ecs/pc2/core/list/AccountList.java
@@ -113,6 +113,9 @@ public class AccountList extends BaseElementList {
                 PermissionList permissionList = permissionGroup.getPermissionList (type);
                 if (permissionList != null){
                     account.clearListAndLoadPermissions(permissionList);
+                    if (account.getClientId().getClientNumber() == 1 && account.getClientId().getClientType().equals(ClientType.Type.FEEDER)) {
+                        permissionGroup.addShadowPermissions(account);
+                    }
                 } else {
                     account.addPermission(Permission.Type.LOGIN);
                     account.addPermission(Permission.Type.DISPLAY_ON_SCOREBOARD);

--- a/src/edu/csus/ecs/pc2/core/security/Permission.java
+++ b/src/edu/csus/ecs/pc2/core/security/Permission.java
@@ -317,6 +317,27 @@ public class Permission implements Serializable {
          * Act as proxy team in shadow mode
          */
         SHADOW_PROXY_TEAM,
+
+        /**
+         * Allow User to enable/disable shadowing
+         */
+        ENABLE_SHADOW_MODE,
+
+        /**
+         * Start/Stop Shadowing
+         */
+        START_STOP_SHADOWING,
+
+        /**
+         * View Runs Compare Scoreboard
+         */
+        COMPARE_RUNS_SCOREBOARD,
+
+        /**
+         * Modify Shadow settings.
+         */
+        MODIFY_SHADOW_SETTINGS,
+
     };
 
     private Hashtable<Type, String> hash = new Hashtable<Type, String>();
@@ -419,6 +440,12 @@ public class Permission implements Serializable {
         hash.put(Type.EDIT_EVENT_FEED,"Edit Event Feeds");
         hash.put(Type.VIEW_EVENT_FEED,"View Event Feeds");
         hash.put(Type.SHADOW_PROXY_TEAM,"Shadow Proxy Team");
+
+        hash.put(Type.ENABLE_SHADOW_MODE, "Enable Shadow Mode");
+        hash.put(Type.START_STOP_SHADOWING, "Start/Stop Shadowing");
+        hash.put(Type.COMPARE_RUNS_SCOREBOARD, "Allow Compare Runs/Scoreboard");
+        hash.put(Type.MODIFY_SHADOW_SETTINGS, "Modify Shadow Settings");
+
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/ui/EditAccountPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditAccountPane.java
@@ -1059,8 +1059,11 @@ public class EditAccountPane extends JPanePlugin {
     protected void resetPermissions() {
         Account fakeAccount = new Account(account.getClientId(), account.getPassword(), account.getSiteNumber());
         PermissionList permissionList = new PermissionGroup().getPermissionList (account.getClientId().getClientType());
-        if (permissionList != null){
+        if (permissionList != null) {
             account.clearListAndLoadPermissions(permissionList);
+            if (account.getClientId().getClientNumber() == 1 && account.getClientId().getClientType().equals(ClientType.Type.FEEDER)) {
+                new PermissionGroup().addShadowPermissions(account);
+            }
         }
         populatePermissions(fakeAccount);
         permissionList = null;

--- a/src/edu/csus/ecs/pc2/ui/PluginLoadPane.java
+++ b/src/edu/csus/ecs/pc2/ui/PluginLoadPane.java
@@ -10,6 +10,7 @@ import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JOptionPane;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 
 import edu.csus.ecs.pc2.core.IInternalController;
@@ -95,13 +96,41 @@ public class PluginLoadPane extends JPanePlugin {
             openNewPluginButton = new JButton();
             openNewPluginButton.setBounds(new Rectangle(41, 147, 134, 36));
             openNewPluginButton.setText("Add Tab");
-            openNewPluginButton.addActionListener(new java.awt.event.ActionListener() {
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                    addNewTab();
+            openNewPluginButton.addMouseListener(new java.awt.event.MouseAdapter() {
+                public void mouseClicked(java.awt.event.MouseEvent e) {
+                    if (e.isShiftDown() && e.isControlDown()) {
+                        // to make it easier to find tba, put tabs on left.
+                        parentTabbedPane.setTabPlacement (SwingConstants.LEFT);    
+                        openAllPluginsInTabs();
+                    } else {
+                        addNewTab();
+                    }
                 }
             });
         }
         return openNewPluginButton;
+    }
+
+    /**
+     * Add tab for every plugin in combo box.
+     */
+    protected void openAllPluginsInTabs() {
+
+        int size = getPluginComboBox().getItemCount();
+        for (int i = 0; i < size; i++) {
+            PluginWrapper  wrapper = (PluginWrapper) getPluginComboBox().getItemAt(i);
+            AddNewPane(wrapper.getPlugin());
+        }
+    }
+    
+    /**
+     * Add a single tab.
+     * @param plugin
+     */
+    protected void AddNewPane(JPanePlugin plugin) {
+        getController().register(plugin);
+        plugin.setContestAndController(getContest(), getController());
+        parentTabbedPane.add(plugin, plugin.getPluginTitle());
     }
 
     protected void addNewTab() {

--- a/src/edu/csus/ecs/pc2/ui/ReportPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ReportPane.java
@@ -340,6 +340,7 @@ public class ReportPane extends JPanePlugin {
     private void updateGUIperPermissions() {
         generateSummaryButton.setEnabled(isAllowed(Permission.Type.EDIT_ACCOUNT));
         viewReportButton.setEnabled(isAllowed(Permission.Type.EDIT_ACCOUNT));
+        exportDataButton.setEnabled(isAllowed(Permission.Type.EDIT_ACCOUNT));
     }
 
     protected void refreshGUI() {


### PR DESCRIPTION
### Description of what the PR does

Add Permissions to for shadow mode.

### Issue which the PR fixes

#463 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.1766]
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1 - Test the default permissions for feeder1 and feeder 3

start server using tenprobs sample
start feeder 1
   Go to the Shadow Mode tab, all the following components will be enabled
Enable Shadowing Mode
Primary CCS URL
Primary CCS Login (account)
Primary CCS Password
Last Event Id
Start Shadowing Button
Compare Runs Button
Compare Scoreboard Button
(the Update button only enabled if one of the component values is changed)

start feeder 2
(checked) Shadowing Mode
Start Shadowing Button
Compare Runs Button
Compare Scoreboard Button

Test 2 - live enable/disable of shadow settings.

Editing an account shadow permission will (like most other settings) enable or disable (shadow) components.

Start the feeder account and view how components are enabled/disabled as the permissions (below)
are changed.

The following permission enable/disable components (live)

ENABLE_SHADOW_MODE, "Enable Shadow Mode");
   Disable/Enable 
     Shadow Mode checkbox
START_STOP_SHADOWING, "Start/Stop Shadowing");
   Disable/Enable 
      Shadow Mode checkbox

COMPARE_RUNS_SCOREBOARD, "Allow Compare Runs/Scoreboard");
   Disable/Enable 
      Compare Runs Button
      Compare Scoreboard Button

MODIFY_SHADOW_SETTINGS, "Modify Shadow Settings");
   Disable/Enable 
     Enable Shadowing Mode
     Primary CCS URL
     Primary CCS Login (account)
     Primary CCS Password
     Last Event Id