### PR TITLE
I480 aj stuck looping

### DIFF
--- a/src/edu/csus/ecs/pc2/core/list/UnavailableRunComparatorByExpirationTime.java
+++ b/src/edu/csus/ecs/pc2/core/list/UnavailableRunComparatorByExpirationTime.java
@@ -1,0 +1,24 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.list;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import edu.csus.ecs.pc2.core.model.UnavailableRun;
+
+/**
+ * Unavailable Run Comparator -- compares Unavailable Run objects based on their expiration times.
+ *
+ * @author John Clevenger, PC2 Development Team (pc2@ecs.csus.edu)
+ */
+
+public class UnavailableRunComparatorByExpirationTime implements Comparator<UnavailableRun>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public int compare(UnavailableRun run1, UnavailableRun run2) {
+        
+        return Long.compare(run1.getExpirationTimeInSecs(), run2.getExpirationTimeInSecs());
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
+++ b/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
@@ -1,0 +1,192 @@
+package edu.csus.ecs.pc2.core.list;
+
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+import java.util.concurrent.PriorityBlockingQueue;
+
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.UnavailableRun;
+import edu.csus.ecs.pc2.ui.AutoJudgingMonitor;
+
+/**
+ * This class maintains a list of unavailable runs -- that is, runs which an AutoJudge has previously requested but
+ * received back a RUN_NOTAVAILABLE response (packet).
+ * 
+ * The list of unavailable runs is managed as a {@link PriorityBlockingQueue}.  Note: class {@link PriorityBlockingQueue} 
+ * is used rather than {@link PriorityQueue} because the former is thread-safe whereas the latter is not.
+ * 
+ * The priority of a queue element is based on an "expiration time" -- the contest elapsed time (in seconds) at which the run should no longer
+ * be considered "unavailable".  Runs whose "expiration time" has arrived become candidates for removal
+ * from the list. (The purpose of this is to ensure that at some point an AJ will go back and
+ * consider runs which were PREVIOUSLY unavailable but which might now be legitimately available; this could happen for example if some
+ * other judge grabbed the run while a given judge was requesting it, but then the other judge returned the run unjudged.)
+ * 
+ * Runs with earlier expiration times appear closer to the head of the queue.  When a run is inserted into the queue (by calling
+ * method {@link #addRun(Run run)}), that method computes an "expiration time" (the contest time at which the run becomes a candidate
+ * for removal from the list.  
+ * 
+ * The class also tracks the <I>number of times</i> a given run gets inserted into the UnavailableRunsList; the more times a given
+ * Run gets inserted, the longer (further in the future) its computed "expiration time" will be (see method {@link #addRun(Run)} for details).
+ * 
+ * The list managed by this class was created as a (hopefully, temporary) workaround for the issue of AJ's repeatedly 
+ * requesting the same unavailable run ad infinitum -- something which has been seen in various contests.  
+ * See https://github.com/pc2ccs/pc2v9/issues/480 for details.
+ * 
+ * @author John Clevenger, PC2 Development Team (pc2@ecs.csus.edu)
+ *
+ */
+public class UnavailableRunsList {
+    
+    public static long INITIAL_EXPIRATION_TIME_OFFSET_SECS = 60;
+    
+    //a Priority Queue holding the unavailable runs, ordered by increasing "expiration time".
+    //the priority queue has an initial capacity of 11 (the default) and uses an UnavailableRunComparatorByExpirationTime for determining priority.
+    private PriorityBlockingQueue<UnavailableRun> unavailableRuns = new PriorityBlockingQueue<UnavailableRun>(11, new UnavailableRunComparatorByExpirationTime());
+    
+    //a hashtable to keep track of how many times any given run has ever been added to the UnavailableRunsList.
+    // This allows computing increased expiration times the more times a given run is found "unavailable".
+    private Hashtable<Run,Integer> allAddedRuns = new Hashtable<Run,Integer>();
+    
+    private IInternalContest contest;
+    private Log log;
+    
+    /**
+     * Constructs an (initially-empty) UnavailableRunsList for the specified IInternalContest.
+     * 
+     * @param contest the IInternalContest on which this UnavailableRunsList is based.
+     * @param controller the IInternalController for the contest, used to obtain the Log to be used by this class.
+     * 
+     */
+    public UnavailableRunsList (IInternalContest contest, IInternalController controller) {
+        this.contest = contest;
+        if (controller != null) {
+            this.log = controller.getLog();
+        }
+    }
+    
+    /**
+     * Adds the specified Run to the list of unavailable runs.
+     * 
+     * Each run which is added to the list is given an "expiration time" -- the contest elapsed time (in seconds) when the run 
+     * is no longer to be treated as "unavailable".  The expiration time of a run on the list is a function of both
+     * the time it is put on the list and how many times (if any) it has PREVIOUSLY been put on the list; runs which 
+     * have been added to the list previously are given increasingly longer (further in the future) expiration times.
+     * 
+     * Note that runs are not "automatically" removed from the list when their "expiration time" has arrived; a call to
+     * method {@link #removeExpiredRuns()} must be made to cause expired runs to be removed
+     * (see method {@link AutoJudgingMonitor#findNextAutoJudgeRun()}). 
+     * 
+     * @param run the Run to be added to the list.
+     */
+    public void addRun(Run run) {
+        
+        if (contest==null) {
+            throw new RuntimeException("UnavailableRunsList contains null contest");
+        }
+        
+        if (run==null) {
+            if (log!=null) {
+                log.warning("Attempted to add a null run to the UnavailableRunsList!");
+            } else {
+                System.err.println("Attempted to add a null run to the UnavailableRunsList, and no log is available for logging!!");
+                throw new RuntimeException("Attempted to add a null run to the UnavailableRunsList, and no log is available for logging!!");
+            }
+        }
+        
+        //find the number of times the run has previously been added to the UnavailableRunsList (if any).
+        //  (Note that we're checking the hashtable of ALL runs which have EVER been added to the UnavailableRunsList, 
+        //  not the current UnavailableRunsList.) The "allAddedRuns" hashtable maps Runs to a count of the number of times 
+        // that run has ever been added to the UnavailableRunsList.
+        int timesAddedToRunList;
+        if (allAddedRuns.containsKey(run)) {
+            
+            //the run has previously been added; get the count of number of times it has been added previously
+            timesAddedToRunList = allAddedRuns.get(run);
+            
+            //indicate another addition is occurring
+            timesAddedToRunList++ ;
+            allAddedRuns.put(run, timesAddedToRunList);
+            
+        } else {
+            
+            //this is the first time the run has been added
+            allAddedRuns.put(run,  1);
+            timesAddedToRunList = 1;
+        }
+        
+        //compute how long past "now", as a function of number of times already added, the run should "expire" on the UnavailableRunsList.
+        // (Note that the current calculation is a LINEAR increase in time; it would probably be better to have something like an EXPONENTIAL
+        //   increase.  However, since this entire class is (hopefully) temporary, I didn't spend any more time on that... jlc)
+        long contestTimeNowInSecs = contest.getContestTime().getElapsedSecs();
+        long expirationTimeInSecs = contestTimeNowInSecs + (INITIAL_EXPIRATION_TIME_OFFSET_SECS * timesAddedToRunList) ;
+        
+        //add the run to the priority queue (note that method add(run) adds the run into the queue in priority order based on the expiration time in the run)
+        UnavailableRun runToAdd = new UnavailableRun(run, expirationTimeInSecs);
+        unavailableRuns.add(runToAdd);
+        
+        if (log!=null) { 
+            log.info("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ")");
+        } else {
+            System.err.println("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ") but no log was available for logging!!");
+            throw new RuntimeException("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ") but no log was available for logging!!");            
+        }
+    }
+    
+    /**
+     * This method returns an indication of whether the specified run is currently contained in the list of "unavailable runs".
+     * 
+     * @param run the run to be looked for in the UnavailableRuns list.
+     * @return true if the run is in the unavailable runs list; false otherwise.
+     */
+    public boolean contains(Run run) {
+        
+        //get an iterator over all the Unavailable Runs, without actually removing any of them from the priority queue        
+        Iterator<UnavailableRun> iterator = unavailableRuns.iterator();
+        
+        //check each UnavailableRun to see if it matches the received Run
+        UnavailableRun nextRun;
+        while (iterator.hasNext()) {
+            nextRun = iterator.next();
+            if (nextRun != null  &&  nextRun.getRun().equals(run)) {
+                //we found the specified Run in the list
+                return true;
+            }
+        }
+        
+        //after checking all the runs in the queue (iterator) we didn't find the specified run
+        return false;
+    }
+    
+    /**
+     * This method goes through the list of unavailable runs and removes any runs whose "expiration time" has passed.
+     * Unavailable Runs are ordered in the queue based on their expiration time in contest elapsed seconds; what this
+     * method does is remove from the UnavailableRuns list all runs at the head of the queue with an expiration time
+     * less that the current contest elapsed time. 
+     */
+    public void removeExpiredRuns() {
+        
+        if (contest==null) {
+            throw new RuntimeException("UnavailableRunsList contains null contest");
+        }
+        
+        long timeNow = contest.getContestTime().getElapsedSecs();
+        
+        //repeatedly look at the run at the head of the queue to see if its expiration time has passed
+        while (unavailableRuns.peek().getExpirationTimeInSecs() < timeNow) {
+            
+            //the run at the head of the queue has an expiration time which has passed; remove it from the queue
+            // (note that method "poll()" is the PriorityBlockingQueue method to remove the head of the queue without blocking if the queue is empty)
+            UnavailableRun removedRun = unavailableRuns.poll();
+            
+            //if we actually removed a run and we have a non-null log, log the removal
+            //  (note that poll() can return null if the queue is empty)
+            if (removedRun!=null && log!=null) {
+                    log.info("Removed run " + removedRun.getRun().getNumber() + " from UnavailableRuns list");
+            }
+        }
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
+++ b/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
@@ -7,6 +7,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.ElementId;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.model.UnavailableRun;
@@ -57,7 +58,7 @@ public class UnavailableRunsList {
     
     //a hashtable to keep track of how many times any given run has ever been added to the UnavailableRunsList.
     // This allows computing increased expiration times the more times a given run is found "unavailable".
-    private Hashtable<Run,Integer> allAddedRuns = new Hashtable<Run,Integer>();
+    private Hashtable<ElementId,Integer> allAddedRuns = new Hashtable<ElementId,Integer>();
     
     private IInternalContest contest;
     private Log log;
@@ -107,22 +108,22 @@ public class UnavailableRunsList {
         
         //find the number of times the run has previously been added to the UnavailableRunsList (if any).
         //  (Note that we're checking the hashtable of ALL runs which have EVER been added to the UnavailableRunsList, 
-        //  not the current UnavailableRunsList.) The "allAddedRuns" hashtable maps Runs to a count of the number of times 
-        // that run has ever been added to the UnavailableRunsList.
+        //  not the current UnavailableRunsList.) The "allAddedRuns" hashtable maps Runs (via their ElementId) to a count 
+        //  of the number of times that run has ever been added to the UnavailableRunsList.
         int timesAddedToRunList;
-        if (allAddedRuns.containsKey(run)) {
+        if (allAddedRuns.containsKey(run.getElementId())) {
             
             //the run has previously been added; get the count of number of times it has been added previously
-            timesAddedToRunList = allAddedRuns.get(run);
+            timesAddedToRunList = allAddedRuns.get(run.getElementId());
             
             //indicate another addition is occurring
             timesAddedToRunList++ ;
-            allAddedRuns.put(run, timesAddedToRunList);
+            allAddedRuns.put(run.getElementId(), timesAddedToRunList);
             
         } else {
             
             //this is the first time the run has been added
-            allAddedRuns.put(run,  1);
+            allAddedRuns.put(run.getElementId(),  1);
             timesAddedToRunList = 1;
         }
         
@@ -161,7 +162,7 @@ public class UnavailableRunsList {
         UnavailableRun nextRun;
         while (iterator.hasNext()) {
             nextRun = iterator.next();
-            if (nextRun != null  &&  nextRun.getRun().equals(run)) {
+            if (nextRun != null  &&  nextRun.getRun().getElementId().equals(run.getElementId())) {
                 //we found the specified Run in the list
                 return true;
             }

--- a/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
+++ b/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
@@ -176,16 +176,15 @@ public class UnavailableRunsList {
         long timeNow = contest.getContestTime().getElapsedSecs();
         
         //repeatedly look at the run at the head of the queue to see if its expiration time has passed
-        while (unavailableRuns.peek().getExpirationTimeInSecs() < timeNow) {
+        while ( (unavailableRuns.peek()!=null) && (unavailableRuns.peek().getExpirationTimeInSecs() < timeNow) ) {
             
             //the run at the head of the queue has an expiration time which has passed; remove it from the queue
             // (note that method "poll()" is the PriorityBlockingQueue method to remove the head of the queue without blocking if the queue is empty)
             UnavailableRun removedRun = unavailableRuns.poll();
             
-            //if we actually removed a run and we have a non-null log, log the removal
-            //  (note that poll() can return null if the queue is empty)
-            if (removedRun!=null && log!=null) {
-                    log.info("Removed run " + removedRun.getRun().getNumber() + " from UnavailableRuns list");
+            //log the removal
+            if (log!=null) {
+                log.info("Removed run " + removedRun.getRun().getNumber() + " from UnavailableRuns list");
             }
         }
     }

--- a/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
+++ b/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
@@ -101,7 +101,6 @@ public class UnavailableRunsList {
             if (log!=null) {
                 log.warning("Attempted to add a null run to the UnavailableRunsList!");
             } else {
-                System.err.println("Attempted to add a null run to the UnavailableRunsList, and no log is available for logging!!");
                 throw new RuntimeException("Attempted to add a null run to the UnavailableRunsList, and no log is available for logging!!");
             }
         }
@@ -139,11 +138,11 @@ public class UnavailableRunsList {
         unavailableRuns.add(runToAdd);
         
         if (log!=null) { 
-            log.info("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList 
+            log.info("Added run " + run.getNumber() + " from site " + run.getSiteNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList 
                             + "; time until expiration = " + expirationLengthInSecs + " secs); list size = " + unavailableRuns.size());
         } else {
-            System.err.println("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ") but no log was available for logging!!");
-            throw new RuntimeException("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ") but no log was available for logging!!");            
+            throw new RuntimeException("Added run " + run.getNumber() + " from site " + run.getSiteNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList 
+                            + "; time until expiration = " + expirationLengthInSecs + " secs; list size = " + unavailableRuns.size()+ ") but no log was available for logging!!");            
         }
     }
     

--- a/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
+++ b/src/edu/csus/ecs/pc2/core/list/UnavailableRunsList.java
@@ -131,13 +131,15 @@ public class UnavailableRunsList {
         //   increase.  However, since this entire class is (hopefully) temporary, I didn't spend any more time on that... jlc)
         long contestTimeNowInSecs = contest.getContestTime().getElapsedSecs();
         long expirationTimeInSecs = contestTimeNowInSecs + (INITIAL_EXPIRATION_TIME_OFFSET_SECS * timesAddedToRunList) ;
+        long expirationLengthInSecs = expirationTimeInSecs - contestTimeNowInSecs;
         
         //add the run to the priority queue (note that method add(run) adds the run into the queue in priority order based on the expiration time in the run)
         UnavailableRun runToAdd = new UnavailableRun(run, expirationTimeInSecs);
         unavailableRuns.add(runToAdd);
         
         if (log!=null) { 
-            log.info("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ")");
+            log.info("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList 
+                            + "; time until expiration = " + expirationLengthInSecs + " secs); list size = " + unavailableRuns.size());
         } else {
             System.err.println("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ") but no log was available for logging!!");
             throw new RuntimeException("Added run " + run.getNumber() + " to UnavailableRuns list (times added = " + timesAddedToRunList + ") but no log was available for logging!!");            

--- a/src/edu/csus/ecs/pc2/core/model/UnavailableRun.java
+++ b/src/edu/csus/ecs/pc2/core/model/UnavailableRun.java
@@ -1,0 +1,63 @@
+package edu.csus.ecs.pc2.core.model;
+
+import edu.csus.ecs.pc2.core.list.UnavailableRunsList;
+
+/**
+ * This class encapsulates a {@link Run} which an AutoJudge has detected as being "Unavailable" -- that is, a Run
+ * for which the AJ received back a "RUN_NOTAVAILABLE" response (packet) when it issued a "RUN_CHECKOUT" request.
+ * 
+ * The encapsulation contains two things:  the {@link Run} which an AJ has determined is "unavailable", and an
+ * "expiration time", which is the contest elapsed time (in seconds) when the run should no longer be considered "unavailable"
+ * (that is, a "timeout" value for removing the run from the list of Unavailable Runs).
+ * 
+ * Note that UnavailableRuns do not automatically get removed from the UnavailableRuns list when their expiration time
+ * arrives; see {@link UnavailableRunsList#addRun(Run)} and {@link UnavailableRunsList#removeExpiredRuns()}.
+ * 
+ * The class is intended as temporary support -- a workaround for https://github.com/pc2ccs/pc2v9/issues/480.
+ * 
+ * @author John Clevenger, PC2 Development Team (pc2@ecs.csus.edu)
+ *
+ */
+public class UnavailableRun {
+
+    //the Run which has been determined to be unavailable
+    private Run run;
+    
+    //the contest elapsed time, in seconds, when the Run's time on the UnavailableRunsList expires
+    private long expirationTimeInSecs;
+    
+    /**
+     * Constructs an UnavailableRun object containing a {@link Run} which an AutoJudge has determined is "unavailable",
+     * together with an "expiration time" -- a contest elapsed time (in seconds) at which the contained Run should no longer be 
+     * treated as unavailable.
+     * 
+     * @param run the Run which has been determined by an AJ to be "unavailable".
+     * @param expirationTimeInSecs the contest elapsed time (in seconds) when the specified Run should no longer be considered "unavailable".
+     */
+    public UnavailableRun (Run run, long expirationTimeInSecs) {
+        
+        this.run = run;
+        this.expirationTimeInSecs = expirationTimeInSecs;
+    }
+
+    /**
+     * Returns the {@link Run} contained in this UnavailableRun object -- that is, the Run which at some point was
+     * determined by an AutoJudge to be "unavailable".
+     * 
+     * @return the Run which is (or was at some point) "unavailable".
+     */
+    public Run getRun() {
+        return run;
+    }
+
+    /**
+     * Returns the expiration time (contest elapsed time in seconds) for the {@link Run} contained in this UnavailableRun object.
+     * 
+     * @return the expiration time of the unavailability of the contained Run.
+     */
+    public long getExpirationTimeInSecs() {
+        return expirationTimeInSecs;
+    }
+    
+    
+}

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -194,7 +194,11 @@ public class AutoJudgingMonitor implements UIPlugin {
         
         //make sure that any runs which were previously put on the "unavailable runs" list but whose "expiration time"
         // for being on that list has passed get removed from the list, so that the following loop will (again) consider them.  
-        getUnavailableRunsList().removeExpiredRuns();
+        try {
+            getUnavailableRunsList().removeExpiredRuns();
+        } catch (Exception e) {
+            log.log(Log.WARNING, "Exception while attempting to remove expired runs from UnavailableRunsList: ", e);
+        }
 
         for (Run run : runs) {
             if (run.getStatus() == RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT && !getUnavailableRunsList().contains(run)) {

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -352,7 +352,7 @@ public class AutoJudgingMonitor implements UIPlugin {
                                 && event.getRun().getSiteNumber() == runBeingAutoJudged.getSiteNumber()) {
                             
                             // the run we requested is not available -- log this unusual (though possibly legitimate) condition
-                            log.info("Received 'NOT_AVAILABLE' message for requested run " + event.getRun().getNumber() );
+                            log.info("Received 'RUN_NOT_AVAILABLE' message for requested run " + event.getRun().getNumber() + " from site " + event.getRun().getSiteNumber() );
                             
                             //add the run to the list of requested-but-unavailable runs 
                             // (a patch to support keeping the AJ from continually re-requesting the same run; see https://github.com/pc2ccs/pc2v9/issues/480)

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -356,7 +356,16 @@ public class AutoJudgingMonitor implements UIPlugin {
                             
                             //add the run to the list of requested-but-unavailable runs 
                             // (a patch to support keeping the AJ from continually re-requesting the same run; see https://github.com/pc2ccs/pc2v9/issues/480)
-                            getUnavailableRunsList().addRun(runBeingAutoJudged); 
+                            try {
+                                getUnavailableRunsList().addRun(runBeingAutoJudged);
+                            } catch (Exception e1) {
+                                if (runBeingAutoJudged!=null) {
+                                    log.log(Log.WARNING, "Exception attempting to add run " + runBeingAutoJudged.getNumber() 
+                                                        + " from site " + runBeingAutoJudged.getSiteNumber() + " to UnavailableRunsList: ", e1);
+                                } else {
+                                    log.log(Log.WARNING, "Exception attempting to add null run to UnavailableRunsList: ", e1);
+                                }
+                            } 
                             
                             // indicate a response to the RUN_REQUEST was received, so fetchRun can exit
                             synchronized (listening) {

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -16,6 +16,7 @@ import edu.csus.ecs.pc2.core.execute.Executable;
 import edu.csus.ecs.pc2.core.execute.ExecutionData;
 import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
 import edu.csus.ecs.pc2.core.list.RunComparatorByElapsedRunIdSite;
+import edu.csus.ecs.pc2.core.list.UnavailableRunsList;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientSettings;
@@ -90,6 +91,8 @@ public class AutoJudgingMonitor implements UIPlugin {
     private boolean judgingRun;
     
     private Runnable controlLoop = null;
+
+    private UnavailableRunsList unavailableRunsList;
 
     // private edu.csus.ecs.pc2.ui.AutoJudgingMonitor.FetchRunListenerImplemenation fetchRunListenerImplemenation;
 
@@ -188,9 +191,13 @@ public class AutoJudgingMonitor implements UIPlugin {
 
         Run[] runs = contest.getRuns();
         Arrays.sort(runs,new RunComparatorByElapsedRunIdSite());
+        
+        //make sure that any runs which were previously put on the "unavailable runs" list but whose "expiration time"
+        // for being on that list has passed get removed from the list, so that the following loop will (again) consider them.  
+        getUnavailableRunsList().removeExpiredRuns();
 
         for (Run run : runs) {
-            if (run.getStatus() == RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT) {
+            if (run.getStatus() == RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT && !getUnavailableRunsList().contains(run)) {
                 if (filter.matches(run)) {
                     return run;
                 }
@@ -199,6 +206,7 @@ public class AutoJudgingMonitor implements UIPlugin {
 
         return null;
     }
+
 
     /**
      * get filter which contains problems to be auto judged.
@@ -338,8 +346,15 @@ public class AutoJudgingMonitor implements UIPlugin {
                         // and we received a not available for the run we were requesting
                         if (event.getRun().getNumber() ==  runBeingAutoJudged.getNumber() 
                                 && event.getRun().getSiteNumber() == runBeingAutoJudged.getSiteNumber()) {
-                            // XXX should we log this?
-                            // claim to have received it, so fetchRun can exit
+                            
+                            // the run we requested is not available -- log this unusual (though possibly legitimate) condition
+                            log.info("Received 'NOT_AVAILABLE' message for requested run " + event.getRun().getNumber() );
+                            
+                            //add the run to the list of requested-but-unavailable runs 
+                            // (a patch to support keeping the AJ from continually re-requesting the same run; see https://github.com/pc2ccs/pc2v9/issues/480)
+                            getUnavailableRunsList().addRun(runBeingAutoJudged); 
+                            
+                            // indicate a response to the RUN_REQUEST was received, so fetchRun can exit
                             synchronized (listening) {
                                 try {
                                     answerReceived = true;
@@ -359,6 +374,21 @@ public class AutoJudgingMonitor implements UIPlugin {
         public void runRemoved(RunEvent event) {
             // ignored
         }
+    }
+    
+    /**
+     * Returns the list of runs which this judge has previously requested and then received back a
+     * RUN_NOTAVAILABLE message.  
+     * If the list does not already exist, an (empty) list is created and returned.
+     * 
+     * @return the list of previously-requested but unavailable runs.
+     */
+    private UnavailableRunsList getUnavailableRunsList() {
+        
+        if (unavailableRunsList == null) {
+            unavailableRunsList = new UnavailableRunsList(contest,controller);
+        }
+        return unavailableRunsList;
     }
 
     /**


### PR DESCRIPTION

### Description of what the PR does

Adds classes and code changes which cause the `AutoJudgingMonitor` to avoid repeatedly fetching runs for which it has already received a "RUN_NOTAVAILABLE" response to a "RUN_CHECKOUT" request.

Specifically, when the AJMonitor receives a "RUN_NOTAVAILABLE" response it adds the run to an "UnavailableRunsList", together with an "expiration time".  The AJMonitor will never attempt to fetch a run, even if the run is in state QUEUED_FOR_COMPUTER_JUDGEMENT, if the run is currently on the UnavailableRunsList.  The run remains on the list until its "expiration time" arrives, after which time the AJMonitor will again consider attempting to fetch the run.  Runs which get re-added to the UnavailableRunsList are assigned an increasing "expiration time" each time they are re-added.

### Issue which the PR fixes
Fixes #480 

### Environment in which the PR was developed:
Windows 10.1, Eclipse Version: 2019-12 (4.14.0), Java 1.8.0_201.

### Precise steps for _testing_ the PR

It is difficult to establish a completely valid test for this PR because of the fact that the root cause for the issue (runs which appear to be QUEUED_FOR_COMPUTER_JUDGEMENT, or "QFCJ", but which return "NOT AVAILABLE" when they are requested by the AJ) is not known.
Since the root cause isn't known, it's not clear how to reliably generate the situation which this PR addresses.  
The best that can be done is to create those conditions "artificially" and demonstrate that under such conditions the PR code behaves as expected/intended.

The requisite condition for testing the PR is that there are run(s) which appear to be in state QFCJ, but when they are requested by an AJ they return "NOT AVAILABLE".
The purpose of the PR code is to have the AJ put such runs on an "UnavailableRuns" list and not continue to request them.  In addition, the PR is intended to ensure that runs which get put on such an "UnavailableRuns" list are REMOVED from that list after an "expiration time", so that the AJ will (eventually) try them again.
Finally, if the AJ detects that it has encountered an "UnavailableRun" which it has previously seen, it should be put back on the UnavailableRuns list WITH A LONGER EXPIRATION TIME.

There are two methods which have been devised to artificially generate the conditions which will exercise the PR code.
Both methods involve doing two things: (1) removing the "runfiles" for a run (so that a RUN_CHECKOUT request will return "NOT_AVAILABLE"), and (2) ensuring that a run remains in the QFCJ state even when a previous checkout has failed (this is necessary because by default a run whose checkout fails is moved to the NEW state).

The first method involves using the debugger to step through the AutoJudgingMonitor code, pausing it after each time it fetches a run and gets back "NOT AVAILABLE".  During each pause, the run state on the server is modified from "NEW" (to which it reverts when the previous checkout/execution fails) back to "QFCJ".
This approach works, but is complicated not only by the need to use the debugger (thus potentially changing timing), but also by the fact that a run which has been made "bad" by removing its runfiles cannot be edited to change its state (the EditRun frame does not allow editing a "bad" (unavailable) run; see https://github.com/pc2ccs/pc2v9/issues/482).
Thus this approach requires repeatedly removing the runfiles, stepping once through the AJMonitor loop, restoring the runfiles, editing the run's state back to QFCJ, then removing the runfiles again before stepping the AJMonitor once more.

The second method is to use a modified version of the `PacketHandler` class.  In method `PacketHandler.checkoutRun()`, when it fails to get the runfiles it currently cancels the run checkout and then sets the run state to NEW; changing this to instead set the state to QFCJ will accomplish the goal.
The drawback of this approach is that it requires testing with a modified version of the code -- a version that should never be allowed to be put into production.

For either of these methods, the AJ log will show runs continually being attempted to be fetched, getting back NOT_AVAILABLE, and moving the runs to the UnavailableRuns list, with increasingly larger "expiration times".

Both of the above methods have been applied to verify the PR:  JohnC has applied the first method (using the debugger) while JohnB has applied the second method (using a modified `PacketHandler`).  Both approaches demonstrated that the PR works as intended/expected.

A summary of steps for each method follows.

## Method 1: Using the debugger
 
- Setup:
  - Download the distribution/code for the PR.
  - Start a server configured with a contest having at least one problem (we'll call it "Problem A"), one team, and one AutoJudge (we'll assume it's Judge9, but it doesn't matter) enabled for judging Problem A.
  - Start an Admin, verify the configuration (including that Judge9 is configured and enabled to auto-judge Problem A).
  - In Eclipse:
    - Ensure that you have pulled the PR code.  
    - Open the code for the `AutoJudgingMonitor` class.
    - Put a breakpoint at the start of method `findNextAutoJudgeRun()`.  
    - Start a PC2v9 client (within Eclipse); login as Judge 9.
    - This should cause the AJ to stop at the breakpoint.
  - On the Admin, start the contest clock.
  - Start a team client (inside or outside Eclipse; doesn't matter).
  - Submit a run for Problem A.
  - Verify that the submission shows as QUEUED_FOR_COMPUTER_JUDGEMENT ("QFCJ") on the Admin.
  - Hit "continue" in the Eclipse debugger.  This should cause the AJ to successfully fetch the run, judge it, and return a judgement, then stop at the breakpoint again when it loops around to begin looking for another run to judge.
  - As soon as the AJ finishes judging the run, IMMEDIATELY stop the contest clock on the Admin.
    - This is so that we can make the run become "unavailable" before its "expiration time" is reached, which defaults initially to 60 seconds.
  - Verify that the run now shows as "judged" on the Admin ("Status" is either "yes" or "no-xxx", depending on what code you submitted).

- Verify that an "unavailable" run gets moved to unavailableRunsList and not processed further. To do this:
  - On the Admin, edit the run: change its state from JUDGED to QUEUED_FOR_COMPUTER_JUDGEMENT (QFCJ).
  - On the SERVER: in the profiles/xxxx/db.1 folder, move the run files for the run (files named like "s1r1.xxx.files") to a temporary holding place. Be sure to SAVE the runfiles (that is, MOVE them, don't DELETE them; see below).
    - Be sure to do this file moving AFTER the above step of changing the run state, since the EditRun frame will not allow editing a run if its runfiles have been removed).
  - In the Eclipse debugger, hit "Continue".
    - This will cause the AJ to see the run again (because it is QFCJ), and therefore to send a RUN_CHECKOUT request for the run.
    - Because the runfiles for the run are missing, the server will reply with a "RUN_NOTAVAILABLE" packet.
    - When the AJ gets this packet, it will put the run on the "UnavailableRunsList".
    - The AJ will then loop back around to look for more runs, and will hit the breakpoint again.
  - On the Admin, verify that the run state has changed to NEW (this is because the server recognized the failed checkout; the PacketHandler changes the state to NEW in that case).
  - In the debugger, open the AJMonitor's "variables" list and examine the "unavailableRunsList" element:
    - Verify that the hashtable element named "allAddedRuns" has a single entry; the "key" will be the ElementId of the submitted Run and the "value" should be "1" (because this run has been added to the unavailableRunsList just once).
    - Verify that the "unavailableRuns" element of the "unavailableRunsList" is a PriorityBlockingQueue with one entry:  an "unavailableRun" containing two things:  a Run whose ElementId is the same as the ElementId found in the "allAddedRuns" hashtable, and an "expirationTimeInSeconds" with a value that is (roughly) 60 greater than the number of contest seconds that had elapsed on the contest clock at the time at which you submitted the run.  (For example, if the run was submitted exactly two minutes (120 seconds) into the contest, the value should be something like 120+60=180.)
    - If both the above checks verify successfully, it means the AJ correctly moved the (bad, unavailable) run to the unavailableRunsList, with an expiration time in the (near) future.
  - Examine the AJ log (under "logs" in the Eclipse Workspace); verify the existence of the above sequence is correctly logged near the end of the log:
    - AJ sends "RUN_REQUEST" to server.
    - AJ gets back a "RUN_NOTAVAILABLE" packet, handled in method RunsPane.RunListener.
    - AJ logs a message like:
```
        220710 124451.248|INFO|Thread-29|addRun|Added run 1 to UnavailableRuns list (times added = 1; time until expiration = 60 secs); list size = 1
```
   
    - ensure that the RunId is correct ('1' in the above example, because only one run was submitted).
    - ensure that the "times added" value is 1 (because this is the first time this run was found to be "unavailable").  
    - ensure that the "time until expiration" is 60 seconds.
    - ensure that the "list size" is 1.

- Verify that an unavailable run moves OFF the unavailableRunsList when its "expiration time" arrives. To do this:
  - On the Admin, start the clock.
  - Wait two minutes (to ensure the 60-second "expiration time" has passed regardless of where in the minute the sequence of events occurs).
  - Stop the clock.
  - In the Debugger, hit "continue".  This will cause the AJ to go through another "fetch cycle"  - part of which includes calling `UnavailableRunsList.removeExpiredRuns()`.  Since more than the 60-second "expiration time" has now elapsed on the contest clock the AJ should remove the previously-quarantined run from the unavailableRuns list. However, the AJ won't see any "QFCJ" runs (because the run is currently in state "NEW").  The AJ will loop back around and hit the breakpoint again.
  - In the Debugger, examine the AJMonitor's UnavailableRunsList's "allAddedRuns" hashtable and "unavailableRuns" PriorityBlocking queue.  The queue should be empty, but the run should still appear in the hashtable and have a value of 1.
    - This demonstrates that the AJ correctly removed the run from the UnavailableRunsList.

- Verify that an unavailable run which has previously been seen (as unavailable) gets put on the unavailableRunsList but with a longer "expiration time" and an increased "timesAdded" count. To do this:
  - On the server, RESTORE the run files for the run from the place where you saved them, above (i.e., copy them back into the db.1 folder).  This is so the run's state can be properly edited...
  - On the Admin, edit the run:  change its state back to QUEUED_FOR_COMPUTER_JUDGEMENT.
    - Since the AJ is not running, the run will remaining showing on the Admin as QUEUED.
  - Again move the "runfiles" out of the db.1 folder (saving them somewhere else for later).
    - This means the state is that the run is "QUEUED" but is going to generate a "NOT_AVAILABLE" response to a checkout request.
  - Hit "continue" in the debugger. This will cause the AJ to fetch the (one) QUEUED run, process it (which will fail), and loop back around, stopping at the same breakpoint again.
  - In the debugger, again examine the AJMonitor's UnavailableRunsList:  
    - the run should again be present in the unavailableRuns PriorityBlockingQueue.
    - the run should have an "expiration time" which is approximately 240 larger than what it had the first time it was put on the list (2 minutes while the clock advanced plus 120 seconds due to the "increased time" algorithm).
    - the run should still be present in the "allAddedRuns" hashtable, with a "count" of 2.
    - the run should be the ONLY run in the "allAddedRuns" hashtable.
  - Examine the AJ log:
    - Verify that the log shows that the AJ issued a "RUN_CHECKOUT" request for the run, got back a "RUN_NOTAVAILABLE" response, and put the run on the "unavailableRuns" list for the second time and with a timeout of 120 seconds.
    - Verify that the AJ logs a message like:
```
        220710 144831.453|INFO|Thread-35|addRun|Added run 1 to UnavailableRuns list (times added = 2; time until expiration = 120 secs); list size = 1
```
    - ensure that the RunId is correct ('1' in the above example, because only one run was submitted).
    - ensure that the "times added" value is 2 (because this is the second time this run was found to be "unavailable").  
    - ensure that the "time until expiration" is 120 seconds (because the value increases each time the same run is found "unavailable").
  
If all of the above works as specified, the AJ is correctly putting UNAVAILABLE RUNS on the "unavailable runs list", removing them when their time expires, and putting them back on the list (with increasing expiration time) if they ever come up again.


## Method 2: Testing by modifying PacketHandler

- Edit the PacketHandler class: around line 3584, change the statement
```
                                theRun.setStatus(Run.RunStates.NEW);
```
to instead be
```
                                theRun.setStatus(Run.RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT);
```

- Start Server, loading a contest with at least one problem ("A"), one team, and one judge.
- Set up judge to AJ problem A.
- Log in as a team and make 5 submissions on Problem A.
- Go into the profiles/xxxxx/db.1 and remove the s1rNNNN.files files for each submission (sort the folder by date, they'll all be at the top).  NNNN is the runID for each of the submissions made above.
- Start up the judge
  - it should attempt to judge each run.
  - it will get back "NOT AVAILABLE" for each run, causing it to put the runs on the UnavailableRuns list.
- Look at the Runs tab (or All Runs) and note that the 5 submissions will still say QFCJ.
- Note that the AJ will not request those QFCJ runs -- because they are all on the "UnavailableRunsList" (with "expiration times" of 60 seconds).
- After 1 minute the AJ will automatically attempt to re-judge all 5 submissions (because their "expiration time" has arrived).
  - The AJ will (again) get back "NOT AVAILABLE", which will cause it to put the runs (again) on the UnavailableRuns list, but with a longer expiration time (2 minutes).
- The AJ will wait 2 minutes, then attempt to re-judge all 5 submissions.
  - again it will fail, putting the runs back on the UnavailableRuns list, but with an even longer time (3 minutes).
- The AJ will continue like this, waiting until the expiration time is reached (longer each time), and then attempting to rejudge the runs (and failing, putting them back on the UnavailableRuns list).
- This will continue forever, with increasingly long expiration times between each attempt.



