### PR TITLE
i628: ignore contest id that is received on PATCH - fixes #628

### DIFF
--- a/src/edu/csus/ecs/pc2/services/web/ContestService.java
+++ b/src/edu/csus/ecs/pc2/services/web/ContestService.java
@@ -132,14 +132,19 @@ public class ContestService implements Feature {
             // return HTTP 400 response code per CLICS spec
             return Response.status(Status.BAD_REQUEST).entity("Missing 'id' key in /contest request").build();
 
-        } else {
-            // validate id
-            // TODO can the contestIdentifier be null?
-            if (!model.getContestIdentifier().equals(requestMap.get("id"))) {
-                controller.getLog().log(Log.WARNING, "Starttime PATCH Service: JSON mismatched 'id' key: '" + requestMap.get("id") + "'");
-                // return HTTP 400 response code per CLICS spec
-                return Response.status(Status.CONFLICT).entity("Invalid 'id' key in /contest request").build();
-            }
+//        } else {
+//            // validate id
+//            // TODO can the contestIdentifier be null?  Yes, but it may be something else too.  The CDS gives 'null',
+//            // and it is unclear what other CCS's that we are shadowing for may provide.  It is almost
+//            // certainly NOT what PC2 set up as the identifier (Default-###############).  As such, until the
+//            // API endpoints are fixed to include a (configurable) contest identifier, a reasonable thing to
+//            // do at this point is not validate the id at all.  Just make sure one was specified (above).  That's
+//            // enough for now.            
+//            if (!model.getContestIdentifier().equals(requestMap.get("id"))) {
+//                controller.getLog().log(Log.WARNING, "Starttime PATCH Service: JSON mismatched 'id' key: '" + requestMap.get("id") + "'");
+//                // return HTTP 400 response code per CLICS spec
+//                return Response.status(Status.CONFLICT).entity("Invalid 'id' key in /contest request").build();
+//            }
         }
         // if we get here then the JSON parsed correctly; see if it contained "start_time" as a key
         if (!requestMap.containsKey("start_time")) {


### PR DESCRIPTION
Comment out section of code that attempts to determine if the supplied contest ID is valid from the remote.  It will almost certainly never be valid due to the way PC2 forms its contest ID, AND the fact that PC2 does not allow you to set the contest ID


### Description of what the PR does
This PR allows a remote CDS to update the contest start time by ignoring the contest ID passed in the request.

### Issue which the PR fixes
Fixes #628 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Version         : 9.8build 20221117
Build Date      : Thursday, November 17th 2022 20:13 UTC
Build Number    : 6414~develop

OS              : Windows 7 6.1 (amd64)
Java Version    : 1.8.0_322

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Enable the event feed on a feeder account.
Start a CDS (or other application) that is able to connect to and send the CLICS PATCH json.
Send a PATCH from the CDS (pause or start time)
Observe that the contest time changes on a PC2 admin.


