### PR TITLE
I 502 add skip sub project build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -125,13 +125,13 @@
 		<antcall target="jar"/>
 	</target>
 
-	<target name="jarSkipTestAndSubprojectBulds" description="create jar file skip unit tests do not build sub projects">
+	<target name="jarSkipTestsAndSubprojectBuilds" description="create jar file skip unit tests do not build sub projects">
 		 <property name="RUN_NO_TESTS" value="Yes"/>
 		 <property name="BUILD_NO_SUBPROJECTS" value="Yes"/>
 		<antcall target="jar"/>
 	</target>
 
-	<target name="jarSkipBuildSubprojectsOnly" description="create jar file, run unit tests, skip building sub projects ">
+	<target name="jarSkipBuildSubprojects" description="create jar file, run unit tests, skip building sub projects ">
 		 <property name="BUILD_NO_SUBPROJECTS" value="Yes"/>
 		<antcall target="jar"/>
 	</target>
@@ -234,9 +234,6 @@ TODO consider switching back to this at 9.8.0/9.9build
     </target>
     <target name="jar" depends="test" description="creates a jar of our classes">
         <antcall target="version"/>
-
-        
-
         <mkdir dir="${dist.dir}" />
 
 		<!-- include the images in the jar -->

--- a/build.xml
+++ b/build.xml
@@ -235,7 +235,7 @@ TODO consider switching back to this at 9.8.0/9.9build
     <target name="jar" depends="test" description="creates a jar of our classes">
         <antcall target="version"/>
 
-        <antcall target="buildSubProjects"/>
+        
 
         <mkdir dir="${dist.dir}" />
 
@@ -258,6 +258,8 @@ TODO consider switching back to this at 9.8.0/9.9build
                 <attribute name="Main-Class" value="edu.csus.ecs.pc2.Starter"/>
             </manifest>
         </jar>
+    	
+    	<antcall target="buildSubProjects"/>
 
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -264,7 +264,7 @@ TODO consider switching back to this at 9.8.0/9.9build
     </target>
 
 	 <!-- build sub-projects unless BUILD_NO_SUBPROJECTS defined -->
-    <target name="buildSubProjects" unless="BUILD_NO_SUBPROJECTS"  description="build subj projects ">
+    <target name="buildSubProjects" unless="BUILD_NO_SUBPROJECTS"  description="build sub projects ">
 
     	<!-- Build the (old) EWTeam project and copy it (in zip/tar.gz form) to the "projects" folder -->
       <ant dir="projects/EWTeam" antfile="package.xml" useNativeBasedir="true" inheritAll="false"/>

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!--  Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau. -->
 <project name="pc2v9" default="jar" basedir=".">
     <description>
         v9 build file
@@ -119,8 +120,19 @@
         </condition>
     </target>
 	
-	<target name="jarSkipTests">
+	<target name="jarSkipTests" description="create jar file skip unit tests">
 		 <property name="RUN_NO_TESTS" value="Yes"/>
+		<antcall target="jar"/>
+	</target>
+
+	<target name="jarSkipTestAndSubprojectBulds" description="create jar file skip unit tests do not build sub projects">
+		 <property name="RUN_NO_TESTS" value="Yes"/>
+		 <property name="BUILD_NO_SUBPROJECTS" value="Yes"/>
+		<antcall target="jar"/>
+	</target>
+
+	<target name="jarSkipBuildSubprojectsOnly" description="create jar file, run unit tests, skip building sub projects ">
+		 <property name="BUILD_NO_SUBPROJECTS" value="Yes"/>
 		<antcall target="jar"/>
 	</target>
 
@@ -222,6 +234,9 @@ TODO consider switching back to this at 9.8.0/9.9build
     </target>
     <target name="jar" depends="test" description="creates a jar of our classes">
         <antcall target="version"/>
+
+        <antcall target="buildSubProjects"/>
+
         <mkdir dir="${dist.dir}" />
 
 		<!-- include the images in the jar -->
@@ -243,23 +258,28 @@ TODO consider switching back to this at 9.8.0/9.9build
                 <attribute name="Main-Class" value="edu.csus.ecs.pc2.Starter"/>
             </manifest>
         </jar>
-    	
+
+    </target>
+
+	 <!-- build sub-projects unless BUILD_NO_SUBPROJECTS defined -->
+    <target name="buildSubProjects" unless="BUILD_NO_SUBPROJECTS"  description="build subj projects ">
+
     	<!-- Build the (old) EWTeam project and copy it (in zip/tar.gz form) to the "projects" folder -->
-        <ant dir="projects/EWTeam" antfile="package.xml" useNativeBasedir="true" inheritAll="false"/>
-        <copy todir="projects">
+      <ant dir="projects/EWTeam" antfile="package.xml" useNativeBasedir="true" inheritAll="false"/>
+      <copy todir="projects">
             <fileset dir="projects/EWTeam/dist" includes="EWTeam*.tar.gz"/>
             <fileset dir="projects/EWTeam/dist" includes="EWTeam*.zip"/>
-        </copy>
-    	
+      </copy>
+
     	<!-- Build the WebTeamInterface (WTI) project (which also implicitly builds WTI-UI) and copy it to the "projects" folder. -->
         <ant dir="projects/WTI-API" antfile="packageWTI.xml" useNativeBasedir="true" inheritAll="false"/>
     	
     	<!-- Copy the archive (zip and tar.gz) files of the WTI project to the projects folder -->
-        <copy todir="projects">
+      <copy todir="projects">
             <fileset dir="projects/WTI-API/dist" includes="WebTeamInterface*.tar.gz"/>
             <fileset dir="projects/WTI-API/dist" includes="WebTeamInterface*.zip"/>
-        </copy>
-   	
+      </copy>
+
     </target>
 
     <target name="clean" description="clean up">

--- a/package.xml
+++ b/package.xml
@@ -162,6 +162,11 @@
         <antcall target="clean"/>
         <antcall target="apizip"/>
         <!-- bug 490 gzip depends on zip do not call explicitly -->
-        <antcall target="gzip"/> 
+        <antcall target="gzip"/>
+    	
+    	<echo message="Version ${version} ${date} ${repo.version} (${timestamp.english})${line.separator}"/>
+    	<echo message="Created  distribution ${zip.path}"/>
+    	<echo message="Created  distribution ${gzip.path}"/>
+    	<echo message="Packaging complete."/>
     </target>
 </project>

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-<!-- $Id$ -->
-<!-- $HeadURL$ -->
+<!--  Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau. -->
 <project name="package-pc2v9" default="archives" basedir=".">
     
 	<!--
@@ -141,10 +140,15 @@
     
     
    	<target name="archiveSkipTests">
-		 <property name="RUN_NO_TESTS" value="Yes"/>
-		<antcall target="archives"/>
-	</target>
+		   <property name="RUN_NO_TESTS" value="Yes"/>
+		   <antcall target="archives"/>
+      </target>
 
+   	<target name="archiveSkipTestsAndBuildSubProjects">
+		   <property name="RUN_NO_TESTS" value="Yes"/>
+		   <property name="BUILD_NO_SUBPROJECTS" value="Yes"/>
+		   <antcall target="archives"/>
+      </target>
     
     <target name="archives" depends="init" description="public in dist, private in build">
 

--- a/package.xml
+++ b/package.xml
@@ -144,7 +144,7 @@
 		   <antcall target="archives"/>
       </target>
 
-   	<target name="archiveSkipTestsAndBuildSubProjects">
+   	<target name="archiveSkipTestsAndSubprojectBuilds">
 		   <property name="RUN_NO_TESTS" value="Yes"/>
 		   <property name="BUILD_NO_SUBPROJECTS" value="Yes"/>
 		   <antcall target="archives"/>


### PR DESCRIPTION
### Description of what the PR does

Add new ant targets that will skip the building of sub projects, this
can reduce building the pc2.jar and creating distributions to under 2 min.

Unit tests and building of sub project can add 10 minutes to the build time.

Added the folling at the end of the package.xml (in the archve* targets):
      [tar] Entry: pc2-9.8build/samps/contests/valtest/config/sumit/submissions/security_violation/SumitSVFileWrite.java longer than 100 characters.
\# new stuff/output
     [echo] Version 9.8build 20221006 6195 (Thursday, October 6 2022 06:54 UTC)
     [echo] Created  distribution C:\repos\laned55forkMerge\dist/pc2-9.8build-6195.zip
     [echo] Created  distribution C:\repos\laned55forkMerge\dist/pc2-9.8build-6195.tar.gz
     [echo] Packaging complete.
Added that to aid in where the dist are created and to show the build number
rather than see the end of creating the tar.gz file (see above).

### Issue which the PR fixes

Fixes #502 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2006]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

in build.xml run target jarSkipTestAndSubprojectBulds

in package.xml run target archiveSkipTestsAndBuildSubProjects



