### PR TITLE
Change JSON record generator for "runs" to use run case testNumber, fixes issue #621

### DIFF
--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -534,7 +534,10 @@ public class JSONTool {
         element.put("id", run.getElementId().toString());
         element.put("judgement_id", run.getRunElementId().toString());
         // CLICS spec says this has to start at 1 not 0 (ACPC 2022 DJ Shadow)
-        element.put("ordinal", ordinal+1);
+        // The RunTestCase already has a 1-based test case number, we can use
+        // that since it really exactly what we want here.  It is always in the
+        // range 1 through #_of_test_cases.
+        element.put("ordinal", run.getTestNumber());
         element.put("judgement_type_id", getJudgementType(model.getJudgement(run.getJudgementId())));
         // SOMEDAY get the time from the server instead of the judge
         element.put("time", Utilities.getIso8601formatterWithMS().format(run.getDate().getTime()));

--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -533,7 +533,8 @@ public class JSONTool {
         ObjectNode element = mapper.createObjectNode();
         element.put("id", run.getElementId().toString());
         element.put("judgement_id", run.getRunElementId().toString());
-        element.put("ordinal", ordinal);
+        // CLICS spec says this has to start at 1 not 0 (ACPC 2022 DJ Shadow)
+        element.put("ordinal", ordinal+1);
         element.put("judgement_type_id", getJudgementType(model.getJudgement(run.getJudgementId())));
         // SOMEDAY get the time from the server instead of the judge
         element.put("time", Utilities.getIso8601formatterWithMS().format(run.getDate().getTime()));


### PR DESCRIPTION
CLICS spec says the ordinal for "runs" test cases should start at 1, not 0.  This change uses the judgement testNumber (1 .. #_test_data_sets) instead of the index into all run cases.

Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Addresses the issue reported by DOMJudge that the event-feed endpoint starts the "runs" test case ordinal at 0 instead of 1.

### Issue which the PR fixes
Fixes #621 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Remove the event feed cache file: logs/EventfeedLog_*
Start up a contest that has judged runs.
Start up a feeder client and start the Event Feed
Connect to the event-feed endpoint
Examine the returned event-feed stream and note that the "runs" records for test cases start at ordinal 1 instead of 0 and will be a maximum of the number of input data files.
