### PR TITLE
I 484 improvement with run processing and saving run list

### DIFF
--- a/src/edu/csus/ecs/pc2/core/list/RunList.java
+++ b/src/edu/csus/ecs/pc2/core/list/RunList.java
@@ -35,7 +35,7 @@ public class RunList implements Serializable {
      * List of runs.
      */
     private Hashtable<String, Run> runHash = new Hashtable<String, Run>(200);
-    
+
     /**
      * Lock for accessing list of runs.
      */
@@ -52,9 +52,14 @@ public class RunList implements Serializable {
 
     private LinkedList<String> backupList = new LinkedList<String>();
     
+    private RunListWriteThread runListWriteThread = null;
+    
+    private Object runListWriteLock = new Object();
+
     public RunList() {
         saveToDisk = false;
         nextRunNumber = getINIBaseRunNumber();
+        createAndStartRunListWriteThread();
     }
 
     private int getINIBaseRunNumber() {
@@ -79,7 +84,7 @@ public class RunList implements Serializable {
         } else {
             retVal = 1;
         }
-        
+
         return retVal;
     }
 
@@ -110,7 +115,7 @@ public class RunList implements Serializable {
         add(run);
         return run;
     }
-    
+
     /**
      * Add a run into the run list, no changes.
      * @param run
@@ -126,7 +131,7 @@ public class RunList implements Serializable {
             writeToDisk();
         }
     }
-    
+
 
     /**
      * Get a run from the list.
@@ -175,7 +180,7 @@ public class RunList implements Serializable {
      * @throws IOException 
      */
     public boolean delete(Run run) throws IOException, ClassNotFoundException, FileSecurityException {
-        
+
         synchronized (runHashLock) {
             Run fetchedRun = get(getRunKey(run));
             if (fetchedRun == null) {
@@ -186,7 +191,7 @@ public class RunList implements Serializable {
         }
         writeToDisk();
         return true;
-        
+
 
     }
 
@@ -271,7 +276,7 @@ public class RunList implements Serializable {
         }
         writeToDisk();
     }
-    
+
     public Enumeration <Run> getRunList() {
         synchronized (runHashLock) {
             return runHash.elements();
@@ -281,8 +286,8 @@ public class RunList implements Serializable {
     protected String getFileName() {
         return storage.getDirectoryName() + File.separator + "runlist.dat";
     }
-    
-    
+
+
     public String getBackupFilename() {
         return storage.getDirectoryName() + File.separator + "runlist." + Utilities.getDateTime() + "." + System.nanoTime() + ".dat";
     }
@@ -303,40 +308,11 @@ public class RunList implements Serializable {
             return false;
         }
         
-        boolean stored;
-        String fileName = getFileName();
-        
-        String backupFilename;
-        
-        Hashtable<String, Run>copyofRunHash;
-        synchronized (runHashLock) {
-            backupFilename = getBackupFilename();
-            
-            try {
-                File currentRunList = new File (fileName);
-                File backupRunList= new File (backupFilename);
+        synchronized (runListWriteLock) {
+            runListWriteLock.notify();
+        }
 
-                currentRunList.renameTo(backupRunList);
-            } catch (Exception e) {
-                StaticLog.getLog().log(Log.WARNING, "FAILED to rename current " + fileName + " to " + backupFilename, e);
-            }
-            
-            copyofRunHash = new Hashtable<String, Run>(runHash);
-            
-            stored = storage.store(fileName, copyofRunHash);
-        }
-        stored =  true;
-        
-        backupList.add(backupFilename);
-        while(backupList.size() > 100) {
-            String removeBackupFile = backupList.removeFirst();
-            File file = new File(removeBackupFile);
-            if (file.exists()) {
-                file.delete();
-            }
-        }
-       
-        return stored;
+        return true;
     }
 
     /**
@@ -414,7 +390,7 @@ public class RunList implements Serializable {
             logException("Unable to copy run info files " + getFileName() + " to " + storage2.getDirectoryName(), e);
         }
     }
-    
+
     private void logException(String string, Exception e) {
         if (StaticLog.getLog() != null) {
             StaticLog.getLog().log(Log.WARNING, string, e);
@@ -423,9 +399,97 @@ public class RunList implements Serializable {
             e.printStackTrace(System.err);
         }
     }
-    
+
     public int getNextRunNumber() {
         return nextRunNumber;
+    }
+
+    /**
+     * Backup and store run list.
+     * @return true if run list and backup done.
+     */
+    boolean backupAndWriteRunList() {
+
+        boolean stored = false;
+
+        String fileName = getFileName();
+
+        String backupFilename;
+
+        Hashtable<String, Run> copyofRunHash;
+
+        try {
+
+            synchronized (runHashLock) {
+                backupFilename = getBackupFilename();
+
+                try {
+                    File currentRunList = new File(fileName);
+                    File backupRunList = new File(backupFilename);
+
+                    currentRunList.renameTo(backupRunList);
+                } catch (Exception e) {
+                    StaticLog.getLog().log(Log.WARNING, "FAILED to rename current " + fileName + " to " + backupFilename, e);
+                }
+
+                copyofRunHash = new Hashtable<String, Run>(runHash);
+
+                stored = storage.store(fileName, copyofRunHash);
+            }
+            stored = true;
+
+            backupList.add(backupFilename);
+            while (backupList.size() > 100) {
+                String removeBackupFile = backupList.removeFirst();
+                File file = new File(removeBackupFile);
+                if (file.exists()) {
+                    file.delete();
+                }
+            }
+
+        } catch (Exception e) {
+            StaticLog.getLog().log(Log.WARNING, "Problem storing or backing up run list", e);
+        }
+
+        return stored;
+    }
+    
+    
+    public RunListWriteThread createAndStartRunListWriteThread() {
+        if (runListWriteThread == null) {
+            runListWriteThread = new RunListWriteThread();
+            runListWriteThread.start();
+        }
+        
+        return runListWriteThread;
+    }
+    
+    
+    /**
+     * Thread that writes that backs up and writes run list file.
+     * 
+     * @author Douglas A. Lane <pc2@ecs.csus.edu>
+     *
+     */
+    class RunListWriteThread extends Thread {
+
+        @Override
+        public void run() {
+            try {
+
+                synchronized (runListWriteLock) {
+                    while (true) {
+                        runListWriteLock.wait();
+                        backupAndWriteRunList();
+                        
+                    }
+                }
+
+            } catch (Exception e) {
+                StaticLog.getLog().log(Log.WARNING, "Problem storing or backing up run list", e);
+            }
+
+        }
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/list/RunList.java
+++ b/src/edu/csus/ecs/pc2/core/list/RunList.java
@@ -56,6 +56,8 @@ public class RunList implements Serializable {
     
     private Object runListWriteLock = new Object();
 
+    private Object diskWriteLock = new Object();
+
     public RunList() {
         saveToDisk = false;
         nextRunNumber = getINIBaseRunNumber();
@@ -433,7 +435,9 @@ public class RunList implements Serializable {
                 }
 
                 copyofRunHash = new Hashtable<String, Run>(runHash);
-
+            }
+            
+            synchronized (diskWriteLock) {
                 stored = storage.store(fileName, copyofRunHash);
             }
             stored = true;

--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.File;
@@ -794,10 +794,10 @@ public class InternalContest implements IInternalContest {
             runFilesList.add(newRun, runFiles);
             SerializedFile file = runFiles.getMainFile();
             if (file != null){
-                run.setEntryPoint(file.getName());
+                newRun.setEntryPoint(file.getName());
+                addRun(newRun);
             }
         }
-        addRun(newRun);
         return newRun;
     }
 

--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -792,11 +792,11 @@ public class InternalContest implements IInternalContest {
         Run newRun = runList.addNewRun(run); // this set the run number.
         if (runFiles != null) {
             runFilesList.add(newRun, runFiles);
-            SerializedFile file = runFiles.getMainFile();
-            if (file != null){
-                newRun.setEntryPoint(file.getName());
-                addRun(newRun);
-            }
+//            SerializedFile file = runFiles.getMainFile();
+//            if (file != null){
+//                newRun.setEntryPoint(file.getName());
+//                addRun(newRun);
+//            }
         }
         return newRun;
     }

--- a/test/edu/csus/ecs/pc2/core/list/RunListTest.java
+++ b/test/edu/csus/ecs/pc2/core/list/RunListTest.java
@@ -229,9 +229,7 @@ public class RunListTest extends AbstractTestCase {
 //        startExplorer(new File(testDir));
         
         
-        // TODO 
-//        Thread.sleep(20* 000);
-//        assertExpectedFileCount("Expecting runlist files count ", new File(testDir), 8);
+        assertExpectedFileCount("Expecting runlist files count ", new File(testDir), 8);
         assertNoZeroSizeFiles(new File(testDir));
         
     }

--- a/test/edu/csus/ecs/pc2/core/list/RunListTest.java
+++ b/test/edu/csus/ecs/pc2/core/list/RunListTest.java
@@ -223,16 +223,16 @@ public class RunListTest extends AbstractTestCase {
 
         Run[] runs = sample.createRandomRuns(contest, numRuns, true, true, true);
         
+        runList.setSaveToDisk(true);
+        
         for (Run run : runs) {
             runList.addNewRun(run);
             runList.updateRun(run);
         }
         
-        runList.setSaveToDisk(true);
-
 //        startExplorer(new File(testDir));
         
-        assertExpectedFileCount("Expecting dir entries ", new File(testDir), 9);
+        assertExpectedFileCount("Expecting runlist files count ", new File(testDir), 8);
         
         assertNoZeroSizeFiles(new File(testDir));
         

--- a/test/edu/csus/ecs/pc2/core/list/RunListTest.java
+++ b/test/edu/csus/ecs/pc2/core/list/RunListTest.java
@@ -132,9 +132,9 @@ public class RunListTest extends AbstractTestCase {
         int numRuns = 500;
         
         String testDir = getOutputDataDirectory("runlistbackupStress");
-
         removeDirectory(testDir); // remove files from previous test
-
+//        startExplorer(testDir);
+        
         new File(testDir).mkdirs();
         
         FileStorage storage = new FileStorage(testDir);
@@ -142,8 +142,6 @@ public class RunListTest extends AbstractTestCase {
 
         SampleContest sample = new SampleContest();
         IInternalContest contest = sample.createContest(2, 12, 22, 12, true);
-
- 
 
         Run[] runs = sample.createRandomRuns(contest, numRuns, true, true, true);
 
@@ -182,7 +180,6 @@ public class RunListTest extends AbstractTestCase {
         
         // 101 because we only keep 100 backups + 1 runlist.dat
         assertExpectedFileCount("Expecting dir entries ", new File(testDir), 101);
-        
         assertNoZeroSizeFiles(new File(testDir));
         
     }
@@ -208,7 +205,6 @@ public class RunListTest extends AbstractTestCase {
     public void testBackup() throws Exception {
         
         String testDir = getOutputDataDirectory("runlistbackup");
-
         removeDirectory(testDir); // remove files from previous test
 
         new File(testDir).mkdirs();
@@ -232,8 +228,10 @@ public class RunListTest extends AbstractTestCase {
         
 //        startExplorer(new File(testDir));
         
-        assertExpectedFileCount("Expecting runlist files count ", new File(testDir), 8);
         
+        // TODO 
+//        Thread.sleep(20* 000);
+//        assertExpectedFileCount("Expecting runlist files count ", new File(testDir), 8);
         assertNoZeroSizeFiles(new File(testDir));
         
     }


### PR DESCRIPTION
### Description of what the PR does

Now runlist is run on a thread

Two unit tests are failing because not all runlist files are written.  Sometimes the unit tests pass, sometimes they don't.

for testBackupStressUsingThreads
org.junit.ComparisonFailure: Expecting dir entries  in C:\repos\lane55fork\.\testout\RunListTest\runlistbackupStress expected:<[101]> but was:<[5]>

for testBackup
org.junit.ComparisonFailure: Expecting runlist files count  in C:\repos\lane55fork\.\testout\RunListTest\runlistbackup expected:<[8]> but was:<[2]>

### Issue which the PR fixes

#484 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)