### PR TITLE
Exclude teams not displayed on scoreboard, fixes #588

### DIFF
--- a/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
@@ -160,7 +160,17 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         
         setContest(contest);
 
-        Vector<Account> accountVector = getContest().getAccounts(Type.TEAM);
+        /*
+         * Get all the teams, then create a new vector of only those teams shown on the
+         * scoreboard.  The new vector is used for the standings computations.
+         */
+        Vector<Account> allAccountVector = getContest().getAccounts(Type.TEAM);
+        Vector<Account> accountVector = new Vector<Account>();
+        for(Account av : allAccountVector) {
+            if(av.isAllowed(Permission.Type.DISPLAY_ON_SCOREBOARD)) {
+                accountVector.add(av);
+            }
+        }
         Account[] accounts = (Account[]) accountVector.toArray(new Account[accountVector.size()]);
 
         // Kludge for DefaultStandingsRecordComparator


### PR DESCRIPTION
Teams that are not displayed on the scoreboard should be excluded from the generated results.tsv. This involves creating a new vector that consists only of those teams that are displayed on the scoreboard and using that for the standings computations.

Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Only includes those teams that are displayed on the scoreboard in the results.tsv.  This is done in the core.scoring.NewScoringAlgorithm.

### Issue which the PR fixes
Fixes #588 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Windows 7 6.1 (amd64)
Java Version    : 1.8.0_322
(Yes, you read right: that IS Windows 7)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Load a contest.
Create teams, and mark one or more as "not shown on scoreboard"
Submit some (successful) runs by teams that shown on the scoreboard.
Submit some (successful) runs by teams that are not shown on the scoreboard.
Let them get judged.
Finalize the contest.
Look at the results.tsv file. The teams not shown on the scoreboard will **NOT** be in the results.tsv file.

