### PR TITLE
Add processing for {:problemshort} - fixes #565

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2490,6 +2490,9 @@ public class Executable extends Plugin implements IExecutable {
                 if (index > 0) {
                     newString = replaceString(newString, "{:problem}", index);
                     newString = replaceString(newString, "{:problemletter}", Utilities.convertNumber(index));
+                    if(problem != null) {
+                        newString = replaceString(newString, "{:problemshort}", problem.getShortName());
+                    }
                 }
             }
             if (inRun.getSubmitter() != null) {


### PR DESCRIPTION
There was no way to get the problem short name on the command line of the execute command.  Supporting the documented {:problemshort} substitution variable does this.


### Description of what the PR does
Adds the Submission execution substitution variable {:problemshort}

### Issue which the PR fixes
#565 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Use the {:problemshort} substitution variable on an execute command in the language settings for C++. eg.  ./a.out {:problemshort}
Create and judge a c++ submission.
Look at the log file produced by the judging of the submission and notice that substitution took place.
