### PR TITLE
i569: --load can now load contest.yaml/CDP from DIR

### DIFF
--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -3088,9 +3088,15 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         File cdpConfigDirectory = null;
 
         if (entry.isDirectory()) {
-
-            // found a directory
-            cdpConfigDirectory = new File(entry.getAbsoluteFile() + File.separator + CONFIG_DIRNAME);
+            
+            String contestYamlFile = entry.getPath() + File.separator + IContestLoader.DEFAULT_CONTEST_YAML_FILENAME;
+            if (new File(contestYamlFile).exists()) {
+                // if contest.yaml in current directory, then this is the equiv of config directory.
+                return entry;
+            } else {
+                // found a CDP base directory
+                cdpConfigDirectory = new File(entry.getAbsoluteFile() + File.separator + CONFIG_DIRNAME);
+            }
 
         } else if (entry.isFile()) {
 


### PR DESCRIPTION
### Description of what the PR does

For --load, before when specifying a directory, could only specify parent directory of config/ dir.
If CDP not in config/ dir then had to specify DIR/contest.yaml (work around)
Now --load DIR will load if finds file DIR/contest.yaml

### Issue which the PR fixes

Fixes #569 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Copy files recursively from a CDP config/ into DIR 
To load cdp from DIR, use --load DIR
Before fix the --load DIR, would fail.