### PR TITLE
i552: Do not start shadowing, if clock stopped.  Show message

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -176,6 +176,11 @@ public class ShadowControlPane extends JPanePlugin {
 
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (!currentlyShadowing) {
+                        
+                        if (!getContest().getContestTime().isContestRunning()) {
+                            showErrorMessage("Contest clock STOPPED, cannot start shadowing", "Cannot start shadowing");
+                            return;
+                        }
 
                     	SwingUtilities.invokeLater(new Runnable() {
                             public void run() {


### PR DESCRIPTION
### Description of what the PR does

On Feeder, Shadow Pane, if contest clock not running (and cannot submit runs into server) 
show message:  Contest clock STOPPED, cannot start shadowing 
and do not start shadowing.

### Issue which the PR fixes

#552

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2006]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start Server
Start Admin
Add FEEDER account
Add/Configure Settings -> Remote CCS Settings
Start FEEDER 1
On Shadow Pane
Select Start shadowing

Expected:
A dialog shows:  Contest clock STOPPED, cannot start shadowing 
select ok
shadow does NOT start

Before:
shadowing would start (and runs could not be added/accepted)
