### PR TITLE
I623 update web services json scoreboard

### DIFF
--- a/src/edu/csus/ecs/pc2/services/web/ScoreboardService.java
+++ b/src/edu/csus/ecs/pc2/services/web/ScoreboardService.java
@@ -1,8 +1,6 @@
 // Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.web;
 
-import java.io.IOException;
-
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
@@ -13,18 +11,16 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
-import javax.xml.bind.JAXBException;
+import javax.ws.rs.core.Response.Status;
 
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.exports.ccs.StandingsJSON2016;
-import edu.csus.ecs.pc2.services.core.ScoreboardJson;
+import edu.csus.ecs.pc2.exports.ccs.ContestAPIStandingsJSON;
 /**
  * Webservice to handle scoreboard requests
  * 
@@ -55,21 +51,15 @@ public class ScoreboardService implements Feature {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getScoreboard(@Context HttpServletRequest servletRequest, @Context SecurityContext sc) {
 
+        ContestAPIStandingsJSON standings = new ContestAPIStandingsJSON();
+
         String jsonScoreboard;
         try {
             ContestTime contestTime = contest.getContestTime();
             // verify contest has started or user is an admin
             if (contestTime.getElapsedMS() > 0 || sc.isUserInRole("admin")) {
                 //ok to return scoreboard
-
-                try {
-                    ScoreboardJson sbJsonObject = new ScoreboardJson();                    
-                    jsonScoreboard = sbJsonObject.createJSON(contest, controller.getLog());
-                } catch (IllegalContestState | JAXBException | IOException e) {
-                    controller.getLog().log(Log.WARNING,"Exception creating PC2 scoreboard JSON: " + e.getMessage(), e);
-                    return Response.status(Status.INTERNAL_SERVER_ERROR).build();
-                }
-                
+                jsonScoreboard = standings.createJSON(contest, controller, sc.isUserInRole("public"), servletRequest, sc);
             } else {
                 // do not show (return) the scoreboard if the contest has not
                 // been started and the requester is not an admin)
@@ -77,7 +67,7 @@ public class ScoreboardService implements Feature {
                 return Response.status(Status.FORBIDDEN).build();
             }
 
-        } catch (Exception e) {
+        } catch (IllegalContestState e) {
             controller.getLog().log(Log.WARNING, "ScoreboardService: problem creating scoreboard JSON:  " + e, e);
             e.printStackTrace();
             //return HTTP error response code

--- a/src/edu/csus/ecs/pc2/services/web/ScoreboardService.java
+++ b/src/edu/csus/ecs/pc2/services/web/ScoreboardService.java
@@ -1,6 +1,8 @@
 // Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.web;
 
+import java.io.IOException;
+
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
@@ -11,16 +13,18 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
-import javax.ws.rs.core.Response.Status;
+import javax.xml.bind.JAXBException;
 
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.exports.ccs.ContestAPIStandingsJSON;
+import edu.csus.ecs.pc2.exports.ccs.StandingsJSON2016;
+import edu.csus.ecs.pc2.services.core.ScoreboardJson;
 /**
  * Webservice to handle scoreboard requests
  * 
@@ -51,15 +55,21 @@ public class ScoreboardService implements Feature {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getScoreboard(@Context HttpServletRequest servletRequest, @Context SecurityContext sc) {
 
-        ContestAPIStandingsJSON standings = new ContestAPIStandingsJSON();
-
         String jsonScoreboard;
         try {
             ContestTime contestTime = contest.getContestTime();
             // verify contest has started or user is an admin
             if (contestTime.getElapsedMS() > 0 || sc.isUserInRole("admin")) {
                 //ok to return scoreboard
-                jsonScoreboard = standings.createJSON(contest, controller, sc.isUserInRole("public"), servletRequest, sc);
+
+                try {
+                    ScoreboardJson sbJsonObject = new ScoreboardJson();                    
+                    jsonScoreboard = sbJsonObject.createJSON(contest, controller.getLog());
+                } catch (IllegalContestState | JAXBException | IOException e) {
+                    controller.getLog().log(Log.WARNING,"Exception creating PC2 scoreboard JSON: " + e.getMessage(), e);
+                    return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+                }
+                
             } else {
                 // do not show (return) the scoreboard if the contest has not
                 // been started and the requester is not an admin)
@@ -67,7 +77,7 @@ public class ScoreboardService implements Feature {
                 return Response.status(Status.FORBIDDEN).build();
             }
 
-        } catch (IllegalContestState e) {
+        } catch (Exception e) {
             controller.getLog().log(Log.WARNING, "ScoreboardService: problem creating scoreboard JSON:  " + e, e);
             e.printStackTrace();
             //return HTTP error response code


### PR DESCRIPTION
### Description of what the PR does

Updates the **/scoreboard** endpoint in the WebServices API to return a JSON scoreboard in a CLICS-compatible format.

Previously, the /scoreboard endpoint was returning a "2016 JSON" scoreboard, which is not compatible with any formal CLICS specification.  Now, it returns the same JSON format as that used by the Shadow Controller, which is the CLICS 2020 specification.

Note that what the PR does _**not**_ do is update the endpoint to the current (2022-07) CLICS spec; that should be handled under a separate Issue/PR.

### Issue which the PR fixes:

Fixes #623.

### Environment in which the PR was developed:

Windows 10.1, Java 1.8.0_271.

### Precise steps for _testing_ the PR:

#### Minimum Test:
- Start a server running a contest in which there are some "yes" submissions from different teams.
- Start an Event Feed client.
- On the EF Client, select the "Web Services" tab.
- Click the "Start" button to start the web server.
- Open a browser to the **/contest/scoreboard** endpoint of the web server.
- Verify that the response is a scoreboard JSON string in CLICS 2020-03 format.  (See https://ccs-specs.icpc.io/2020-03/contest_api#scoreboard)

#### Full test:
- Start the PC2 server and web server as described above under "Minimum Test"
- Start a _second_ PC2 server configured with the same CDP as the first server.
- Start an Admin on the second PC2 server; use the "Settings" tab to set the "Shadow Mode" configuration to point to the first PC2 server (in other words, set up the second PC2 system to act as a Shadow of the first PC2 system).
- Start an "Event Feed Client" on the second server.
- Select "Shadow Mode" on the event feed client, and click "Start Shadowing".
- Click the "Compare Scoreboards" button.
Previously, this action would throw an Exception in the Feeder log (see Issue #623), with the result being an empty "Compare Scoreboards" grid with a header saying "no comparison available".  Now, the local and remote PC2 scoreboards should be shown side-by-side.
