### PR TITLE
i507: Add safeHTML to embedded PC-sup2 strings - to facilitate move to github actions

### DIFF
--- a/website/data/pc2.yaml
+++ b/website/data/pc2.yaml
@@ -1,5 +1,5 @@
 # Mapping from tool index from JSON files to name to display on all-builds page
 - tool: pc2
-  name: PC<sup>2</sup> System
+  name: PC&sup2; System
 - tool: api-doc
-  name: PC<sup>2</sup> Documentation
+  name: PC&sup2; API Documentation

--- a/website/layouts/shortcodes/allbuilds.html
+++ b/website/layouts/shortcodes/allbuilds.html
@@ -14,7 +14,7 @@
             {{ if isset $build.downloads $pc2.tool }}
             {{ $download := index $build.downloads $pc2.tool }}
             <tr>
-                <td><b>{{ $pc2.name }}</b></td>
+                <td><b>{{ $pc2.name | safeHTML }}</b></td>
                 <td>
                     <a href="{{ $download.urls.zip }}">{{ $pc2.tool }}-{{ $download.version }}.zip</a> ({{ $download.sizes.zip }} MB)
                     {{ if and (isset $download.urls.sha256 "zip") (isset $download.urls.sha512 "zip") }}
@@ -24,7 +24,7 @@
             </tr>
                 {{ if isset $download.urls "tar_gz" }}
             <tr>
-                <th>{{ $pc2.name }} in tar.gz form</th>
+                <th>{{ $pc2.name | safeHTML }} in tar.gz form</th>
                 <td>
                     <a href="{{ $download.urls.tar_gz }}">{{ $pc2.tool }}-{{ $download.version }}.tar.gz</a> ({{ $download.sizes.tar_gz }} MB)
                     {{ if and (isset $download.urls.sha256 "tar_gz") (isset $download.urls.sha512 "tar_gz") }}

--- a/website/layouts/shortcodes/pc2block.html
+++ b/website/layouts/shortcodes/pc2block.html
@@ -6,17 +6,17 @@
 {{ $nightlyTool := index $nightly.downloads (.Get "toolname") }}
 <div class="col-md-9 mb-3">
     <p>
-        {{ .Get "description" }}
+        {{ .Get "description" | safeHTML}}
     </p>
     <p>
         Downloads: <br/> 
-        Stable Release: &nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $stableTool.version }}.tar.gz</a><br />
+        Stable Release: &nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" | safeHTML }} version {{ $stableTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $stableTool.urls.tar_gz }}">{{ .Get "shortname" | safeHTML }} version {{ $stableTool.version }}.tar.gz</a><br />
 {{ if gt $preRelease.published_at $stableRelease.published_at }}
-        Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
+        Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" | safeHTML }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" | safeHTML }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
 {{ else }}
         No release candidate at this time.<br />
 {{ end }}
-        Nightly Build: &nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.zip }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $nightlyTool.version }}.tar.gz</a><br />
+        Nightly Build: &nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.zip }}">{{ .Get "shortname" | safeHTML }} version {{ $nightlyTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $nightlyTool.urls.tar_gz }}">{{ .Get "shortname" | safeHTML }} version {{ $nightlyTool.version }}.tar.gz</a><br />
         Documentation: &nbsp;&nbsp;&nbsp;<a href="/docs/{{ .Get "doc" }}.pdf">Contest Administrator's Guide (PDF)</a><br />
     </p>
     <p>

--- a/website/layouts/shortcodes/pc2download.html
+++ b/website/layouts/shortcodes/pc2download.html
@@ -7,24 +7,24 @@
 
 <h2>Download</h2>
 <p>
-    The latest stable release {{ .Get "name" }} version is {{ $stableTool.version }}, released on {{ $stableRelease.date }}.
+    The latest stable release {{ .Get "name" | safeHTML}} version is {{ $stableTool.version }}, released on {{ $stableRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-primary" href="{{ $stableTool.urls.zip }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" }}</i> (version {{ $stableTool.version }}) as zip</a>
+    <a class="btn btn-primary" href="{{ $stableTool.urls.zip }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" | safeHTML}}</i> (version {{ $stableTool.version }}) as zip</a>
     &nbsp;&nbsp;&nbsp;&nbsp;
-    <a class="btn btn-primary" href="{{ $stableTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" }}</i> (version {{ $stableTool.version }}) as tar.gz</a>
+    <a class="btn btn-primary" href="{{ $stableTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" | safeHTML}}</i> (version {{ $stableTool.version }}) as tar.gz</a>
     <br />
     <br />
 </p>
 <p>
 {{ if gt $preRelease.published_at $stableRelease.published_at }}
         Release Candidate: &nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.zip</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ $prereleaseTool.urls.tar_gz }}">{{ .Get "shortname" }} version {{ $prereleaseTool.version }}.tar.gz</a><br />
-    The latest release candidate {{ .Get "name" }} version is {{ $prereleaseTool.version }}, released on {{ $preRelease.date }}.
+    The latest release candidate {{ .Get "name" | safeHTML}} version is {{ $prereleaseTool.version }}, released on {{ $preRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-danger" href="{{ $prereleaseTool.urls.zip }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prereleaseTool.version }}) as zip</a>
+    <a class="btn btn-danger" href="{{ $prereleaseTool.urls.zip }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" | safeHTML}}</i> (version {{ $prereleaseTool.version }}) as zip</a>
     &nbsp;&nbsp;&nbsp;&nbsp;
-    <a class="btn btn-danger" href="{{ $prereleaseTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" }}</i> (version {{ $prereleaseTool.version }}) as tar.gz</a>
+    <a class="btn btn-danger" href="{{ $prereleaseTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download release candidate <i>{{ .Get "name" | safeHTML}}</i> (version {{ $prereleaseTool.version }}) as tar.gz</a>
 {{ else }}
         No release candidate at this time.
 {{ end }}
@@ -32,19 +32,19 @@
     <br />
 </p>
 <p>
-    The latest nightly build {{ .Get "name" }} version is {{ $nightlyTool.version }}, released on {{ $nightly.date }}.
+    The latest nightly build {{ .Get "name" | safeHTML}} version is {{ $nightlyTool.version }}, released on {{ $nightly.date }}.
 </p>
 <p>
-    <a class="btn btn-danger" href="{{ $nightlyTool.urls.zip }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" }}</i> (version {{ $nightlyTool.version }}) as zip</a>
+    <a class="btn btn-danger" href="{{ $nightlyTool.urls.zip }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" | safeHTML}}</i> (version {{ $nightlyTool.version }}) as zip</a>
     &nbsp;&nbsp;&nbsp;&nbsp;
-    <a class="btn btn-danger" href="{{ $nightlyTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" }}</i> (version {{ $nightlyTool.version }}) as tar.gz</a>
+    <a class="btn btn-danger" href="{{ $nightlyTool.urls.tar_gz }}"><i class="fas fa-download"></i> Download nightly build <i>{{ .Get "name" | safeHTML}}</i> (version {{ $nightlyTool.version }}) as tar.gz</a>
     <br />
     <br />
 </p>
 <h2>Documentation</h2>
 
 <p>
-    The {{ .Get "name" }} Administrator's Guide is contained in the <b>/doc</b> folder in all of the above downloads.  You can also download it directly by clicking on the following link:
+    The {{ .Get "name" | safeHTML}} Administrator's Guide is contained in the <b>/doc</b> folder in all of the above downloads.  You can also download it directly by clicking on the following link:
 </p>
 <p>
     <a class="btn btn-secondary" href="/docs/{{ .Get "doc" }}.pdf"><i class="fas fa-file-pdf"></i> Download / view documentation (PDF format)</a>

--- a/website/layouts/shortcodes/previousbuilds.html
+++ b/website/layouts/shortcodes/previousbuilds.html
@@ -14,7 +14,7 @@
             {{ if isset $build.downloads $pc2.tool }}
             {{ $download := index $build.downloads $pc2.tool }}
             <tr>
-                <th>{{ $pc2.name }}</th>
+                <th>{{ $pc2.name | safeHTML }}</th>
                 <td>
                     <a href="{{ $download.urls.zip }}">{{ $pc2.tool }}-{{ $download.version }}.zip</a> ({{ $download.sizes.zip }} MB)
                     {{ if and (isset $download.urls.sha256 "zip") (isset $download.urls.sha512 "zip") }}
@@ -24,7 +24,7 @@
             </tr>
                 {{ if isset $download.urls "tar_gz" }}
             <tr>
-                <th>{{ $pc2.name }} in tar.gz form</th>
+                <th>{{ $pc2.name | safeHTML }} in tar.gz form</th>
                 <td>
                     <a href="{{ $download.urls.tar_gz }}">{{ $pc2.tool }}-{{ $download.version }}.tar.gz</a> ({{ $download.sizes.tar_gz }} MB)
                     {{ if and (isset $download.urls.sha256 "tar_gz") (isset $download.urls.sha512 "tar_gz") }}

--- a/website/themes/pc2/layouts/_default/baseof.html
+++ b/website/themes/pc2/layouts/_default/baseof.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{{ block "title" . }}{{ .Site.Title }}{{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
+    <title>{{ block "title" . }}{{ .Site.Title | safeHTML }}{{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
 
     <link rel="stylesheet" href="/plugins/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="/css/adminlte.min.css">
@@ -25,14 +25,14 @@
 </head>
 <body class="hold-transition sidebar-mini">
     <div class="wrapper">
-        {{ partial "navbar.html" . }}
-        {{ partial "sidebar.html" . }}
+        {{ partial "navbar.html" . | safeHTML }}
+        {{ partial "sidebar.html" . | safeHTML }}
         <div class="content-wrapper">
             <div class="content-header">
                 <div class="container-fluid">
                     <div class="row mb-2">
                         <div class="col-md-12">
-                            <h1 class="m-0 text-dark">{{ .Params.Title }}</h1>
+                            <h1 class="m-0 text-dark">{{ .Params.Title | safeHTML }}</h1>
                         </div>
                     </div>
                 </div>

--- a/website/themes/pc2/layouts/partials/navbar.html
+++ b/website/themes/pc2/layouts/partials/navbar.html
@@ -4,7 +4,7 @@
             <a class="nav-link" data-widget="pushmenu" href="#"><i class="fas fa-bars"></i></a>
         </li>
         <li class="nav-item d-none d-sm-inline-block">
-            <a class="nav-link" href="/">{{ .Site.Title }}</a>
+            <a class="nav-link" href="/">{{ .Site.Title | safeHTML }}</a>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
The PC&sup2; website generation process, which now runs on a github workflow, apparently uses a different version of the "hugo" website generator.  This new version of hugo appears to be more strict about including html escapes in substitute strings.  Adding safeHTML to the places where strings are obtained dynamically fixes this.

Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Addresses changes in the website generation process where **PC&sup2;** would come out as **PC&amp;sup2;** since hugo escaped the **&amp;sup2;** to **&amp;amp;sup2;**.  All places in the template files that referenced strings that could have embedded HTML encoding have been changed to use the safeHTML function.

### Issue which the PR fixes
#507 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Linux 20.04
Hugo  v0.101.0-466fa43c16709b4483689930a4f9ac8add5c9f66 linux/amd64 BuildDate=2022-06-16T07:09:16Z VendorInfo=gohugoio

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
After the website is generated by the workflow (and hugo), verify that no **PC&amp;sup2;** sequences appear on any of the pages.
