### PR TITLE
i612: expand size of ShadowCompareScoreboardSummaryPane.

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareScoreboardSummaryPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareScoreboardSummaryPane.java
@@ -33,7 +33,7 @@ public class ShadowCompareScoreboardSummaryPane extends JPanel {
      */
     public ShadowCompareScoreboardSummaryPane() {
         
-        setMaximumSize(new Dimension(500, 100));
+        setMaximumSize(new Dimension(800, 100));
 
 //        JLabel header = new JLabel("Comparison of PC2 vs. Remote Scoreboard");
 //        header.setAlignmentX(Component.CENTER_ALIGNMENT);


### PR DESCRIPTION
### Description of what the PR does

Expands the size of the CompareScoreboardSummaryPane.  Previously, the pane had a maximum width of 500.  If the "Scoreboards do not match (xx of yy rows mismatched)" message is too large to fit in this size, it disappears (it gets moved down to the next row by the Flowlayout manager, but the next row isn't visible).   This is similar to the problem which caused the "Pending" field on the RunComparison screen to disappear at certain times -- Issue #584 ).  

This PR expands the SummaryPane width to 800.  The CompareScoreboardSummaryPane is placed in a `ShadowCompareScoreboardPane` which is a `JPanePlugin` (which is a `JPanel`) of width >1000, so expanding the size of the SummaryPane should be fine and should allow larger message strings to display properly.

### Issue which the PR fixes

Fixes #612 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 10.1, Java 1.8.0_271

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Run a PC2 Shadow against a Primary CCS running a contest which has many teams (>100) and for which many scoreboard mismatches occur (for example, during the initial phase of the contest when the Primary CCS has judged many runs but the PC2 Shadow is lagging behind).   (An example contest is the ICPC WF Dhaka contest).  Previously, a lengthy message like "Scoreboard do NOT match (xxx of yyy rows mismatched)" could disappear under certain GUI environments (e.g. Ubuntu 20.04).  Now the panel should display properly.