### PR TITLE
i614: changed team row so sorts numerically

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -42,6 +42,7 @@ import javax.swing.table.TableRowSorter;
 
 import edu.csus.ecs.pc2.clics.CLICSJudgementType;
 import edu.csus.ecs.pc2.clics.CLICSJudgementType.CLICS_JUDGEMENT_ACRONYM;
+import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
@@ -236,7 +237,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         for (String key : currentJudgementMap.keySet()) {
             
             ShadowJudgementInfo curJudgementInfo = currentJudgementMap.get(key);
-            data[row][0] = curJudgementInfo.getTeamID();
+            data[row][0] = new Integer(Utilities.nullSafeToInt(curJudgementInfo.getTeamID(), 0));
             data[row][1] = curJudgementInfo.getProblemID();
             data[row][2] = curJudgementInfo.getLanguageID();
             data[row][3] = new Integer(key);


### PR DESCRIPTION
Change to safely assign team number string as Integer

### Description of what the PR does

Sorts team number nomically.

### Issue which the PR fixes

Fixes #614

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)


With a contest with at least 30 teams who have submitted a run.

Start shadowing
  Click Start Shadowing
  Click Compare Runs
  Click on Team column, to sort

**Expected behavior**: 

Rows should be sorted by team in numerical order not lexically


