### PR TITLE
i559: add some CLICS fields

### DIFF
--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSLanguage.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSLanguage.java
@@ -14,8 +14,6 @@ import edu.csus.ecs.pc2.core.model.JSONObjectMapper;
  */
 public class CLICSLanguage {
 
-    // languages data = {name=C, id=c}
-
     /**
      * short name, ex python3
      */
@@ -27,6 +25,21 @@ public class CLICSLanguage {
      */
     @JsonProperty
     private String name;
+    
+    @JsonProperty
+    String entry_point_required;
+
+    @JsonProperty
+    String entry_point_name;
+    
+    @JsonProperty
+    String extensions;
+
+    @JsonProperty
+    String compiler;
+
+    @JsonProperty
+    String runner;
 
     public String getId() {
         return id;
@@ -34,6 +47,27 @@ public class CLICSLanguage {
 
     public String getName() {
         return name;
+    }
+    
+
+    public String getExtensions() {
+        return extensions;
+    }
+
+    public String getCompiler() {
+        return compiler;
+    }
+
+    public String getRunner() {
+        return runner;
+    }
+    
+    public String getEntry_point_required() {
+        return entry_point_required;
+    }
+
+    public String getEntry_point_name() {
+        return entry_point_name;
     }
 
     public String toJSON() throws JsonProcessingException {

--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSProblem.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSProblem.java
@@ -14,8 +14,7 @@ import edu.csus.ecs.pc2.core.model.JSONObjectMapper;
  *
  */
 public class CLICSProblem {
-
-    // {time_limit=1, color=null, name=Match Game, id=matchgame, label=A, test_data_count=48, rgb=null, ordinal=1}
+    
     @JsonProperty
     private String id;
 
@@ -39,6 +38,19 @@ public class CLICSProblem {
 
     @JsonProperty
     private Integer ordinal;
+    
+    @JsonProperty
+    String uuid;
+    
+    @JsonProperty
+    String max_score;
+    
+    @JsonProperty("package")
+    String package_string;
+    
+    @JsonProperty
+    String statement;
+    
 
     public String getId() {
         return id;
@@ -70,6 +82,22 @@ public class CLICSProblem {
 
     public Integer getOrdinal() {
         return ordinal;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public String getMax_score() {
+        return max_score;
+    }
+
+    public String getPackage() {
+        return package_string;
+    }
+
+    public String getStatement() {
+        return statement;
     }
 
     public String toJSON() throws JsonProcessingException {


### PR DESCRIPTION
### Description of what the PR does

Add some CLICS fields as mentioned in comments for PR # 547  for #536 

Add fields to CLICSProblem: uuid, max_score, package, and statement 
Add fields to CLICSLanguage: entry_point_required, entry_point_name, extensions, compiler, runner.

All events are present in CLICSEventType ( events are: accounts, awards, clarifications, contest, groups, judgement-types, judgements, languages, organizations, persons, problems, runs, state, submissions, teams ), those enums were already present from previous push.

removed old examples (in comments)

### Issue which the PR fixes

#559

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2006]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

review code, verify new fields present

