### PR TITLE
i584: increase size of ShadowCompareRunsSummaryPane JPanel.

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsSummaryPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsSummaryPane.java
@@ -51,7 +51,7 @@ public class ShadowCompareRunsSummaryPane extends JPanel {
      */
     public ShadowCompareRunsSummaryPane(Map<String, ShadowJudgementInfo> currentJudgementMap) {
         
-        this.setMaximumSize(new Dimension(600,40));
+        this.setMaximumSize(new Dimension(700,40));
        
         updateSummary(currentJudgementMap);
 


### PR DESCRIPTION
Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Increases the size of the ShadowCompareRunsSummaryPane.

### Issue which the PR fixes

Fixes #584 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 10, Java 1.8.0_201.


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Run a shadow on a system which previously cut off the Pending Runs count on the CompareRuns pane; verify the Pending runs count is now visible.
