### PR TITLE
Add execute substitution vars :infilename :ansfilename - fixes #567

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2517,6 +2517,11 @@ public class Executable extends Plugin implements IExecutable {
                 } else {
                     newString = replaceString(newString, "{:ansfile}", nullArgument);
                 }
+                
+                String fileName = problem.getDataFileName(dataSetNumber);
+                if (fileName != null && !fileName.equals("")) {
+                    newString = replaceString(newString, "{:infilename}", fileName);
+                } else {
                     newString = replaceString(newString, "{:infilename}", nullArgument);
                 }
                 fileName = problem.getAnswerFileName(dataSetNumber);

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1812,7 +1812,7 @@ public class Executable extends Plugin implements IExecutable {
             }
 
             log.log(Log.DEBUG, "before substitution: " + cmdline);
-            cmdline = substituteAllStrings(run, cmdline);
+            cmdline = substituteAllStrings(run, cmdline, dataSetNumber+1);
             log.log(Log.DEBUG, "after  substitution: " + cmdline);
 
             /**
@@ -2397,6 +2397,10 @@ public class Executable extends Plugin implements IExecutable {
         return replaceString(origString, beforeString, afterString);
     }
 
+    public String substituteAllStrings(Run inRun, String origString) {
+        return(substituteAllStrings(inRun, origString, 1));
+    }
+    
     /**
      * return string with all field variables filled with values.
      * 
@@ -2417,13 +2421,15 @@ public class Executable extends Plugin implements IExecutable {
      *              {:pc2home}
      * </pre>
      * 
+     * @param dataSetNumber
+     *            which set of judge data to use (1 in the case of only 1 file)
      * @param inRun
      *            submitted by team
      * @param origString
      *            - original string to be substituted.
      * @return string with values
      */
-    public String substituteAllStrings(Run inRun, String origString) {
+    public String substituteAllStrings(Run inRun, String origString, int dataSetNumber) {
         String newString = "";
         String nullArgument = "-"; /* this needs to change */
 
@@ -2510,6 +2516,14 @@ public class Executable extends Plugin implements IExecutable {
                     newString = replaceString(newString, "{:ansfile}", problem.getAnswerFileName());
                 } else {
                     newString = replaceString(newString, "{:ansfile}", nullArgument);
+                }
+                    newString = replaceString(newString, "{:infilename}", nullArgument);
+                }
+                fileName = problem.getAnswerFileName(dataSetNumber);
+                if (fileName != null && !fileName.equals("")) {
+                    newString = replaceString(newString, "{:ansfilename}", fileName);
+                } else {
+                    newString = replaceString(newString, "{:ansfilename}", nullArgument);
                 }
                 newString = replaceString(newString, "{:timelimit}", Long.toString(problem.getTimeOutInSeconds()));
             } else {


### PR DESCRIPTION
Provide access to judge's file's real names by exposing them in **:infilename** and **:ansfilename** as substitution variables for the execute step.  This is useful for programs such as interactive validators so it can be determined which case a run fails on.  **:infile** and **:ansfile** are insufficient for this purpose since those always contain the same name for each test case.

### Description of what the PR does
Add two new execute substitution variables **:infilename** and **:ansfilename** as described above.

### Issue which the PR fixes
#567 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Linux 5.4.0-58-generic (amd64)
Java Version    : 11.0.9.1

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Add **[:infilename]** and **[:ansfilename]** to the execute step for a language like C++ or C (those are easy because you can
just stick them after the ./a.out for a test)
Make a submission in that language for a problem that has multiple sets of judge data.
Judge the submission using **administrator1**
Look in the **ADMINISTRATOR1@site1-0.log** and find the substitutions took place:
Ex:
```
221016 122401.671|INFO|Thread-689|log|(External) Input data file: /home/domjudge/ccsconfig-dhaka/contests/pretest/config/accessdenied/data/secret/secret__73-random_11.in
221016 122401.671|DEBUG|Thread-689|log|before substitution: /home/domjudge/ccsconfig-dhaka/contests/pretest/config/pc2-exe-wrapper {:problemletter} {:problemshort} {:infilename} {:ansfilename} ./a.out
221016 122401.671|DEBUG|Thread-689|log|after  substitution: /home/domjudge/ccsconfig-dhaka/contests/pretest/config/pc2-exe-wrapper A accessdenied secret__73-random_11.in secret__73-random_11.ans ./a.out
```
