### PR TITLE
Bump version number to 9.9build.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,7 @@
         value="${date.english} ${time.english}" />
 
     <!-- version is used in the jar manifest & in package.xml -->
-    <property name="version" value="9.8build"/>
+    <property name="version" value="9.9build"/>
 
     <path id="project.classpath">
         <pathelement location="${build.prod.dir}"/>


### PR DESCRIPTION
### Description of what the PR does
Bumps the version number in build.xml from 9.8build to 9.9build, part of the process of promoting the 9.8-6456 Release Candidate to Stable Public Release.

### Environment in which the PR was developed 
Eclipse Version: 2019-12 (4.14.0)

### Precise steps for _testing_ the PR 
Examine the updated build.xml file, verify the version number has been updated to 9.9build.