### PR TITLE
i632 - Send out "runs" events during a live contest - fixes #632

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
+++ b/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
@@ -295,6 +295,8 @@ public final class JudgementUtilites {
                 RunTestCase[] testCases = run.getRunTestCases();
                 for (RunTestCase runTestCase : testCases) {
 
+                    // JB - I think this is wrong - should be == 1, not 0 since getTestNumber() always returns
+                    // > 0, see Executable.executeAndValidateDataSet(), where testNumber is set to dataset + 1
                     if (runTestCase.getTestNumber() == 0) {
                         // if new set of test cases, start list all over again.
                         list = new ArrayList<Judgement>();
@@ -312,6 +314,35 @@ public final class JudgementUtilites {
         }
 
         return list;
+    }
+
+    /**
+     * Get test cases for last run
+     * Based on Doug Lane's code posted to Slack.
+     * 
+     * @param contest
+     * @param run
+     * @return null array if no test cases judgement in run, else the list of judgements
+     */
+    public static RunTestCase[] getLastTestCaseArray(IInternalContest contest, Run run) {
+        
+        List<RunTestCase> list = new ArrayList<RunTestCase>();
+        try {
+            
+            // Find last test case with ordinal 1 in the list of run cases
+            RunTestCase[] testCases = run.getRunTestCases();
+            for (RunTestCase runTestCase : testCases) {
+                // Found a new start of test cases, so dump old array and make new one
+                if (runTestCase.getTestNumber() == 1) {
+                    list = new ArrayList<RunTestCase>();
+                }
+                list.add(runTestCase);
+            }
+        } catch (Exception e) {
+            System.err.println("ERROR in getLastTestCaseArray "+e.getMessage());
+            e.printStackTrace();
+        }
+        return (RunTestCase[]) list.toArray(new RunTestCase[list.size()]);
     }
     
     /**

--- a/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
@@ -15,6 +15,7 @@ import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.list.AccountComparator;
 import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.AccountEvent;
 import edu.csus.ecs.pc2.core.model.Clarification;
@@ -43,6 +44,7 @@ import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.ProblemEvent;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.model.RunEvent;
+import edu.csus.ecs.pc2.core.model.RunTestCase;
 import edu.csus.ecs.pc2.core.security.Permission;
 import edu.csus.ecs.pc2.core.util.JSONTool;
 import edu.csus.ecs.pc2.services.core.EventFeedJSON;
@@ -401,6 +403,13 @@ public class EventFeedStreamer extends JSONUtilities implements Runnable, UIPlug
                     if (run.isJudged()) {
                         String json = getJSONEvent(JUDGEMENT_KEY, getNextEventId(), EventFeedOperation.UPDATE, jsonTool.convertJudgementToJSON(run).toString());
                         sendJSON(json + NL);
+                        // Now send out the runcases (test cases).  Get most recent ones for this run.
+                        RunTestCase [] testCases = JudgementUtilites.getLastTestCaseArray(contest, run);
+                        for (int j = 0; j < testCases.length; j++) {
+                            json = getJSONEvent(RUN_KEY, getNextEventId(), EventFeedOperation.CREATE, jsonTool.convertToJSON(testCases, j).toString());
+                            sendJSON(json + NL);
+                        }
+                        
                     } else {
                         String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), EventFeedOperation.UPDATE, jsonTool.convertToJSON(run, servletRequest, null).toString());
                         sendJSON(json + NL);


### PR DESCRIPTION
During a live contest, when a submission is judged, the corresponding "runs" test cases events are not sent to the event-feed.  This fixes that by sending the runs test cases after the judgements record is sent.

### Description of what the PR does
Changed `EventFeedStreamer `to send out applicable run test cases ("runs" events) after a judgement is sent.

### Issue which the PR fixes
Fixes #632 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS : Windows 7 6.1 (amd64)
Java Version : 1.8.0_341


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Start a contest.
Start an event feeder.
Make submissions using a team account.
Judge submissions made by team account.
Observe event-feed endpoint using a browser. There are now"runs" events present in the event feed right after the judgement for each submission.