### PR TITLE
i489: add --nologging option

### DIFF
--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -3261,6 +3261,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                     "[" + NOLOGGING_OPTION_STRING + "] ", //
                     "[" + INI_FILENAME_OPTION_STRING + " filename] [" + //
                     CONTEST_PASSWORD_OPTION + " <pass>] [" + NO_GUI_OPTION_STRING + "] "+ //
+                    "[" + NOSTANDINGS_OPTION_STRING + "] "+ //
                     "[" + REMOTE_SERVER_OPTION_STRING + " <remoteHostname> --proxyme]" + //
                     "[" + MAIN_UI_OPTION + " classname]", // 
                     "", //
@@ -3288,6 +3289,10 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             } catch (IOException e) {
                 fatalError("Unable to read file " + propertiesFileName, e);
             }
+        }
+        
+        if (parseArguments.isOptPresent(NOSTANDINGS_OPTION_STRING)) {
+            Utilities.setShowStandingsPanes(false);
         }
 
         if (parseArguments.isOptPresent(NO_GUI_OPTION_STRING)) {

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -130,6 +130,7 @@ import edu.csus.ecs.pc2.ui.UIPluginList;
  */
 public class InternalController implements IInternalController, ITwoToOne, IBtoA {
 
+    private static final String NOLOGGING_OPTION_STRING = "--nologging";
 
     private static final String INI_FILENAME_OPTION_STRING = "--ini";
 
@@ -3253,6 +3254,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                     "Usage: Starter [--help] [-F filename] [--server] [--first] [--login <login>] [--password <pass>] " + //
                     "[" + LOAD_OPTION_STRING + " <dir>|<file> ] " + //
                     "[--skipini] " + //
+                    "[" + NOLOGGING_OPTION_STRING + "] ", //
                     "[" + INI_FILENAME_OPTION_STRING + " filename] [" + //
                     CONTEST_PASSWORD_OPTION + " <pass>] [" + NO_GUI_OPTION_STRING + "] "+ //
                     "[" + REMOTE_SERVER_OPTION_STRING + " <remoteHostname> --proxyme]" + //
@@ -3264,6 +3266,10 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 System.out.println(string);
             }
             System.exit(0);
+        }
+
+        if (parseArguments.isOptPresent(NOLOGGING_OPTION_STRING)) {
+            Log.setDoNotWriteLogEntries(true);
         }
 
         if (parseArguments.isOptPresent(FILE_OPTION_STRING)) {

--- a/src/edu/csus/ecs/pc2/core/log/Log.java
+++ b/src/edu/csus/ecs/pc2/core/log/Log.java
@@ -111,6 +111,8 @@ public class Log extends Logger {
 
     public static final String LOG_DIRECTORY_NAME = "logs";
 
+    private static boolean doNotWriteLogEntries = false;
+
     private LogStreamHandler streamHandler = null;
     
     private Handler consoleHandler = null;
@@ -314,5 +316,34 @@ public class Log extends Logger {
     
     public String getLogfilename() {
         return logfilename;
+    }
+    
+    @Override
+    public void log(Level level, String msg) {
+        if (!doNotWriteLogEntries) {
+            super.log(level, msg);
+        }
+    }
+
+    @Override
+    public void log(Level level, String msg, Object param1) {
+        if (!doNotWriteLogEntries) {
+            super.log(level, msg, param1);
+        }
+    }
+
+    @Override
+    public void log(Level level, String msg, Throwable thrown) {
+        if (!doNotWriteLogEntries) {
+            super.log(level, msg, thrown);
+        }
+    }
+
+    public static void setDoNotWriteLogEntries(boolean doNotLog) {
+        doNotWriteLogEntries = doNotLog;
+    }
+    
+    public static boolean isDoNotWriteLogEntries() {
+        return doNotWriteLogEntries;
     }
 }


### PR DESCRIPTION
### Description of what the PR does

Adds  --nologging option that will suppress all logging.
Will create zero byte log files but the file size will not increase.

### Issue which the PR fixes

#489 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start Admin (or any other client) using the  --nologging  option.

Expected to create log and lck files but files will
remain zero bytes.  For example

07/12/2022  11:34 PM                 0 ADMINISTRATOR1@site0-0.log
07/12/2022  11:34 PM                 0 ADMINISTRATOR1@site0-0.log.lck
07/12/2022  11:34 PM                 0 ADMINISTRATOR1@site1-0.log
07/12/2022  11:34 PM                 0 ADMINISTRATOR1@site1-0.log.lck
07/12/2022  11:34 PM                 0 ADMINISTRATOR1@site1.security-0.log
07/12/2022  11:34 PM                 0 ADMINISTRATOR1@site1.security-0.log.lck