### PR TITLE
add the Dockerfile to rebuild pc2fromecs/jdk8hugo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Create GitHub release
         shell: bash
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           eval $(ssh-agent -s)
           echo "${{ secrets.SSH_PRIVATE_KEY_WEBSITE }}" | tr -d '\r' | ssh-add -
           mkdir -p ~/.ssh
@@ -69,7 +70,7 @@ jobs:
           git push
           RELEASE_COMMIT=$(git rev-parse HEAD)
           cd "$cur_dir"
-          curl --silent --show-error --retry 6 --max-time 300 -X POST \
+          curl --silent --show-error --retry 6 --retry-all-errors --max-time 300 -X POST \
             -H "Authorization: token ${{ secrets.RELEASE_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY_OWNER}/${TARGET}/releases \
@@ -83,7 +84,7 @@ jobs:
             echo $archive...
             case "$archive" in
               *.zip)
-                  curl --silent --show-error --retry 6 --max-time 300 --data-binary "@$archive" -X POST \
+                  curl --silent --show-error --retry 6 ---retry-all-errors -max-time 300 --data-binary "@$archive" -X POST \
                     -H "Authorization: token ${{ secrets.RELEASE_TOKEN }}" \
                     -H 'Accept: application/vnd.github.v3+json' \
                     -H 'Content-Type: application/zip' \
@@ -91,7 +92,7 @@ jobs:
                     | jq .state 
                 ;;
               *.tar.gz)
-                  curl --silent --show-error --retry 6 --max-time 300 --data-binary "@$archive" -X POST \
+                  curl --silent --show-error --retry 6 --retry-all-errors --max-time 300 --data-binary "@$archive" -X POST \
                     -H "Authorization: token ${{ secrets.RELEASE_TOKEN }}" \
                     -H 'Accept: application/vnd.github.v3+json' \
                     -H 'Content-Type: application/gzip' \
@@ -101,7 +102,7 @@ jobs:
             esac
             if [ -f $archive.sha256.txt ]; then
                 echo $archive.sha256.txt...
-                curl --silent --show-error --retry 6 --max-time 300 --data-binary "@$archive.sha256.txt" -X POST \
+                curl --silent --show-error --retry 6 --retry-all-errors --max-time 300 --data-binary "@$archive.sha256.txt" -X POST \
                     -H "Authorization: token ${{ secrets.RELEASE_TOKEN }}" \
                     -H 'Accept: application/vnd.github.v3+json' \
                     -H 'Content-Type: text/plain' \
@@ -110,7 +111,7 @@ jobs:
             fi
             if [ -f $archive.sha512.txt ]; then
                 echo $archive.sha512.txt...
-                curl --silent --show-error --retry 6 --max-time 300 --data-binary "@$archive.sha512.txt" -X POST \
+                curl --silent --show-error --retry 6 --retry-all-errors --max-time 300 --data-binary "@$archive.sha512.txt" -X POST \
                     -H "Authorization: token ${{ secrets.RELEASE_TOKEN }}" \
                     -H 'Accept: application/vnd.github.v3+json' \
                     -H 'Content-Type: text/plain' \

--- a/builddocker/Dockerfile
+++ b/builddocker/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:22.04
+LABEL maintainer="Troy Boudreau"
+
+RUN apt-get update \
+   && apt-get install -y wget openssh-client git jq curl python3 python3-requests unzip npm openjdk-8-jdk ant python2 \
+   && rm -rf /var/lib/apt/lists/* \
+   && wget -O /root/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.101.0/hugo_0.101.0_Linux-64bit.deb \
+   && dpkg -i /root/hugo.deb \
+   && rm /root/hugo.deb
+COPY package.json /root
+RUN npm install -g n && n 14
+ENV PATH="/usr/local/bin:${PATH}"
+RUN cd /root && npm install
+RUN apt purge --yes openjdk-11-jre-headless

--- a/builddocker/README
+++ b/builddocker/README
@@ -1,0 +1,5 @@
+# pc2fromecs with d$ password
+docker login
+cp ../projects/WTI-UI/package.json .
+docker build . -f Dockerfile -t pc2fromecs/jdk8hugo
+docker push pc2fromecs/jdk8hugo

--- a/builddocker/package.json
+++ b/builddocker/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "wti-ui",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint",
+    "e2e": "ng e2e"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^7.2.14",
+    "@angular/cdk": "^7.3.7",
+    "@angular/common": "~7.2.0",
+    "@angular/compiler": "~7.2.0",
+    "@angular/core": "~7.2.0",
+    "@angular/forms": "~7.2.0",
+    "@angular/material": "^7.3.7",
+    "@angular/platform-browser": "~7.2.0",
+    "@angular/platform-browser-dynamic": "~7.2.0",
+    "@angular/router": "~7.2.0",
+    "core-js": "^2.5.4",
+    "rxjs": "~6.3.3",
+    "tslib": "^1.9.0",
+    "zone.js": "~0.8.26"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "~0.13.0",
+    "@angular/cli": "~7.3.1",
+    "@angular/compiler-cli": "~7.2.0",
+    "@angular/language-service": "~7.2.0",
+    "@types/node": "~8.9.4",
+    "@types/jasmine": "~2.8.8",
+    "@types/jasminewd2": "~2.0.3",
+    "codelyzer": "~4.5.0",
+    "jasmine-core": "~2.99.1",
+    "jasmine-spec-reporter": "~4.2.1",
+    "karma": "~3.1.1",
+    "karma-chrome-launcher": "~2.2.0",
+    "karma-coverage-istanbul-reporter": "~2.0.1",
+    "karma-jasmine": "~1.1.2",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "protractor": "~5.4.0",
+    "ts-node": "~7.0.0",
+    "tslint": "~5.11.0",
+    "typescript": "~3.2.2"
+  }
+}


### PR DESCRIPTION
with ubuntu22.04 which has the curl version that
supports --retry-all-errors

Also note the /root/node_modules with all the dependecies
for WTI-API are installed on this container.
It would be time safer to "cp -r /root/mode_modules projects/WTI-UI/"
effectively in the projects/WTI-API/buildWTI.xml if /root/node_modules
exists.

fixes #519