### PR TITLE
i490:  Add --nostandings to not load Standings panes

### DIFF
--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.File;
@@ -130,6 +130,10 @@ import edu.csus.ecs.pc2.ui.UIPluginList;
  */
 public class InternalController implements IInternalController, ITwoToOne, IBtoA {
 
+    /**
+     * Do not show standings panes on AdminView
+     */
+    private static final String NOSTANDINGS_OPTION_STRING = "--nostandings";
 
     private static final String INI_FILENAME_OPTION_STRING = "--ini";
 
@@ -3254,7 +3258,8 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                     "[" + LOAD_OPTION_STRING + " <dir>|<file> ] " + //
                     "[--skipini] " + //
                     "[" + INI_FILENAME_OPTION_STRING + " filename] [" + //
-                    CONTEST_PASSWORD_OPTION + " <pass>] [" + NO_GUI_OPTION_STRING + "] "+ //
+                    CONTEST_PASSWORD_OPTION + " <pass>] [" + NO_GUI_OPTION_STRING + "] "+ // 
+                    "[" + NOSTANDINGS_OPTION_STRING + "] "+ //
                     "[" + REMOTE_SERVER_OPTION_STRING + " <remoteHostname> --proxyme]" + //
                     "[" + MAIN_UI_OPTION + " classname]", // 
                     "", //
@@ -3280,6 +3285,10 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             }
         }
 
+        if (parseArguments.isOptPresent(NOSTANDINGS_OPTION_STRING)) {
+            Utilities.setShowStandingsPanes(false);
+        }
+        
         if (parseArguments.isOptPresent(NO_GUI_OPTION_STRING)) {
 
             usingGUI = false;

--- a/src/edu/csus/ecs/pc2/core/Utilities.java
+++ b/src/edu/csus/ecs/pc2/core/Utilities.java
@@ -55,6 +55,8 @@ import edu.csus.ecs.pc2.ui.MultipleFileViewer;
 public final class Utilities {
 
     private static boolean debugMode = false;
+    
+    private static boolean showStandingsPanes = true;
 
     /**
      * LETTERS is a lookup always 1-26 String.substring starts at 0, so letters begin at 1
@@ -1967,6 +1969,14 @@ public final class Utilities {
         result += fractionString;
         
         return result;
+    }
+
+    public static void setShowStandingsPanes(boolean showStandingsPanes) {
+        Utilities.showStandingsPanes = showStandingsPanes;
+    }
+    
+    public static boolean isShowStandingsPanes() {
+        return showStandingsPanes;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
+++ b/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
@@ -375,11 +375,13 @@ public class AdministratorView extends JFrame implements UIPlugin, ChangeListene
                 SitesPane sitesPanel = new SitesPane();
                 addUIPlugin(getRunContestTabbedPane(), "Sites", sitesPanel);
 
-                StandingsTablePane standingsTablePane = new StandingsTablePane();
-                addUIPlugin(getRunContestTabbedPane(), "Standings", standingsTablePane);
+                if (Utilities.isShowStandingsPanes()) {
+                    StandingsTablePane standingsTablePane = new StandingsTablePane();
+                    addUIPlugin(getRunContestTabbedPane(), "Standings", standingsTablePane);
 
-                StandingsHTMLPane standingsHTMLPane = new StandingsHTMLPane("full.xsl");
-                addUIPlugin(getRunContestTabbedPane(), "Standings HTML", standingsHTMLPane);
+                    StandingsHTMLPane standingsHTMLPane = new StandingsHTMLPane("full.xsl");
+                    addUIPlugin(getRunContestTabbedPane(), "Standings HTML", standingsHTMLPane);
+                }
 
                 TeamStatusPane teamStatusPane = new TeamStatusPane();
                 addUIPlugin(getRunContestTabbedPane(), "Team Status", teamStatusPane);


### PR DESCRIPTION
### Description of what the PR does

Adds command line option --nostandings that (for the Admin only) does not load
the Standings or Standings HTML panes

### Issue which the PR fixes

#490 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start the Admin, 
Standings and Standings HTML panes should be present under the Run Contest tab
Exit the Admin

Start the Admin with the  --nostandings option
Neither Standings or Standings HTML panes should be present under the Run Contest tab
Exit the Admin