### PR TITLE
i496: add support for AJ lists in model, add report, add packet

### DIFF
--- a/src/edu/csus/ecs/pc2/core/ContestLoader.java
+++ b/src/edu/csus/ecs/pc2/core/ContestLoader.java
@@ -3,10 +3,13 @@ package edu.csus.ecs.pc2.core;
 
 import java.io.IOException;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Vector;
 
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Account;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
 import edu.csus.ecs.pc2.core.model.BalloonSettings;
 import edu.csus.ecs.pc2.core.model.Category;
 import edu.csus.ecs.pc2.core.model.Clarification;
@@ -1032,7 +1035,40 @@ public class ContestLoader {
         addGeneralProblemToModel(contest, controller, packet);
         
         setFinalizeData(contest, controller, packet);
+        
+        addAvailAJLists (contest, controller, packet);
 
+    }
+
+    /**
+     * Extract from packet and add avaialbe AJ Runs and Judges.
+     * 
+     * @param contest
+     * @param controller
+     * @param packet
+     */
+    @SuppressWarnings("unchecked")
+    private void addAvailAJLists(IInternalContest contest, IInternalController controller, Packet packet) {
+        
+        try {
+
+            List<AvailableAJ> availableJudges  = (List<AvailableAJ> ) PacketFactory.getObjectValue(packet, PacketFactory.AVAILABLE_AUTO_JUDGE_JUDGES);
+            if (availableJudges != null) {
+                for (AvailableAJ availableAJ : availableJudges) {
+                    contest.addAvailableAutoJudge(availableAJ.getClientId());
+                }
+            }
+            List<AvailableAJRun> availableRuns  = (List<AvailableAJRun>) PacketFactory.getObjectValue(packet, PacketFactory.AVAILABLE_AUTO_JUDGE_RUNS);
+            if (availableRuns!=null) {
+                for (AvailableAJRun availableAJRun : availableRuns) {
+                    Run run = contest.getRun(availableAJRun.getRunId());
+                    contest.addAvailableAutoJudgeRun(run);
+                }
+            }
+            
+        } catch (Exception e) {
+            controller.logWarning("Unable to load available AJ lists into model ", e);
+        } 
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/IInternalController.java
+++ b/src/edu/csus/ecs/pc2/core/IInternalController.java
@@ -761,4 +761,10 @@ public interface IInternalController {
      */
     void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId);
 
+    /**
+     * Send Available to Auto Judge to server.
+     * 
+     * @param judgeClientId judge client
+     */
+    void sendAvailableToAutoJudge(ClientId judgeClientId);
 }

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -30,6 +30,7 @@ import edu.csus.ecs.pc2.core.archive.PacketArchiver;
 import edu.csus.ecs.pc2.core.exception.ContestSecurityException;
 import edu.csus.ecs.pc2.core.exception.ProfileException;
 import edu.csus.ecs.pc2.core.exception.ServerProcessException;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
 import edu.csus.ecs.pc2.core.log.EvaluationLog;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.StaticLog;
@@ -1110,6 +1111,10 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         updateAutoStartInformation(inContest, this);
         
         updateAutoStopClockThread();
+        
+        JudgementUtilites.loadAvaiableRunsAndJudges(contest, this);
+        
+        JudgementUtilites.initialAssignAJ(contest, this, packetHandler);
     }
 
     private void insureProfileDirectory(Profile profile) {
@@ -2226,6 +2231,16 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 } catch (ContestSecurityException e) {
                     log.log(Log.WARNING, "Warning on canceling runs/clars for " + clientId, e);
                 }
+            }
+            
+            try {
+                if (JudgementUtilites.judgeAutoJudgeEnabled(contest, clientId)) {
+                    contest.removeAvailableAutoJudge(clientId);
+                    getLog().log(Log.INFO, "connection Dropped for " + clientId + " removed from Available Auto Judge List");
+                }
+
+            } catch (Exception e) {
+                log.log(Log.WARNING, "Warning on removeAvailableAutoJudge for " + clientId, e);
             }
         }
 

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -4666,4 +4666,11 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         
     }
     
+    @Override
+    public void sendAvailableToAutoJudge(ClientId judgeClientId) {
+        ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
+        Packet packet = PacketFactory.createAvaiableToAutoJudge(judgeClientId, serverClientId);
+        sendToLocalServer(packet);
+    }
+    
 }

--- a/src/edu/csus/ecs/pc2/core/MockController.java
+++ b/src/edu/csus/ecs/pc2/core/MockController.java
@@ -610,4 +610,9 @@ public class MockController implements IInternalController {
         return false;
     }
 
+    @Override
+    public void sendAvailableToAutoJudge(ClientId judgeClientId) {
+        ;
+    }
+
 }

--- a/src/edu/csus/ecs/pc2/core/NullController.java
+++ b/src/edu/csus/ecs/pc2/core/NullController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.IOException;
@@ -46,7 +46,6 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * @version $Id$
  */
 
-// $HeadURL$
 public class NullController implements IInternalController {
 
     public void addNewAccount(Account account) {
@@ -558,5 +557,11 @@ public class NullController implements IInternalController {
     @Override
     public boolean isSuppressLoginsPaneDisplay() {
         return false;
+    }
+
+    @Override
+    public void sendAvailableToAutoJudge(ClientId judgeClientId) {
+        // TODO Auto-generated method stub
+        
     }
 }

--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -4126,6 +4126,10 @@ public class PacketHandler {
             contestLoginSuccessData.setRemoteLoggedInUsers(getAllRemoteLoggedInUsers());
             contestLoginSuccessData.setLocalLoggedInUsers(getAllLocalLoggedInUsers());
             contestLoginSuccessData.setConnectionHandlerIDs(inContest.getConnectionHandleIDs());
+            
+            contestLoginSuccessData.setAvailableToAJRuns(contest.getAvailableAutoJudgeRuns());
+            contestLoginSuccessData.setAvaiableToAJJudges(contest.getAvailableAutoJudges());
+            
         } else {
             contestLoginSuccessData.setRemoteLoggedInUsers(new ClientId[0]);
             contestLoginSuccessData.setLocalLoggedInUsers(new ClientId[0]);

--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2012 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.File;
@@ -79,7 +79,7 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
-
+// TODO 496 on local judge logoff remove them from AJ Judge List
 public class PacketHandler {
 
     private IInternalContest contest = null;
@@ -466,6 +466,10 @@ public class PacketHandler {
                 
             case AUTO_REGISTRATION_SUCCESS:
                 handleAutoRegistratioSuccess(packet, connectionHandlerID);
+                break;
+                
+            case RESET_AUTO_JUDGE:
+                handleResetAutoJudge(packet, connectionHandlerID);
                 break;
           
             default:
@@ -4506,5 +4510,10 @@ public class PacketHandler {
         AutoJudgeListsManager.dump("New Run  debug 22 AF " + run + " for judge "+judgeClientId , System.out, contest );
 
     }
+
+    private void handleResetAutoJudge(Packet packet, ConnectionHandlerID connectionHandlerID) {
+        // TODO 496 implement reset of judge, stop any judging, send available to auto judge
+    }
+
                
 }

--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -2470,6 +2470,8 @@ public class PacketHandler {
                 controller.getLog().info("No logoff server allowed, logoff packet "+packet+" ignored");
                 
             } else if (contest.isLocalLoggedIn(whoLoggedOff)) {
+                
+                contest.removeAvailableAutoJudge(whoLoggedOff);
                 // Logged into this server, so we log them off and send out packet.
                 controller.logoffUser(whoLoggedOff);
                 
@@ -3554,7 +3556,7 @@ public class PacketHandler {
      * @throws ClassNotFoundException 
      * @throws IOException 
      */
-    private void checkoutRun(Packet packet, Run run, ClientId whoRequestsRunId, boolean readOnly, boolean computerJudge, ConnectionHandlerID connectionHandlerID) throws ContestSecurityException,
+    public void checkoutRun(Packet packet, Run run, ClientId whoRequestsRunId, boolean readOnly, boolean computerJudge, ConnectionHandlerID connectionHandlerID) throws ContestSecurityException,
             IOException, ClassNotFoundException, FileSecurityException {
 
         if (isServer()) {
@@ -4440,18 +4442,8 @@ public class PacketHandler {
             Run run = contest.findRunToAutoJudge(sourceClientId);
 
             if (run != null) {
-                controller.getLog().log(Log.INFO, "Found Run for auto judge judge=" + sourceClientId + " Run is " + run);
-                contest.removeAvailableAutoJudge(sourceClientId);
-
-                try {
-
-                    controller.getLog().log(Level.INFO, "Attempting to checkout" + run + " to judge " + sourceClientId);
-
-                    // process run as if judge/client had sent a request run
-                    checkoutRun(packet, run, sourceClientId, false, true, connectionHandlerID);
-                } catch (Exception e) {
-                    controller.getLog().log(Level.INFO, "Unable to checkout run " + run + " to judge " + sourceClientId, e);
-                }
+                
+                PacketUtilities.checkoutRun(run, contest, controller, this, sourceClientId, connectionHandlerID, packet);
 
             } else {
                 controller.getLog().log(Log.INFO, "No run in list to auto judge for judge=" + sourceClientId);
@@ -4464,7 +4456,6 @@ public class PacketHandler {
 
     }
     
-
     /**
      * Assign run to auto judge.
      * 

--- a/src/edu/csus/ecs/pc2/core/PacketUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/PacketUtilities.java
@@ -1,0 +1,69 @@
+package edu.csus.ecs.pc2.core;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.logging.Level;
+
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientType.Type;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.RunFiles;
+import edu.csus.ecs.pc2.core.packet.Packet;
+import edu.csus.ecs.pc2.core.packet.PacketFactory;
+import edu.csus.ecs.pc2.core.security.FileSecurityException;
+import edu.csus.ecs.pc2.core.transport.ConnectionHandlerID;
+
+/**
+ * Packet Handling Utilities.
+ * 
+ * @author Douglas A. Lane, PC^2 team pc2@ecs.csus.edu
+ */
+public class PacketUtilities {
+
+    /**
+     * 
+     * @param run
+     * @param contest
+     * @param controller
+     * @param packetHandler
+     * @param sourceClientId
+     * @param connectionHandlerID
+     * @param packet
+     */
+    public static void checkoutRun(Run run, IInternalContest contest, IInternalController controller, PacketHandler packetHandler, ClientId judgeId, ConnectionHandlerID connectionHandlerID,
+            Packet packet) {
+
+        controller.getLog().log(Log.INFO, "Found Run for auto judge judge=" + judgeId + " Run is " + run);
+        contest.removeAvailableAutoJudge(judgeId);
+
+        try {
+            controller.getLog().log(Level.INFO, "Attempting to checkout" + run + " to judge " + judgeId);
+
+            // process run as if judge/client had sent a request run
+            packetHandler.checkoutRun(packet, run, judgeId, false, true, connectionHandlerID);
+        } catch (Exception e) {
+            controller.getLog().log(Level.INFO, "Unable to checkout run " + run + " to judge " + judgeId, e);
+        }
+    }
+
+    public static void checkoutRun(Run run, IInternalContest contest, IInternalController controller, PacketHandler packetHandler, ClientId judgeId) throws ClassNotFoundException, IOException, FileSecurityException {
+
+        RunFiles runFiles = contest.getRunFiles(run);
+        ClientId source = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
+
+        Enumeration<ConnectionHandlerID> connEnum = contest.getConnectionHandlerIDs(judgeId);
+
+        // since only one judge login can only be on
+        if (connEnum.hasMoreElements()) {
+            ConnectionHandlerID connectionHandlerID = connEnum.nextElement();
+            Packet packet = PacketFactory.createSubmittedRun(source, judgeId, run, runFiles, run.getOverRideElapsedTimeMS(), run.getOverrideNumber());
+            checkoutRun(run, contest, controller, packetHandler, judgeId, connectionHandlerID, packet);
+        } else {
+            controller.getLog().log(Level.INFO, "Unable to checkout (unable to find ConnectionHandlerID) for  " + run + " to judge " + judgeId);
+        }
+
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
+++ b/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
@@ -8,11 +8,13 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
 
+import edu.csus.ecs.pc2.core.list.ProblemList;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.LogUtilities;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Judgement;
 import edu.csus.ecs.pc2.core.model.JudgementRecord;
@@ -388,6 +390,44 @@ public final class JudgementUtilites {
 
         return list;
     }
+
+
+    /**
+     * Can Problem be auto judged.?
+     * 
+     * Problem must:
+     * <li> computer judged
+     * <li> has a validator
+     * 
+     * @param problem
+     * @return
+     */
+    public static boolean canBeAutoJudged(Problem problem) {
+        return problem.isComputerJudged() && problem.isValidatedProblem();
+    }
+
+    /**
+     * Returns the list of problems that match filter.
+     * 
+     * @param contest
+     * @param judgesAJProblemsFilter - judge client id
+     * @return
+     */
+    public static ProblemList getAutoJudgedProblemList(IInternalContest contest, Filter judgesAJProblemsFilter) {
+        ProblemList list = new ProblemList();
+        
+        Problem[] problems = contest.getProblems();
+        for (Problem problem : problems) {
+            if (JudgementUtilites.canBeAutoJudged(problem)) {
+               if (judgesAJProblemsFilter.matches(problem)) {
+                   list.add(problem);
+               }
+            }
+        }
+        
+        return list;
+    }
+
     
 
 }

--- a/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
+++ b/src/edu/csus/ecs/pc2/core/execute/JudgementUtilites.java
@@ -13,6 +13,7 @@ import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.LogUtilities;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientSettings;
 import edu.csus.ecs.pc2.core.model.ElementId;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -20,6 +21,7 @@ import edu.csus.ecs.pc2.core.model.Judgement;
 import edu.csus.ecs.pc2.core.model.JudgementRecord;
 import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.Run.RunStates;
 import edu.csus.ecs.pc2.core.model.RunTestCase;
 
 /**
@@ -393,9 +395,8 @@ public final class JudgementUtilites {
 
 
     /**
-     * Can Problem be auto judged.?
+     * Can Problem be auto judged.?.
      * 
-     * Problem must:
      * <li> computer judged
      * <li> has a validator
      * 
@@ -428,6 +429,28 @@ public final class JudgementUtilites {
         return list;
     }
 
-    
+    /**
+     * Is this a rn that is queued for computer judging.
+     * @param run
+     * @return true if queued for computer judgement, else false.
+     */
+    public static boolean isQueuedForComputerJudging(Run run) {
+        return RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT.equals(run.getStatus());
+    }
+
+    /**
+     * Is auto judging enabled on this client?
+     * @param contest
+     * @param fromId
+     * @return true if enabled, false if not enabled.
+     */
+    public static boolean judgeAutoJudgeEnabled(IInternalContest contest, ClientId clientId) {
+        ClientSettings clientSettings = contest.getClientSettings(clientId);
+        if (clientSettings != null) {
+            return clientSettings.isAutoJudging();
+        }
+        return false;
+    }
+
 
 }

--- a/src/edu/csus/ecs/pc2/core/execute/RunJudger.java
+++ b/src/edu/csus/ecs/pc2/core/execute/RunJudger.java
@@ -1,0 +1,310 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.execute;
+
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Judgement;
+import edu.csus.ecs.pc2.core.model.JudgementRecord;
+import edu.csus.ecs.pc2.core.model.Problem;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.RunFiles;
+import edu.csus.ecs.pc2.core.model.RunResultFiles;
+
+/**
+ * Run judger.
+ * 
+ * @author pc2@ecs.csus.edu
+ */
+public class RunJudger {
+
+    private IInternalContest contest;
+
+    private IInternalController controller;
+
+    private Notifier notifyMessager = new Notifier();
+
+    private boolean usingGui = false;
+
+    /**
+     * Run currently being judged.
+     */
+    private Run runBeingJudged = null;
+
+    private RunJudger() {
+        // no default constructor
+        ;
+    }
+
+    public RunJudger(IInternalContest contest, IInternalController controller) {
+        this.contest = contest;
+        this.controller = controller;
+    }
+
+    /**
+     * Judge Run.
+     * 
+     * @param run
+     * @param runFiles
+     * @return excution data
+     * @throws Exception
+     */
+    public ExecutionData executeAndAutoJudgeRun(Run run, RunFiles runFiles) throws Exception {
+
+        long executeTimeMS = 0;
+
+        if (runBeingJudged != null) {
+            throw new Exception("Cannot judge " + run + " already judging run " + runBeingJudged);
+        }
+
+        runBeingJudged = run;
+
+        notifyMessager.updateStatusLabel("Received run");
+        notifyMessager.updateMessage(getRunDescription(run));
+
+        try {
+
+            notifyMessager.updateStatusLabel("Judging run");
+
+        } catch (Exception e) {
+            warn("Exception logged ", e);
+        }
+
+        System.gc();
+
+        Executable executable = new Executable(contest, controller, run, runFiles);
+
+        // Suppress pop up messages on errors
+        executable.setShowMessageToUser(false);
+        executable.setUsingGUI(usingGui);
+
+        notifyMessager.updateMessage(getRunDescription(run));
+
+        executable.execute();
+
+        // Dump execution results files to log
+        String executeDirctoryName = JudgementUtilites.getExecuteDirectoryName(getContest().getClientId());
+        Problem problem = getContest().getProblem(run.getProblemId());
+        ClientId clientId = getContest().getClientId();
+        List<Judgement> judgements = JudgementUtilites.getLastTestCaseJudgementList(contest, run);
+        JudgementUtilites.dumpJudgementResultsToLog(getLog(), clientId, run, executeDirctoryName, problem, judgements, executable.getExecutionData(), "", new Properties());
+
+        ExecutionData executionData = executable.getExecutionData();
+
+        executeTimeMS = executionData.getExecuteTimeMS();
+
+        RunResultFiles runResultFiles = null;
+
+        JudgementRecord judgementRecord = null;
+
+        TimeZone tz = TimeZone.getTimeZone("GMT");
+        GregorianCalendar startTimeCalendar = new GregorianCalendar(tz);
+
+        try {
+
+            if (executionData.getExecutionException() != null) {
+                notifyMessager.updateStatusLabel("ERROR - " + executionData.getExecutionException().getMessage());
+                getLog().log(Log.WARNING, "ERROR - " + executionData.getExecutionException().getMessage(), "ERROR - " + executionData.getExecutionException());
+
+                // judgementRecord stays null
+
+            } else if (!executionData.isCompileSuccess()) {
+                // Compile failed, darn!
+
+                notifyMessager.updateStatusLabel("Run failed to compile");
+
+                Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, "CE");
+                String judgementString = "No - Compilation Error"; // default
+                ElementId elementId = null;
+                if (judgement != null) {
+                    judgementString = judgement.getDisplayName();
+                    elementId = judgement.getElementId();
+                } else {
+                    // TODO: find judgement string by name (from somewhere other than the judgements list)
+                    elementId = contest.getJudgements()[1].getElementId();
+                }
+
+                judgementRecord = new JudgementRecord(elementId, contest.getClientId(), false, true, true);
+                judgementRecord.setValidatorResultString(judgementString);
+
+            } else if (executionData.isValidationSuccess()) {
+
+                // We got stuff from validator!!
+                String results = executable.getValidationResults();
+                if (results == null) {
+                    results = "Undetermined";
+                } else {
+                    results = results.trim();
+                }
+                if (results.length() == 0) {
+                    results = "Undetermined";
+                }
+
+                boolean solved = false;
+
+                // Try to find result text in judgement list
+                // (start with a default of a non-variable-scoring "no" judgment)
+                ElementId elementId = contest.getJudgements()[2].getElementId();
+
+                for (Judgement judgement : contest.getJudgements()) {
+                    if (judgement.getDisplayName().trim().equalsIgnoreCase(results)) {
+                        elementId = judgement.getElementId();
+                    }
+                }
+
+                // Or perhaps it is a yes? yes?
+                Judgement yesJudgement = contest.getJudgements()[0];
+                // bug 280 ICPC Validator Interface Standard calls for "accepted" in any case.
+                if (results.equalsIgnoreCase("accepted")) {
+                    results = yesJudgement.getDisplayName();
+                }
+                if (yesJudgement.getDisplayName().equalsIgnoreCase(results)) {
+                    elementId = yesJudgement.getElementId();
+                    solved = true;
+                }
+
+                Judgement judgement = contest.getJudgement(elementId);
+                notifyMessager.updateMessage("Judged run " + run + " results " + results + " Judgement " + judgement.getAcronym() + " : " + judgement.getDisplayName());
+                info("Judged run " + run + " results " + results + " Judgement " + judgement.getAcronym() + " : " + judgement.getDisplayName());
+
+                judgementRecord = new JudgementRecord(elementId, contest.getClientId(), solved, true, true);
+                judgementRecord.setValidatorResultString(results);
+
+            } else {
+                // Something went wrong either during validation or execution
+                // Unable to validate result: Undetermined
+
+                warn("Run compiled but failed to validate " + run);
+
+                // default to a non-variable-scoring "no" judgment
+                ElementId elementId = contest.getJudgements()[2].getElementId();
+                judgementRecord = new JudgementRecord(elementId, contest.getClientId(), false, true, true);
+                judgementRecord.setValidatorResultString("Undetermined");
+
+            }
+
+        } catch (Exception e) {
+            warn("Exception during execute/validating run " + run, e);
+        }
+
+        try {
+            if (judgementRecord == null) {
+
+                warn("Problem judging run " + run + " unable to create judgement record");
+                notifyMessager.updateStatusLabel("Problem judging run");
+                // Cancel the run, hope for better luck.
+
+                notifyMessager.updateStatusLabel("Returning run to server");
+                controller.cancelRun(run);
+
+            } else {
+
+                info("Sending judgement to server " + run);
+                notifyMessager.updateStatusLabel("Sending judgement to server ");
+
+                tz = TimeZone.getTimeZone("GMT");
+                GregorianCalendar cal = new GregorianCalendar(tz);
+
+                long milliDiff = cal.getTime().getTime() - startTimeCalendar.getTime().getTime();
+                long totalSeconds = milliDiff / 1000;
+                judgementRecord.setHowLongToJudgeInSeconds(totalSeconds);
+                judgementRecord.setExecuteMS(executeTimeMS);
+
+                runResultFiles = new RunResultFiles(run, run.getProblemId(), judgementRecord, executable.getExecutionData());
+                controller.submitRunJudgement(run, judgementRecord, runResultFiles);
+            }
+
+        } catch (Exception e) {
+            warn("Problem updating judgement files or sending packet for run " + run, e);
+            System.out.println("Problem updating judgement files or sending packet for run " + run + " " + e.getMessage());
+        }
+
+        info("Sending AVAILABLE_TO_AUTO_JUDGE to server.");
+        controller.sendAvailableToAutoJudge(contest.getClientId());
+        runBeingJudged = null;
+
+        return executable.getExecutionData();
+    }
+
+    private Log getLog() {
+        return controller.getLog();
+    }
+
+    public IInternalContest getContest() {
+        return contest;
+    }
+
+    private String getRunDescription(Run runToCheckOut) {
+        // ## - Problem Title (Run NN, Site YY)
+        return " Run " + runToCheckOut.getNumber() + " Site " + runToCheckOut.getSiteNumber() + " - " + contest.getProblem(runToCheckOut.getProblemId()).getDisplayName();
+    }
+
+    public IInternalController getController() {
+        return controller;
+
+    }
+
+    public void info(String s) {
+        controller.getLog().info(s);
+        if (!usingGui) {
+            System.out.println(s);
+        }
+
+    }
+
+    public void warn(String s) {
+        controller.getLog().warning(s);
+        if (!usingGui) {
+            System.err.println(s);
+        }
+
+    }
+
+    public void warn(String s, Exception exception) {
+        controller.getLog().log(Log.WARNING, s, exception);
+        System.err.println(Thread.currentThread().getName() + " " + s);
+        System.err.flush();
+        exception.printStackTrace(System.err);
+    }
+
+    public class Notifier {
+
+        public void updateStatusLabel(String string) {
+            // TODO 496 write to log and to stdout?
+
+            // TODO Auto-generated method stub
+
+        }
+
+        public void updateMessage(String runDescription) {
+            // TODO Auto-generated method stub
+
+        }
+
+    }
+    
+    /**
+     * get run being judged.
+     * 
+     * @return null if no run being judged, else the run
+     */
+    public Run getRunBeingJudged() {
+        return runBeingJudged;
+    }
+
+    /**
+     * Is judger already judging ?
+     * @return true if judging, false if not
+     */
+    public boolean isJudging() {
+        return runBeingJudged == null;
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/execute/RunJudger.java
+++ b/src/edu/csus/ecs/pc2/core/execute/RunJudger.java
@@ -59,8 +59,10 @@ public class RunJudger {
     public ExecutionData executeAndAutoJudgeRun(Run run, RunFiles runFiles) throws Exception {
 
         long executeTimeMS = 0;
+        
+        System.out.println("debug 22 executeAndAutoJudgeRun "+run);
 
-        if (runBeingJudged != null) {
+        if (runBeingJudged == null) {
             throw new Exception("Cannot judge " + run + " already judging run " + runBeingJudged);
         }
 
@@ -268,23 +270,26 @@ public class RunJudger {
     }
 
     public void warn(String s, Exception exception) {
-        controller.getLog().log(Log.WARNING, s, exception);
         System.err.println(Thread.currentThread().getName() + " " + s);
         System.err.flush();
         exception.printStackTrace(System.err);
+        controller.getLog().log(Log.WARNING, s, exception);
     }
 
     public class Notifier {
 
         public void updateStatusLabel(String string) {
+            
             // TODO 496 write to log and to stdout?
-
-            // TODO Auto-generated method stub
+            info(string);
+            System.out.println(string);
 
         }
 
-        public void updateMessage(String runDescription) {
-            // TODO Auto-generated method stub
+        public void updateMessage(String string) {
+            // TODO 496 write to log and to stdout?
+               info(string);
+            System.out.println(string);
 
         }
 
@@ -304,7 +309,7 @@ public class RunJudger {
      * @return true if judging, false if not
      */
     public boolean isJudging() {
-        return runBeingJudged == null;
+        return runBeingJudged != null;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/list/AutoJudgeListsManager.java
+++ b/src/edu/csus/ecs/pc2/core/list/AutoJudgeListsManager.java
@@ -1,0 +1,328 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.list;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.MockController;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
+import edu.csus.ecs.pc2.core.log.StaticLog;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientSettings;
+import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.Filter;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.report.AutojudgeListReport;
+
+/**
+ * Methods to maintain auto judge lists.
+ * 
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ */
+public class AutoJudgeListsManager  {
+
+    /**
+     * List of currently available AutoJudge clients (that is, Judge clients which have registered as being available to AutoJudge a set of problems).
+     */
+    private AvailableAJList availableAJList = new AvailableAJList();
+
+    /**
+     * List of submitted runs currently awaiting dispatching to an available AutoJudge.
+     */
+    private AvailableAJRunList availableAJRunList = new AvailableAJRunList();
+
+    /**
+     * Locking object for synchronizing access to the lists of available AutoJudges and runs waiting to be AutoJudged
+     */
+    Object ajLock = new Object();
+
+    /**
+     * Clear/rest all lists.
+     */
+    public void clear() {
+        availableAJList = new AvailableAJList();
+        availableAJRunList = new AvailableAJRunList();
+    }
+
+    /**
+     * Add judge to available judge list.
+     * 
+     * @param contest
+     * @param judgeClientId
+     * @return null if auto judge not added
+     */
+    public AvailableAJ addAvailableAutoJudge(IInternalContest contest, ClientId judgeClientId) {
+
+        // Auto judge settings are in ClientSettings
+        ClientSettings settings = contest.getClientSettings(judgeClientId);
+
+        if (settings == null || !settings.isAutoJudging()) {
+            // Cannot add - judge not autojudging
+            return null;
+        }
+
+        Filter judgesAJProblemsFilter = settings.getAutoJudgeFilter();
+        ProblemList problemList = JudgementUtilites.getAutoJudgedProblemList(contest, judgesAJProblemsFilter);
+
+        if (problemList.getList().length == 0) {
+            // Judge has no problems assigned.
+            return null;
+        }
+
+        synchronized (ajLock) {
+            AvailableAJ availableAJ = new AvailableAJ(judgeClientId, problemList);
+            availableAJList.add(availableAJ);
+            return availableAJ;
+        }
+    }
+
+    /**
+     * Remove judge from available judge list.
+     * 
+     * @param judgeClientId
+     */
+    public void removeAvailableAutoJudge(ClientId judgeClientId) {
+        synchronized (ajLock) {
+            ProblemList problemList = new ProblemList();
+            AvailableAJ availableAJ = new AvailableAJ(judgeClientId, problemList);
+            availableAJList.remove(availableAJ);
+        }
+    }
+
+    /**
+     * find Auto Judge for input run, if found remove run and judge from AJ lists.
+     * 
+     * @param run
+     * @return null if no judge found to auto judge run, else the clientid for the judge
+     */
+    public ClientId findAutoJudgeForRun(Run run) {
+
+        synchronized (ajLock) {
+
+            for (AvailableAJRun currentAJRun : availableAJRunList) {
+
+                for (AvailableAJ currentAJ : availableAJList) {
+
+                    try {
+                        // check if the problem for the current run can be judged by the current AJ
+                        if (currentAJ.canJudge(currentAJRun.getProblemId())) {
+
+
+                            // remove Judge from list
+                            availableAJList.remove(currentAJ);
+
+                            // remove AJRun from list
+                            availableAJRunList.remove(currentAJRun);
+
+                            return currentAJ.getClientId();
+                        }
+                    } catch (Exception e) {
+                        log(Level.WARNING, "Problem finding auto judge for run " + run);
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * find a run in the available runs list for the input judge, if found remove run and judge from AJ lists.
+     * 
+     * @param judgeClientId
+     * @return null if no run found to auto judge, else return Run
+     */
+    public Run findRunToAutoJudge(IInternalContest contest, ClientId judgeClientId) {
+
+        synchronized (ajLock) {
+
+            Run run = null;
+
+            //check each run which is awaiting an AJ
+            for (AvailableAJRun currentAJRun : availableAJRunList) {
+
+                for (AvailableAJ currentAJ : availableAJList) {
+                    
+                    try {
+                        //check if the problem for the current run can be judged by the current AJ
+                        if (currentAJ.canJudge(currentAJRun.getProblemId())) {
+                            
+                            try {
+                                // remove Judge from list
+                                availableAJList.remove(currentAJ);
+                                
+                                try {
+                            
+                                    // remove AJRun from list
+                                    availableAJRunList.remove(currentAJRun);
+                                    
+                                    return contest.getRun(currentAJRun.getRunId());
+                                    
+                                } catch (Exception e) {
+                                    
+                                    log(Level.WARNING, "Problem removing run from list "+currentAJRun+" adding AJ back into list "+currentAJ, e);
+                                    
+                                    //  Add Judge back into list because/when run could not be removed from list.
+                                    availableAJList.add(currentAJ);
+                                }
+                                
+                            } catch (Exception e) {
+                                log(Level.WARNING, "Problem removing judge from list "+currentAJ+" ", e);
+                            }
+                            
+                        }
+                    } catch (Exception e) {
+                        log(Level.WARNING, "Problem assigning run to judge "+currentAJ.getClientId()+" "+getRun(contest, currentAJRun.getRunId()));
+                    }
+                }
+            }
+
+            return run;
+        }
+    }
+
+    /**
+     * "Safe" logging method using StaticLog
+     * 
+     * @param warning
+     * @param string
+     */
+    private void log(Level level, String message) {
+
+        try {
+            StaticLog.getLog().log(level, message);
+        } catch (Exception e) {
+            System.err.println("Unable to write message to StaticLog " + e.getMessage()+" "+message);
+            System.err.println(message);
+        }
+
+    }
+    
+    private void log(Level level, String message, Throwable throwable) {
+
+        try {
+            StaticLog.getLog().log(level, message, throwable);
+        } catch (Exception e) {
+            System.err.println("Unable to write message to StaticLog " + e.getMessage()+" "+message);
+            throwable.printStackTrace(System.err);
+        }
+
+    }
+
+    /**
+     * Get Run info/String for run
+     * 
+     * @param contest
+     * @param elementId
+     * @return run info if run exists, else string "Run elementid = " + elementId
+     */
+    private String getRun(IInternalContest contest, ElementId elementId) {
+        
+        try {
+            return contest.getRun(elementId).toString();
+        } catch (Exception e) {
+            // if there is a problem, output the run elementId
+            return "Run.elementid = "+elementId;
+        }
+        
+    }
+
+    /**
+     * Add run to available run list.
+     * @param run
+     * @return run added
+     */
+    public AvailableAJRun addRunToAutoJudge(Run run) {
+        synchronized (ajLock) {
+            AvailableAJRun ajRun = new AvailableAJRun(run.getElementId(), run.getElapsedMS(), run.getProblemId());
+            availableAJRunList.add(ajRun);
+            return ajRun;
+        }
+    }
+
+    /**
+     * Remove run from available run list.
+     * @param run
+     */
+    public void removeAutoJudgeRun(Run run) {
+        synchronized (ajLock) {
+            AvailableAJRun ajRun = new AvailableAJRun(run.getElementId(), run.getElapsedMS(), run.getProblemId());
+            availableAJRunList.remove(ajRun);
+        }
+    }
+
+    /**
+     * return list of runs available to be auto judged.
+     * @return
+     */
+    public List<AvailableAJRun> getAvailableAJRuns(){
+        
+        // TODO i 496 getAvailableAJRuns synchronize this ?
+        
+        List<AvailableAJRun> list = new ArrayList<AvailableAJRun>();
+        for (AvailableAJRun availableAJRun : availableAJRunList) {
+            list.add(availableAJRun);
+        }
+        return list;
+    }
+    
+    
+    /**
+     * get list of judges that can auto judge.
+     * @return
+     */
+    public List<AvailableAJ> getAvailableAJList() {
+        
+        // TODO i 496 getAvailableAJList synchronize this ?
+        
+        List<AvailableAJ> list = new ArrayList<AvailableAJ>();
+        for (AvailableAJ availableAJ : availableAJList) {
+            list.add(availableAJ);
+        }
+        return list;
+    }
+
+    /**
+     * Dump AJ lists to printWriter
+     * @param comment
+     * @param printWriter
+     * @param contest
+     */
+    public static void dump(String comment, PrintWriter printWriter, IInternalContest contest) {
+
+        try {
+            if (comment != null) {
+                printWriter.println(comment);
+            }
+
+            AutojudgeListReport report = new AutojudgeListReport();
+            IInternalController controller = new MockController();
+            report.setContestAndController(contest, controller);
+            report.writeReport(printWriter);
+            printWriter.flush();
+            report = null;
+
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+        }
+
+    }
+
+    /**
+     * Sump lists to printStream.
+     * @param comment
+     * @param out
+     * @param contest
+     */
+    public static void dump(String comment, PrintStream out, IInternalContest contest) {
+        dump(comment, new PrintWriter(out), contest);
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/list/AutoJudgeListsManagerTest.java
+++ b/src/edu/csus/ecs/pc2/core/list/AutoJudgeListsManagerTest.java
@@ -1,0 +1,275 @@
+// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.list;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.csus.ecs.pc2.core.exception.RunUnavailableException;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientSettings;
+import edu.csus.ecs.pc2.core.model.ClientType;
+import edu.csus.ecs.pc2.core.model.ClientType.Type;
+import edu.csus.ecs.pc2.core.model.Filter;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Problem;
+import edu.csus.ecs.pc2.core.model.Problem.VALIDATOR_TYPE;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.SampleContest;
+import edu.csus.ecs.pc2.core.security.FileSecurityException;
+import edu.csus.ecs.pc2.core.util.AbstractTestCase;
+
+/**
+ * Unit test.
+ * 
+ * @author Douglas A. Lane
+ */
+public class AutoJudgeListsManagerTest extends AbstractTestCase {
+
+    SampleContest sample = new SampleContest();
+
+    /**
+     * Test add and remove judge from AJ list.
+     * 
+     * @throws Exception
+     */
+    public void testaddAvailableAutoJudge() throws Exception {
+
+        AutoJudgeListsManager handler = new AutoJudgeListsManager();
+
+        assertEquals("AJs in list ", 0, handler.getAvailableAJList().size());
+        assertEquals("Runs in list ", 0, handler.getAvailableAJRuns().size());
+
+        IInternalContest contest = sample.createStandardContest();
+        List<Run> listRuns = addSomeRuns(contest);
+        assertEquals("Runs added ", 16, listRuns.size());
+
+        Run[] runs = contest.getRuns();
+
+        handler.addRunToAutoJudge(runs[0]);
+        handler.addRunToAutoJudge(runs[1]);
+        handler.addRunToAutoJudge(runs[2]);
+
+        assertEquals("Runs in list ", 3, handler.getAvailableAJRuns().size());
+
+        VALIDATOR_TYPE type = VALIDATOR_TYPE.CUSTOMVALIDATOR;
+
+        Problem[] problems = contest.getProblems();
+        for (Problem problem : problems) {
+            // set as an auto judged problem
+            problem.setComputerJudged(true);
+            problem.setValidatorType(type);
+            contest.updateProblem(problem);
+        }
+
+        // create 12 judges
+        contest.generateNewAccounts(ClientType.Type.JUDGE.toString(), 12, true);
+
+        ClientId autojudge = contest.getAccounts(Type.JUDGE).firstElement().getClientId();
+
+//        Vector<Account> judges = contest.getAccounts(Type.JUDGE);
+//        for (Account judgeaccount : judges) {
+//            addAutoJudge(contest, judgeaccount, problems);
+//        }
+
+        addAutoJudge(contest, autojudge, problems);
+        AvailableAJ availaj = handler.addAvailableAutoJudge(contest, autojudge);
+        assertNotNull("Expecting to add aj " + autojudge, availaj);
+
+        assertEquals("AJs in list ", 1, handler.getAvailableAJList().size());
+        assertEquals("Runs in list ", 3, handler.getAvailableAJRuns().size());
+
+        // findRunToAutoJudge will remove items from list if run found
+        Run run = handler.findRunToAutoJudge(contest, autojudge);
+        assertNotNull(run);
+
+        assertEquals("AJs in list ", 0, handler.getAvailableAJList().size());
+        assertEquals("Runs in list ", 2, handler.getAvailableAJRuns().size());
+
+    }
+
+    /**
+     * Test addAvailableAutoJudgeRun and findRunToAutoJudge using IInternalContest methods.
+     * 
+     * @throws Exception
+     */
+    public void ttestaddAvailableAutoJudgeRunUsingContest() throws Exception {
+
+        IInternalContest contest = sample.createStandardContest();
+        assertEquals("AJs in list ", 0, contest.getAvailableAutoJudges().size());
+        assertEquals("Runs in list ", 0, contest.getAvailableAutoJudgeRuns().size());
+
+        List<Run> listRuns = addSomeRuns(contest);
+        assertEquals("Runs added ", 16, listRuns.size());
+
+        Run[] runs = contest.getRuns();
+
+        contest.addAvailableAutoJudgeRun(runs[0]);
+        contest.addAvailableAutoJudgeRun(runs[1]);
+        contest.addAvailableAutoJudgeRun(runs[2]);
+
+        assertEquals("Runs in list ", 3, contest.getAvailableAutoJudgeRuns().size());
+
+        VALIDATOR_TYPE type = VALIDATOR_TYPE.CUSTOMVALIDATOR;
+
+        Problem[] problems = contest.getProblems();
+        for (Problem problem : problems) {
+            // set as an auto judged problem
+            problem.setComputerJudged(true);
+            problem.setValidatorType(type);
+            contest.updateProblem(problem);
+        }
+
+        // create 12 judges
+        contest.generateNewAccounts(ClientType.Type.JUDGE.toString(), 12, true);
+
+        ClientId autojudge = contest.getAccounts(Type.JUDGE).firstElement().getClientId();
+
+        addAutoJudge(contest, autojudge, problems);
+        AvailableAJ availaj = contest.addAvailableAutoJudge(autojudge);
+        assertNotNull("Expecting to add aj " + autojudge, availaj);
+
+        assertEquals("AJs in list ", 1, contest.getAvailableAutoJudges().size());
+        assertEquals("Runs in list ", 3, contest.getAvailableAutoJudgeRuns().size());
+
+//        AutoJudgeListsManager.dump("debug junit", System.out, contest);
+
+        Run run = contest.findRunToAutoJudge(autojudge);
+        assertNotNull(run);
+
+        assertEquals("AJs in list ", 0, contest.getAvailableAutoJudges().size());
+        assertEquals("Runs in list ", 2, contest.getAvailableAutoJudgeRuns().size());
+
+    }
+
+    /**
+     * Test findAutoJudgeForRun.
+     * 
+     * @throws Exception
+     */
+    public void testfindAutoJudgeForRun() throws Exception {
+        IInternalContest contest = sample.createStandardContest();
+        assertEquals("AJs in list ", 0, contest.getAvailableAutoJudges().size());
+        assertEquals("Runs in list ", 0, contest.getAvailableAutoJudgeRuns().size());
+
+        List<Run> listRuns = addSomeRuns(contest);
+        assertEquals("Runs added ", 16, listRuns.size());
+
+        Run[] runs = contest.getRuns();
+        contest.addAvailableAutoJudgeRun(runs[0]);
+        contest.addAvailableAutoJudgeRun(runs[1]);
+        contest.addAvailableAutoJudgeRun(runs[2]);
+
+        assertEquals("Runs in list ", 3, contest.getAvailableAutoJudgeRuns().size());
+
+        VALIDATOR_TYPE type = VALIDATOR_TYPE.CUSTOMVALIDATOR;
+
+        Problem[] problems = contest.getProblems();
+        for (Problem problem : problems) {
+            // set as an auto judged problem
+            problem.setComputerJudged(true);
+            problem.setValidatorType(type);
+            contest.updateProblem(problem);
+        }
+
+        // create 12 judges
+        contest.generateNewAccounts(ClientType.Type.JUDGE.toString(), 12, true);
+
+        ClientId autojudge = contest.getAccounts(Type.JUDGE).firstElement().getClientId();
+
+        addAutoJudge(contest, autojudge, problems);
+        AvailableAJ availaj = contest.addAvailableAutoJudge(autojudge);
+        assertNotNull("Expecting to add aj " + autojudge, availaj);
+
+        assertEquals("AJs in list ", 1, contest.getAvailableAutoJudges().size());
+        assertEquals("Runs in list ", 3, contest.getAvailableAutoJudgeRuns().size());
+
+        Run run = contest.getRuns()[0];
+        ClientId aj = contest.findAutoJudgeForRun(run);
+        assertNotNull(aj);
+
+        assertEquals("AJs in list ", 0, contest.getAvailableAutoJudges().size());
+        assertEquals("Runs in list ", 2, contest.getAvailableAutoJudgeRuns().size());
+
+    }
+
+    /**
+     * update judge to become an auto judge input problems.
+     * 
+     * @param contest
+     * @param autojudge
+     * @param problems
+     * @return
+     */
+    private ClientSettings addAutoJudge(IInternalContest contest, ClientId autojudge, Problem[] problems) {
+
+        ClientSettings clientSettings = contest.getClientSettings(autojudge);
+
+        Filter autoJudgeFilter = new Filter();
+
+        for (Problem problem : problems) {
+            autoJudgeFilter.addProblem(problem);
+        }
+
+        if (clientSettings == null) {
+            clientSettings = new ClientSettings(autojudge);
+        }
+
+        clientSettings.setAutoJudgeFilter(autoJudgeFilter);
+        clientSettings.setAutoJudging(true);
+
+        contest.updateClientSettings(clientSettings);
+
+        return clientSettings;
+    }
+
+    /**
+     * Add some runs.
+     * 
+     * @param contest
+     * @return list of added runs.
+     * @throws RunUnavailableException
+     * @throws FileSecurityException
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    private List<Run> addSomeRuns(IInternalContest contest) throws ClassNotFoundException, IOException, FileSecurityException, RunUnavailableException {
+
+        List<Run> list = new ArrayList<Run>();
+
+        String[] runsData = {
+
+                "1,1,A,1,No", // 20
+                "2,1,A,3,Yes", // 3 (first yes counts Minutes only)
+                "3,1,A,5,No", // 20
+                "4,1,A,7,Yes", // 20
+                "5,1,A,9,No", // 20
+
+                "6,1,B,11,No", // 20 (all runs count)
+                "7,1,B,13,No", // 20 (all runs count)
+
+                "8,2,A,30,Yes", // 30
+
+                "9,2,B,35,No", // 20 (all runs count)
+                "10,2,B,40,No", // 20 (all runs count)
+                "11,2,B,45,No", // 20 (all runs count)
+                "12,2,B,50,No", // 20 (all runs count)
+                "13,2,B,55,No", // 20 (all runs count)
+
+                "14,2,A,30,No", // doesn't count, no after yes
+                "15,2,A,25,No", // doesn't count, no after yes
+
+                "16,2,A,330,Yes", // doesn't count, yes after yes
+
+        };
+
+        for (String runInfoLine : runsData) {
+            Run newRun = sample.addARun(contest, runInfoLine);
+            list.add(newRun);
+        }
+
+        return list;
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/list/AvailableAJComparator.java
+++ b/src/edu/csus/ecs/pc2/core/list/AvailableAJComparator.java
@@ -1,0 +1,37 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.list;
+
+import java.util.Comparator;
+
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.ClientId;
+
+/**
+ * Compare sort by site, clienttype, client number.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ */
+public class AvailableAJComparator implements Comparator<AvailableAJ> {
+
+    @Override
+    public int compare(AvailableAJ availableAJOne, AvailableAJ availableAJTwo) {
+
+        ClientId clientId1 = availableAJOne.getClientId();
+        ClientId clientId2 = availableAJTwo.getClientId();
+
+        int site1 = clientId1.getSiteNumber();
+        int site2 = clientId2.getSiteNumber();
+
+        if (site1 == site2) {
+
+            if (clientId1.getClientType().equals(clientId2.getClientType())) {
+                return clientId1.getClientNumber() - clientId2.getClientNumber();
+            } else {
+                return clientId1.getClientType().compareTo(clientId2.getClientType());
+            }
+
+        } else {
+            return site1 - site2;
+        }
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/list/AvailableAJList.java
+++ b/src/edu/csus/ecs/pc2/core/list/AvailableAJList.java
@@ -1,0 +1,66 @@
+package edu.csus.ecs.pc2.core.list;
+
+import java.util.Iterator;
+import java.util.Vector;
+
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+
+/**
+ * This class encapsulates a list of {@link AvailableAJ}s -- that is, it maintains a list of all Judge Clients
+ * which have currently registered as "available to auto-judge run submissions".
+ * 
+ * @author John Clevenger, PC2 Development Team
+ *
+ */
+public class AvailableAJList implements Iterable<AvailableAJ> {
+
+    //class Vector is used to hold the list because, unlike ArrayList, Vector is thread-safe
+    private Vector<AvailableAJ> availableAJList = new Vector<AvailableAJ>();
+    
+    /**
+     * Constructs an (initially empty) list of {@link AvailableAJ}s.
+     */
+    public AvailableAJList () {
+        
+    }
+    
+    /**
+     * Adds the specified {@link AvailableAJ} to the list of Available AutoJudges.
+     * 
+     * If the specified AvailableAJ is null, this method does nothing.
+     * 
+     * @param aj the {@link AvailableAJ} to be added to the list.
+     */
+    public void add (AvailableAJ aj) {
+        if (aj != null) {
+            availableAJList.add(aj);
+        }
+    }
+    
+    /**
+     * Removes the specified {@link AvailableAJ} from the list of Available AutoJudges.
+     * 
+     * If the specified AvailableAJ is not currently in the list (as determined by its ClientId),
+     * this method does nothing.
+     * 
+     */
+    public void remove (AvailableAJ aj) {
+        availableAJList.remove(aj);
+    }
+    
+    /**
+     * Returns an indication of the number of elements currently in this AvailableAJList.
+     */
+    public int size() {
+        return availableAJList.size();
+    }
+    
+    /**
+     * Returns an Iterator over the {@link AvailableAJ}s currently in this list.
+     * @return an Iterator<AvailableAJ>.
+     */
+    @Override
+    public Iterator<AvailableAJ> iterator() {
+        return availableAJList.iterator();
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/list/AvailableAJRunList.java
+++ b/src/edu/csus/ecs/pc2/core/list/AvailableAJRunList.java
@@ -1,0 +1,64 @@
+package edu.csus.ecs.pc2.core.list;
+
+import java.util.Iterator;
+import java.util.Vector;
+
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
+
+/**
+ * This class encapsulates a list of {@link AvailableAJRuns}s -- that is, it maintains a list of runs which have 
+ * been submitted and are awaiting assignment to an AutoJudge.
+ * 
+ * @author John Clevenger, PC2 Development Team
+ *
+ */
+public class AvailableAJRunList implements Iterable<AvailableAJRun> {
+
+    //class Vector is used to hold the list because, unlike ArrayList, Vector is thread-safe
+    private Vector<AvailableAJRun> ajRunList = new Vector<AvailableAJRun>();
+    
+    /**
+     * Constructs an (initially empty) list of {@link AvailableAJRun}s.
+     */
+    public AvailableAJRunList () {
+        
+    }
+    
+    /**
+     * Adds the specified {@link AvailableAJRun} to the list of runs available for autojudging.
+     * If the specified AvailableAJRun is null, this method does nothing.
+     * 
+     * @param ajRun the {@link AvailableAJRun} to be added to the list.
+     */
+    public void add (AvailableAJRun ajRun) {
+        if (ajRun != null) {
+            ajRunList.add(ajRun);
+        }
+    }
+    
+    /**
+     * Removes the specified {@link AvailableAJRun} from the list of AvailableAJRuns.
+     * If the specified AvailableAJRun is not currently in the list, this method does nothing.
+     * 
+     * @param ajRun the run which is to be removed from the list.
+     */
+    public void remove (AvailableAJRun ajRun) {
+        ajRunList.remove(ajRun);
+    }
+    
+    /**
+     * Returns an indication of the number of elements currently in this AvailableAJRunList.
+     */
+    public int size() {
+        return ajRunList.size();
+    }
+
+    /**
+     * Returns an Iterator over the {@link AvailableAJRun}s currently in this list.
+     * @return an Iterator<AvailableAJRun>.
+     */
+    @Override
+    public Iterator<AvailableAJRun> iterator() {
+        return ajRunList.iterator();
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/model/AvailableAJ.java
+++ b/src/edu/csus/ecs/pc2/core/model/AvailableAJ.java
@@ -1,0 +1,132 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.model;
+
+import edu.csus.ecs.pc2.core.list.ProblemList;
+
+/**
+ * This class encapsulates the notion of an AutoJudge (AJ) which is currently "available" to accept and judge runs.
+ * 
+ * An AvailableAJ contains a {@link ClientId}
+ * and a list of {@link Problem}s which the AJ client is configured to judge.
+ * 
+ * @author John Clevenger, PC2 Development Team
+ */
+public class AvailableAJ {
+
+    private ClientId clientId ;
+    private ProblemList problemList ;
+    
+    /**
+     * Constructs an AvailableAJ with a specified clientId, and problem list.
+     * 
+     * @param clientId the ClientId for this AutoJudge.
+     * @param probList the list of problems which this AJ is configured to judge.
+     * 
+     */
+    public AvailableAJ (ClientId clientId, ProblemList probList) {
+        this.clientId = clientId;
+        this.problemList = probList;
+    }    
+    
+    /**
+     * Add a problem to the {@link ProblemList} for this AvailableAJ.
+     * 
+     * @param problem the {@link Problem} to be added to this AvailableAJ's list of problems which it can judge.
+     */
+    public void addProblem(Problem problem) {
+        
+        //don't try to add a null problem
+        if (problem != null) {
+            
+            //make sure we have a problem list to which we can add problems
+            if (this.problemList==null) {
+                this.problemList = new ProblemList();
+            }
+            
+            //add the specified problem to this AvailableAJ's problem list
+            this.problemList.add(problem);
+        }
+    }
+    
+    /**
+     * Remove a problem from the {@link ProblemList} for this AvailableAJ.
+     */
+    public void removeProblem (Problem problem) {
+        
+        //don't try to remove null problems
+        if (problem != null) {
+            
+            //make sure we have a problem list
+            if (this.problemList != null) {
+                
+                //remove the specified problem from the ProblemList
+                problemList.delete(problem.getElementId());
+            }
+        }
+    }
+
+    /**
+     * Get the list of problems which this AvailableAJ can judge.
+     * @return the problem list for this AJ.
+     */
+    public ProblemList getProblemList() {
+        return problemList;
+    }
+
+    /**
+     * Set the list of problems which this AvailableAJ can judge.
+     * Invoking this method discards any previously-specified list of problems for this AvailableAJ.
+     * @param problemList the (new) list of problems which this AvailableAJ can judge.
+     */
+    public void setProblemList(ProblemList problemList) {
+        this.problemList = problemList;
+    }
+
+    /**
+     * Get the {@link ClientId} for this AvailableAJ.
+     * @return the AvailableAJ's {@link ClientId}.
+     */
+    public ClientId getClientId() {
+        return clientId;
+    }
+
+    /**
+     * Returns an indication of whether this AutoJudge client is able to judge the specified problem (that is,
+     * whether or not the AJ has been configured for judging the problem).
+     * Note that deciding whether this AJ "can judge" a problem is unrelated to whether or not this AJ
+     * is AVAILABLE for judging.
+     * 
+     * @param problemId the Id of the problem about which the caller is asking.
+     * @return true if this AJ is configured to judge the specified problem; false if not.
+     */
+    public boolean canJudge(ElementId problemId) {
+        
+        Problem[] problist = problemList.getList();
+        for (Problem prob : problist) {
+            if (prob.getElementId().equals(problemId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof AvailableAJ) {
+            AvailableAJ otherAvailableAJ = (AvailableAJ) obj;
+            return clientId.equals(otherAvailableAJ.getClientId());
+        } else {
+            throw new ClassCastException("expected a AvailableAJ found: " + obj.getClass().getName());
+        }
+    }
+    
+    public int hashCode() {
+        return clientId.toString().hashCode();
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/model/AvailableAJ.java
+++ b/src/edu/csus/ecs/pc2/core/model/AvailableAJ.java
@@ -1,6 +1,8 @@
 // Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
+import java.io.Serializable;
+
 import edu.csus.ecs.pc2.core.list.ProblemList;
 
 /**
@@ -11,8 +13,13 @@ import edu.csus.ecs.pc2.core.list.ProblemList;
  * 
  * @author John Clevenger, PC2 Development Team
  */
-public class AvailableAJ {
+public class AvailableAJ implements Serializable{
+    
 
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -2378901620039640236L;
     private ClientId clientId ;
     private ProblemList problemList ;
     

--- a/src/edu/csus/ecs/pc2/core/model/AvailableAJRun.java
+++ b/src/edu/csus/ecs/pc2/core/model/AvailableAJRun.java
@@ -1,6 +1,8 @@
 // Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
+import java.io.Serializable;
+
 /**
  * This class encapsulates the notion of a {@link Run} which is currently waiting to be judged by an AutoJudge.
  * 
@@ -11,8 +13,12 @@ package edu.csus.ecs.pc2.core.model;
  * @author John Clevenger, PC2 Development Team
  *
  */
-public class AvailableAJRun {
+public class AvailableAJRun implements Serializable{
 
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1643039335505755842L;
     private ElementId runId ;
     private long contestSubmissionTimeMsec ;
     private ElementId problemId ;

--- a/src/edu/csus/ecs/pc2/core/model/AvailableAJRun.java
+++ b/src/edu/csus/ecs/pc2/core/model/AvailableAJRun.java
@@ -1,0 +1,65 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.model;
+
+/**
+ * This class encapsulates the notion of a {@link Run} which is currently waiting to be judged by an AutoJudge.
+ * 
+ * An AvailableAJRun contains an {@link ElementId} which is its "run ID", a time field which is the elapsed 
+ * contest time at which the run was submitted, and an {@link ElementId} which is the Id of the {@link Problem}
+ * for which the run was submitted.
+ * 
+ * @author John Clevenger, PC2 Development Team
+ *
+ */
+public class AvailableAJRun {
+
+    private ElementId runId ;
+    private long contestSubmissionTimeMsec ;
+    private ElementId problemId ;
+    
+    /**
+     * Constructs an AvailableAJRun with a specified runId, submission time, and problem Id.
+     * 
+     * @param runId the id of the AvailableAJRun.
+     * @param contestSubmitTimeMsec the contest elapsed time of the submission, in milliseconds.
+     * @param probId the id of the problem for which the run was submitted.
+     */
+    
+    public AvailableAJRun (ElementId runId, long contestSubmissionTimeMsec, ElementId problemId) {
+        this.runId = runId;
+        this.contestSubmissionTimeMsec = contestSubmissionTimeMsec;
+        this.problemId = problemId;
+    }
+
+    public ElementId getRunId() {
+        return runId;
+    }
+
+    public long getContestSubmissionTimeMsec() {
+        return contestSubmissionTimeMsec;
+    }
+
+    public ElementId getProblemId() {
+        return problemId;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof AvailableAJRun) {
+            AvailableAJRun otherAvailableAJRun = (AvailableAJRun) obj;
+            return runId.equals(otherAvailableAJRun.getRunId());
+        } else {
+            throw new ClassCastException("expected a AvailableAJRun found: " + obj.getClass().getName());
+        }
+    }
+    
+    public int hashCode() {
+        return runId.toString().hashCode();
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/model/ContestLoginSuccessData.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestLoginSuccessData.java
@@ -2,6 +2,7 @@
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.Serializable;
+import java.util.List;
 
 import edu.csus.ecs.pc2.core.transport.ConnectionHandlerID;
 
@@ -43,6 +44,8 @@ public class ContestLoginSuccessData implements Serializable {
     private int siteNumber;
     private ContestInformation information; 
     private FinalizeData finalizeData;
+    private List<AvailableAJRun> availableToAJRuns;
+    private List<AvailableAJ> AvaiableToAJJudges;
 
     /**
      * @return Returns the accounts.
@@ -277,5 +280,20 @@ public class ContestLoginSuccessData implements Serializable {
     public void setFinalizeData(FinalizeData finalizeData) {
         this.finalizeData = finalizeData;
     }
-    
+
+    public List<AvailableAJRun> getAvailableToAJRuns() {
+        return availableToAJRuns;
+    }
+
+    public void setAvailableToAJRuns(List<AvailableAJRun> availableToAJRuns) {
+        this.availableToAJRuns = availableToAJRuns;
+    }
+
+    public List<AvailableAJ> getAvaiableToAJJudges() {
+        return AvaiableToAJJudges;
+    }
+
+    public void setAvaiableToAJJudges(List<AvailableAJ> avaiableToAJJudges) {
+        AvaiableToAJJudges = avaiableToAJJudges;
+    }    
 }

--- a/src/edu/csus/ecs/pc2/core/model/IInternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/IInternalContest.java
@@ -1268,7 +1268,7 @@ public interface IInternalContest {
     void removeAvailableAutoJudgeRun(Run run);
 
     /**
-     * For the input client id (judge) find the next run it should judge.
+     * Find run to be autojudged.  If client found then remove run and judge client from available lists.oo
      * 
      * @param judgeClientId
      * @return null (no run found) or the Run.
@@ -1295,7 +1295,8 @@ public interface IInternalContest {
     AvailableAJRun addAvailableAutoJudgeRun(Run run);
 
     /**
-     * Find auto judge for run.
+     * Find auto judge for run.  If run found then remove run and judge client from available lists.oo
+     * 
      * 
      * @param run
      * @return null if no judge found, else the auto judge clientid

--- a/src/edu/csus/ecs/pc2/core/model/IInternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/IInternalContest.java
@@ -1,9 +1,10 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.IOException;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Vector;
 
 import edu.csus.ecs.pc2.core.IStorage;
@@ -1241,4 +1242,63 @@ public interface IInternalContest {
      * @return
      */
     String getCommandLineOptionValue(String optionNaeme);
+
+    /**
+     * Add or Update AutoJudge/judge to list of available auto judges.
+     * 
+     * @param sourceClientId
+     * @return null if cannot add, or the AvailableAJ added.
+     */
+    AvailableAJ addAvailableAutoJudge(ClientId sourceClientId);
+    
+    /**
+     * Remove auto judge from list of available auto judges.
+     * 
+     * If a judge logs out, or the admin turns autojudging off for a judge,
+     * remove the judge from the list. 
+     * @param judgeClientId
+     */
+    void removeAvailableAutoJudge(ClientId judgeClientId);
+
+    /**
+     * Remove run from list of available auto judge runs.
+     * 
+     * @param run
+     */
+    void removeAvailableAutoJudgeRun(Run run);
+
+    /**
+     * For the input client id (judge) find the next run it should judge.
+     * 
+     * @param judgeClientId
+     * @return null (no run found) or the Run.
+     */
+    Run findRunToAutoJudge(ClientId judgeClientId);
+
+    /**
+     * Fetch list of auto judges that are available to auto judge. 
+     */
+    List<AvailableAJ> getAvailableAutoJudges();
+
+    /**
+     * Fetch list of runs that can be auto judged.
+     * @return
+     */
+    List<AvailableAJRun> getAvailableAutoJudgeRuns();
+
+    /**
+     * Add a run to be auto judged.
+     * 
+     * @param run
+     * @return null if no run found, else the avaiable run
+     */
+    AvailableAJRun addAvailableAutoJudgeRun(Run run);
+
+    /**
+     * Find auto judge for run.
+     * 
+     * @param run
+     * @return null if no judge found, else the auto judge clientid
+     */
+    ClientId findAutoJudgeForRun(Run run);
 }

--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -23,6 +23,7 @@ import edu.csus.ecs.pc2.core.exception.RunUnavailableException;
 import edu.csus.ecs.pc2.core.exception.UnableToUncheckoutRunException;
 import edu.csus.ecs.pc2.core.list.AccountList;
 import edu.csus.ecs.pc2.core.list.AccountList.PasswordType;
+import edu.csus.ecs.pc2.core.list.AutoJudgeListsManager;
 import edu.csus.ecs.pc2.core.list.BalloonSettingsList;
 import edu.csus.ecs.pc2.core.list.CategoryDisplayList;
 import edu.csus.ecs.pc2.core.list.CategoryList;
@@ -235,6 +236,33 @@ public class InternalContest implements IInternalContest {
      */
     private JudgementList judgementList = new JudgementList();
     
+    
+    /**
+     * A class that maintains a list of runs and auto judges that are available.
+     * 
+     */
+    private AutoJudgeListsManager autoJudgeListsManager = new AutoJudgeListsManager();
+    
+    // TODO i 496 remove old code availableAJList  
+//    /**     * List of currently available AutoJudge clients (that is, Judge clients which have registered
+//     * as being available to AutoJudge a set of problems).
+//     * deprecated  use AutoJudgeManager
+//     */
+//    private AvailableAJList availableAJList = new AvailableAJList();
+    
+    // TODO i 496 remove old code availableAJRunList
+//    /**
+//     * List of submitted runs currently awaiting dispatching to an available AutoJudge.
+//     * deprecated  use AutoJudgeManager
+//     */
+//    private AvailableAJRunList availableAJRunList = new AvailableAJRunList();
+    
+    // TODO i 496 remove old code ajLock
+//    /**
+//     * Locking object for synchronizing access to the lists of available AutoJudges and runs waiting to be AutoJudged
+//     */
+//    Object ajLock = new Object();
+    
     private SecurityMessageHandler securityMessageHandler;
     
     private Profile profile = null;
@@ -305,6 +333,9 @@ public class InternalContest implements IInternalContest {
 
             resetRunStatus(siteNum);
 
+            // TODO i 496 remove old code
+//            addAvailableAJRuns();
+
             clarificationList.loadFromDisk(siteNum);
             Clarification[] clarList = clarificationList.getList();
             for (int i = 0; i < clarList.length; i++) {
@@ -315,6 +346,29 @@ public class InternalContest implements IInternalContest {
             }
         }
     }
+
+    // TODO i 496 remove unused code
+//    /**
+//     * Add all computer judged runs for current site into AJ List.
+//     */
+//    private void addAvailableAJRuns() {
+//
+//        try {
+//            Run[] runs = runList.getList();
+//            for (Run run : runs) {
+//                Problem problem = getProblem(run.getProblemId());
+//                System.out.println("debug 22 cancelRun " + run + " " + problem);
+//                if (JudgementUtilites.isQueuedForComputerJudging(run) && JudgementUtilites.canBeAutoJudged(problem)) {
+//                    // only need to add run into avaiable AJ list.
+//                    addAvailableAutoJudgeRun(run);
+//                    StaticLog.getLog().log(Log.INFO, "Added run to to available AJ runs " + run);
+//                }
+//            }
+//        } catch (Exception e) {
+//
+//            StaticLog.getLog().log(Log.INFO, "Problem initially adding run(s) to available AJ list");
+//        }
+//    }
 
     /**
      * For each run reset to a non-checked out state. 
@@ -798,8 +852,123 @@ public class InternalContest implements IInternalContest {
 //                addRun(newRun);
 //            }
         }
+
+        // TODO i 496 remove old code that adds and dispatches
+//        //check whether the problem for this run has been assigned for Auto-Judging
+//        if (getProblem(newRun.getProblemId()).isComputerJudged()) {
+//            
+//            //yes, it's a run to be auto-judged; add it to the list of runs awaiting auto-judging
+//            addRunToAJRunList(newRun);
+//        }
+//        
+//        //attempt to assign any and all available runs to available AutoJudges
+//        dispatchRunsToAutoJudges();
+                
         return newRun;
     }
+
+    // TODO i 496 remove code, old code, remove commented out addRunToAJRunList
+//    /**
+//     * This method adds the specified Run to the list of runs awaiting AutoJudging.
+//     * 
+//     * @param run the Run to be added to the waiting-for-AutoJudge list.
+//     * @deprecated use {@link AutoJudgeManager#addRunToAutoJudge(Run)
+//     */
+//    private void addRunToAJRunList(Run run) {
+//        
+//        //construct an AvailableAJRun from the specified input run
+//        AvailableAJRun availableAJRun = new AvailableAJRun(run.getElementId(), run.getElapsedMS(), run.getProblemId());
+//        
+//        //ensure that we don't mess with the available-runs list while some other thread is doing so (for example, running inside method dispatchRunsToAutoJudges())
+//        synchronized (ajLock) {
+//            
+//            //put the availableAJRun in the list of runs available for auto-judging
+//            availableAJRunList.add(availableAJRun);
+//        }
+//    }
+    
+    
+    // TODO i 496 remove old code for dispatchRunsToAutoJudges
+//    /**
+//     * This method checks every run in the list of runs waiting for AutoJudging; if an available AJ can be found for the run
+//     * then the run is "dispatched" to that AJ -- meaning, the method performs a "run checkout", sending the run to the chosen AJ.
+//     */
+//    private void dispatchRunsToAutoJudges() {
+//        boolean done = false;
+//        
+//        while (!done) {
+//            if ( availableAJList.size()<=0  || availableAJRunList.size()<=0 ) {
+//                // there are either no available AJs or no runs waiting for AJs; nothing to dispatch
+//                done = true;
+//            } else {
+//                
+//                //there are available runs, or available AJs (or both); 
+//                //ensure only one thread at a time can manipulate the available AJ and AJRuns lists
+//                synchronized (ajLock) {
+//                    
+//                    AvailableAJ chosenJudge = null;
+//                    AvailableAJRun chosenRun = null;
+//                    //a list to keep track of runs on the "available AJ runs" list which actually get assigned to an AJ
+//                    // (see comments below, where runs get added to this list)
+//                    AvailableAJRunList assignedRunsList = new AvailableAJRunList();
+//                    
+//                    //check each run which is awaiting an AJ
+//                    for (AvailableAJRun currentAJRun : availableAJRunList) {
+//                        
+//                        //try to find an AJ which can judge the current run (i.e. is configured for that problem)
+//                        boolean foundJudge = false;
+//                        for (AvailableAJ currentAJ : availableAJList) {
+//                            
+//                            //check if the problem for the current run can be judged by the current AJ
+//                            if (currentAJ.canJudge(currentAJRun.getProblemId())) {
+//                                
+//                                //we found an AJ which can judge the current run
+//                                foundJudge = true;
+//                                chosenJudge = currentAJ;
+//                                break;
+//                            }
+//                        }
+//                        
+//                        if (foundJudge) {
+//                            
+//                            //we found an available AJ that can judge the run; dispatch the run to that AJ
+//                            assignRunToAutoJudge(chosenRun, chosenJudge);
+//                            
+//                            //remove the assigned judge from the list of available AJs
+//                            availableAJList.remove(chosenJudge);
+//                            
+//                            //add the run to a list of runs which need to be removed from the "availableAJRuns" list.
+//                            // (This is done rather than just immediately removing the run from the list in order to avoid 
+//                            // "concurrent modification" exceptions which could occur if the run
+//                            // was removed while the corresponding iterator is still active.)
+//                            assignedRunsList.add(currentAJRun);
+//                            
+//                        }
+//                        
+//                    }//end for each availableRun
+//                    
+//                    // remove any runs which got dispatched to judges from the "available runs" list (see comment above)
+//                    for (AvailableAJRun assignedRun : assignedRunsList) {
+//                        availableAJRunList.remove(assignedRun);
+//                    }
+//                    
+//                }//end synchronized block
+//            }
+//        }
+//        
+//    }
+
+    // TODO i 496 remove old code
+//    /**
+//     * This method performs a "run checkout", sending the specified run to the specified AJ.
+//     * 
+//     * @param run the Run which is to be assigned to the specified AJ.
+//     * @param judge the available AutoJudge to which the run is to be dispatched.
+//     */
+//    private void assignRunToAutoJudge(AvailableAJRun run, AvailableAJ judge) {
+//        throw new UnsupportedOperationException("Method InternalContest.assignRunToAutoJudge() has not yet been implemented...");
+//
+//    }
 
     /**
      * Accept Clarification, add clar into this server.
@@ -3306,5 +3475,48 @@ public class InternalContest implements IInternalContest {
     @Override
     public String getCommandLineOptionValue(String optionNaeme) {
         return parseArguments.getOptValue(optionNaeme);
+    }
+
+    @Override
+    public AvailableAJ addAvailableAutoJudge(ClientId judgeClientId) {
+        AvailableAJ availableAJ = autoJudgeListsManager.addAvailableAutoJudge(this, judgeClientId);
+        return availableAJ;
+    }
+    
+    @Override
+    public AvailableAJRun addAvailableAutoJudgeRun(Run run) {
+        AvailableAJRun availableAJRun = autoJudgeListsManager.addRunToAutoJudge(run);
+        return availableAJRun;
+    }
+    
+
+    @Override
+    public void removeAvailableAutoJudge(ClientId judgeClientId) {
+        autoJudgeListsManager.removeAvailableAutoJudge(judgeClientId);
+    }
+    
+    @Override
+    public void removeAvailableAutoJudgeRun(Run run) {
+        autoJudgeListsManager.removeAutoJudgeRun(run);
+    }
+
+    @Override
+    public Run findRunToAutoJudge(ClientId judgeClientId) {
+        return autoJudgeListsManager.findRunToAutoJudge(this, judgeClientId);
+    }
+    
+    @Override
+    public ClientId findAutoJudgeForRun(Run run) {
+        return autoJudgeListsManager.findAutoJudgeForRun(run);
+    }
+
+    @Override
+    public List<AvailableAJ> getAvailableAutoJudges() {
+        return autoJudgeListsManager.getAvailableAJList();
+    }
+
+    @Override
+    public List<AvailableAJRun> getAvailableAutoJudgeRuns() {
+        return autoJudgeListsManager.getAvailableAJRuns();
     }
 }

--- a/src/edu/csus/ecs/pc2/core/packet/PacketFactory.java
+++ b/src/edu/csus/ecs/pc2/core/packet/PacketFactory.java
@@ -2369,5 +2369,18 @@ public final class PacketFactory {
         return packet;
     }
 
-    
+
+    /**
+     * Stop judging on judge.
+     * 
+     * @param source
+     * @param destination
+     * @return
+     */
+    public static Packet createResetAutoJudge (ClientId source, ClientId destination) {
+        Properties prop = new Properties();
+        prop.put(CLIENT_ID, source);
+        Packet packet = new Packet(Type.RESET_AUTO_JUDGE, source, destination, prop);
+        return packet;
+    }
 }

--- a/src/edu/csus/ecs/pc2/core/packet/PacketFactory.java
+++ b/src/edu/csus/ecs/pc2/core/packet/PacketFactory.java
@@ -2322,4 +2322,16 @@ public final class PacketFactory {
         return packet;
     }
     
+
+    /**
+     * Auto judge ready to judge.
+     * 
+     */
+    public static Packet createAvaiableToAutoJudge(ClientId source, ClientId destination) {
+        Properties prop = new Properties();
+        prop.put(CLIENT_ID, source);
+        Packet packet = new Packet(Type.AVAILABLE_TO_AUTO_JUDGE, source, destination, prop);
+        return packet;
+    }
+
 }

--- a/src/edu/csus/ecs/pc2/core/packet/PacketFactory.java
+++ b/src/edu/csus/ecs/pc2/core/packet/PacketFactory.java
@@ -6,6 +6,7 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -16,6 +17,8 @@ import edu.csus.ecs.pc2.core.list.ProblemDisplayList;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.Account;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
 import edu.csus.ecs.pc2.core.model.BalloonSettings;
 import edu.csus.ecs.pc2.core.model.Category;
 import edu.csus.ecs.pc2.core.model.Clarification;
@@ -356,6 +359,17 @@ public final class PacketFactory {
     public static final String TEAM_RUN_SOURCE_FILES_LIST = "TEAM_RUN_SOURCE_FILES_LIST";
 
     public static final String REQUEST_LOGIN_AS_PROXY = "REQUEST_LOGIN_AS_PROXY";
+
+    /**
+     * List of available aj runs (AvailableAJRun)
+     */
+    public static final String AVAILABLE_AUTO_JUDGE_RUNS = "AVAILABLE_AUTO_JUDGE_RUNS";
+
+    
+    /**
+     * List of available AJ Judges (AvailableAJ)
+     */
+    public static final String AVAILABLE_AUTO_JUDGE_JUDGES = "AVAILABLE_AUTO_JUDGE_JUDGES";
     
     
     /**
@@ -1199,7 +1213,7 @@ public final class PacketFactory {
         prop.put(SITE_NUMBER, new Integer(data.getSiteNumber()));
         prop.put(CONTEST_TIME, data.getContestTime());
         prop.put(CONTEST_INFORMATION, data.getContestInformation());
-        
+
         if (data.getFinalizeData() != null) {
             prop.put(FINALIZE_DATA, data.getFinalizeData());
         }
@@ -1211,6 +1225,14 @@ public final class PacketFactory {
         if (data.getCategories() != null){
             prop.put(CATEGORY_LIST, data.getCategories());
         }
+
+        if (data.getAvailableToAJRuns() != null) {
+            prop.put(AVAILABLE_AUTO_JUDGE_RUNS, data.getAvailableToAJRuns());
+        }
+        if (data.getAvaiableToAJJudges() != null) {
+            prop.put(AVAILABLE_AUTO_JUDGE_JUDGES, data.getAvaiableToAJJudges());
+        }
+        
     }
 
     /**
@@ -2334,4 +2356,18 @@ public final class PacketFactory {
         return packet;
     }
 
+    /**
+     * Auto judge ready to judge.
+     * 
+     */
+    public static Packet createAvailableAutoJudgeLists(ClientId source, ClientId destination, List<AvailableAJRun> availableRuns, List<AvailableAJ> availableJudges) {
+        Properties prop = new Properties();
+        prop.put(CLIENT_ID, source);
+        prop.put(AVAILABLE_AUTO_JUDGE_RUNS, availableRuns);
+        prop.put(AVAILABLE_AUTO_JUDGE_JUDGES, availableJudges);
+        Packet packet = new Packet(Type.AVAILABLE_AJ_LISTS, source, destination, prop);
+        return packet;
+    }
+
+    
 }

--- a/src/edu/csus/ecs/pc2/core/packet/PacketType.java
+++ b/src/edu/csus/ecs/pc2/core/packet/PacketType.java
@@ -772,6 +772,15 @@ public final class PacketType implements Serializable {
          * Contains: judge client id
          */
          AVAILABLE_TO_AUTO_JUDGE,
+         
+         /**
+          * List of avaiable AJ Judges and Runs.
+          * 
+          * from server to server
+          * contains: List of Available judges to autojudge
+          * List of runs to auto judge
+          */
+         AVAILABLE_AJ_LISTS,
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/packet/PacketType.java
+++ b/src/edu/csus/ecs/pc2/core/packet/PacketType.java
@@ -774,13 +774,21 @@ public final class PacketType implements Serializable {
          AVAILABLE_TO_AUTO_JUDGE,
          
          /**
-          * List of avaiable AJ Judges and Runs.
+          * List of available AJ Judges and Runs.
           * 
           * from server to server
           * contains: List of Available judges to autojudge
           * List of runs to auto judge
           */
          AVAILABLE_AJ_LISTS,
+         
+         /**
+          * Reset Auto Judge - clear any judging done by judge.
+          * 
+          * from server to judge
+          * contains: nothing
+          */
+         RESET_AUTO_JUDGE,
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/packet/PacketType.java
+++ b/src/edu/csus/ecs/pc2/core/packet/PacketType.java
@@ -764,6 +764,14 @@ public final class PacketType implements Serializable {
          * to the server for team's run source (RunFile []) files.
          */
         REQUEST_FETCH_TEAMS_SUBMISSION_FILES,
+        
+        /**
+         * Notify server that this judge is ready to auto judge runs.
+         * 
+         * from auto-judge to server<br>
+         * Contains: judge client id
+         */
+         AVAILABLE_TO_AUTO_JUDGE,
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/report/AutojudgeListReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/AutojudgeListReport.java
@@ -1,0 +1,211 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.report;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.list.AvailableAJComparator;
+import edu.csus.ecs.pc2.core.list.ProblemComparator;
+import edu.csus.ecs.pc2.core.list.ProblemList;
+import edu.csus.ecs.pc2.core.list.RunComparator;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
+import edu.csus.ecs.pc2.core.model.ClientType.Type;
+import edu.csus.ecs.pc2.core.model.Filter;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Problem;
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * Report that shows AJ Judge list and AJ Runs list.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ *
+ */
+public class AutojudgeListReport implements IReportFile {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 2354125593511939010L;
+
+    private IInternalContest contest;
+
+    private IInternalController controller;
+
+    private Log log;
+
+    private Filter filter;
+
+    @Override
+    public void setContestAndController(IInternalContest inContest, IInternalController inController) {
+        this.contest = inContest;
+        this.controller = inController;
+        log = controller.getLog();
+    }
+
+    @Override
+    public String getPluginTitle() {
+        return "Autojudge Lists";
+    }
+
+    @Override
+    public void createReportFile(String filename, Filter aFilter) throws IOException {
+
+        PrintWriter printWriter = new PrintWriter(new FileOutputStream(filename, false), true);
+
+        try {
+            try {
+                printHeader(printWriter);
+
+                writeReport(printWriter);
+
+                printFooter(printWriter);
+
+                printWriter.close();
+
+            } catch (Exception e) {
+                printWriter.println("Exception in report: " + e.getMessage());
+                e.printStackTrace(printWriter);
+            }
+
+            printWriter = null;
+
+        } catch (Exception e) {
+            log.log(Log.INFO, "Exception writing report", e);
+        }
+
+    }
+
+    @Override
+    public String[] createReport(Filter aFilter) {
+        String[] arr = { "createReport not implemented" };
+        return arr;
+    }
+
+    @Override
+    public String createReportXML(Filter aFilter) throws IOException {
+        return Reports.notImplementedXML(this);
+    }
+
+    @Override
+    public void writeReport(PrintWriter printWriter) throws Exception {
+
+        List<AvailableAJ> ajList = contest.getAvailableAutoJudges();
+        Collections.sort(ajList, new AvailableAJComparator());
+
+        printWriter.println("There are " + ajList.size() + " Judges available in Auto Judge list");
+
+        for (AvailableAJ availableAJ : ajList) {
+            printWriter.println("    " + availableAJ.getClientId() + " " + //
+                    getProblemShortNames(contest, availableAJ.getProblemList()));
+        }
+
+        List<AvailableAJRun> runList = contest.getAvailableAutoJudgeRuns();
+        List<Run> runs = getRuns(contest, runList);
+        Collections.sort(runs, new RunComparator());
+
+        printWriter.println("There are " + runList.size() + " Runs in Auto Judge list");
+
+        for (Run run : runs) {
+            printWriter.println("    Run " + run.getNumber() + " " + run);
+        }
+
+        if (!Type.SERVER.equals(contest.getClientId().getClientType())) {
+            printWriter.println();
+            printWriter.println("Note: since this report is not run on the server the lists may be empty.");
+        }
+    }
+
+    private String getProblemShortNames(IInternalContest inContest, ProblemList problemList) {
+        
+        
+        String problemListString = "";
+        
+        Problem[] problems = problemList.getList();
+        if (problems.length > 0) {
+            Arrays.sort(problems, new ProblemComparator(inContest));
+//        Iterator<Problem> iter = Arrays.asList(problems).iterator();
+            List<Problem> list = Arrays.asList(problems);
+            
+            List<String> problemStrings = list.stream() //
+                    .flatMap(p -> Stream.of(p.getLetter()+" - "+p.getShortName())) //
+                    .collect(Collectors.toList());
+            
+            problemListString = String.join(", ",  problemStrings);
+        }
+        
+        return problemList.size() + " problems: "+problemListString;
+    }
+
+    /**
+     * Extract and return a list of runs (from auto judge run list)
+     * 
+     * @param contest2
+     * @param runList
+     * @return
+     */
+    private List<Run> getRuns(IInternalContest contest2, List<AvailableAJRun> runs) {
+
+        List<Run> list = new ArrayList<Run>();
+
+        for (AvailableAJRun availableAJRun : runs) {
+            Run run = contest.getRun(availableAJRun.getRunId());
+            if (run == null) {
+                System.err.println("Warning, could not find run in model for element id " + availableAJRun.getRunId());
+            } else {
+                list.add(run);
+            }
+        }
+
+        return list;
+    }
+
+    @Override
+    public String getReportTitle() {
+        return "Autojudge Lists";
+    }
+
+    @Override
+    public Filter getFilter() {
+        return filter;
+    }
+
+    @Override
+    public void setFilter(Filter filter) {
+        this.filter = filter;
+
+    }
+
+    @Override
+    public boolean suppressHeaderFooter() {
+        return false;
+    }
+
+    @Override
+    public void printHeader(PrintWriter printWriter) {
+        printWriter.println(new VersionInfo().getSystemName());
+        printWriter.println("Date: " + Utilities.getL10nDateTime());
+        printWriter.println(new VersionInfo().getSystemVersionInfo());
+        printWriter.println();
+        printWriter.println(getReportTitle() + " Report");
+    }
+
+    @Override
+    public void printFooter(PrintWriter printWriter) {
+        printWriter.println();
+        printWriter.println("end report");
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/report/Reports.java
+++ b/src/edu/csus/ecs/pc2/core/report/Reports.java
@@ -164,6 +164,8 @@ public final class Reports {
         
         reports.add(new ContestCompareReport());
         
+        reports.add(new AutojudgeListReport());
+        
         return (IReport[]) reports.toArray(new IReport[reports.size()]);
 
     }

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePane.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePane.java
@@ -3,25 +3,33 @@ package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Font;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.util.Arrays;
+import java.util.List;
 
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumnModel;
 
+import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.list.ProblemList;
 import edu.csus.ecs.pc2.core.model.AvailableAJ;
 import edu.csus.ecs.pc2.core.model.AvailableAJRun;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.Run;
 
 /**
- * Pane to show Autoudge Runs and Judges that are available to be autojudged.
+ * Pane to show Autojudge Runs and Judges that are available to be autojudged.
  * 
  * @author Douglas A. Lane <laned@csus.edu>
  *
@@ -102,7 +110,47 @@ public class AutoJudgeAvailablePane extends JPanePlugin {
         judgesCEnterPael.add(judgeCustomizeTable);
 
         JPanel buttonPane = new JPanel();
+
+        
         add(buttonPane, BorderLayout.SOUTH);
+
+        JButton refreshButton = new JButton("Refresh");
+        refreshButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                populateGUI();
+            }
+        });
+        refreshButton.setMnemonic(KeyEvent.VK_R);
+        refreshButton.setToolTipText("Refresh the pane data");
+        buttonPane.add(refreshButton);
+    }
+
+    /**
+     * Refresh gui data.
+     */
+    protected void populateGUI() {
+
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                if (runsTableModel != null) {
+                    runsTableModel.setRowCount(0);
+                }
+                if (judgesTableModel != null) {
+                    judgesTableModel.setRowCount(0);
+                }
+
+                List<AvailableAJRun> runs = getContest().getAvailableAutoJudgeRuns();
+                for (AvailableAJRun availableAJRun : runs) {
+                    updateRunRow(availableAJRun);
+                }
+
+                List<AvailableAJ> judges = getContest().getAvailableAutoJudges();
+                for (AvailableAJ availableAJ : judges) {
+                    updateJudgeRow(availableAJ);
+                }
+            }
+        });
+
     }
 
     private JTableCustomized getrunsCustomizeTab1le() {
@@ -139,7 +187,6 @@ public class AutoJudgeAvailablePane extends JPanePlugin {
     }
 
     private Object toString(ProblemList problemList) {
-        String s = "";
         Problem[] problems = problemList.getList();
         return Arrays.toString(problems);
     }
@@ -183,6 +230,12 @@ public class AutoJudgeAvailablePane extends JPanePlugin {
             tableColumnModel.removeColumn(tableColumnModel.getColumn(columns.length - 1));
         }
         return judgeCustomizeTable;
+    }
+
+    @Override
+    public void setContestAndController(IInternalContest inContest, IInternalController inController) {
+        super.setContestAndController(inContest, inController);
+        populateGUI();
     }
 
     @Override

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePane.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePane.java
@@ -1,0 +1,203 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Font;
+import java.util.Arrays;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.SwingConstants;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumnModel;
+
+import edu.csus.ecs.pc2.core.list.ProblemList;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.Problem;
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * Pane to show Autoudge Runs and Judges that are available to be autojudged.
+ * 
+ * @author Douglas A. Lane <laned@csus.edu>
+ *
+ */
+// TODO 496 Add sort/column header
+// TODO 496 auto size, esp Problems
+// TODO 496 if judge's auto judge settings, problem list or on/off change update judge list
+// TODO 496 dynamic update when judge available
+// TODO 496 dynamic update runs table
+// TODO 496 add count for # judges
+// TODO 496 add count for number of problems
+// TODO 496 on judges table, get Judge display name or remove column
+public class AutoJudgeAvailablePane extends JPanePlugin {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 2645127695835000107L;
+
+    JTableCustomized judgeCustomizeTable = null;
+
+    JTableCustomized runsCustomizeTable = null;
+
+    private DefaultTableModel runsTableModel;
+
+    private DefaultTableModel judgesTableModel;
+
+    public AutoJudgeAvailablePane() {
+        setLayout(new BorderLayout(0, 0));
+
+        JPanel centerPane = new JPanel();
+        add(centerPane, BorderLayout.CENTER);
+        centerPane.setLayout(new BorderLayout(0, 0));
+
+        JSplitPane splitPane = new JSplitPane();
+        splitPane.setOrientation(JSplitPane.VERTICAL_SPLIT);
+        splitPane.addComponentListener(new java.awt.event.ComponentAdapter() {
+            public void componentResized(java.awt.event.ComponentEvent e) {
+                splitPane.setDividerLocation(splitPane.getHeight() / 2);
+            }
+        });
+        centerPane.add(splitPane);
+
+        JPanel rusPanel = new JPanel();
+        splitPane.setRightComponent(rusPanel);
+        rusPanel.setLayout(new BorderLayout(0, 0));
+
+        JPanel runNorthPane = new JPanel();
+        rusPanel.add(runNorthPane, BorderLayout.NORTH);
+        runNorthPane.setLayout(new BorderLayout(0, 0));
+
+        JLabel lblNewLabel = new JLabel("Available Runs");
+        lblNewLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        lblNewLabel.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        runNorthPane.add(lblNewLabel, BorderLayout.CENTER);
+
+        JPanel runsCenterPanel = new JPanel();
+        rusPanel.add(runsCenterPanel, BorderLayout.CENTER);
+        runsCustomizeTable = getrunsCustomizeTab1le();
+        runsCenterPanel.add(runsCustomizeTable);
+
+        JPanel judgesPanel = new JPanel();
+        splitPane.setLeftComponent(judgesPanel);
+        judgesPanel.setLayout(new BorderLayout(0, 0));
+
+        JPanel judgesNorthPanel = new JPanel();
+        judgesPanel.add(judgesNorthPanel, BorderLayout.NORTH);
+        judgesNorthPanel.setLayout(new BorderLayout(0, 0));
+
+        JLabel lblNewLabel_1 = new JLabel("Available Judges");
+        lblNewLabel_1.setFont(new Font("Tahoma", Font.PLAIN, 14));
+        lblNewLabel_1.setHorizontalAlignment(SwingConstants.CENTER);
+        judgesNorthPanel.add(lblNewLabel_1, BorderLayout.NORTH);
+
+        JPanel judgesCEnterPael = new JPanel();
+        judgesPanel.add(judgesCEnterPael);
+
+        judgeCustomizeTable = getjudgeCustomizeTable();
+        judgesCEnterPael.add(judgeCustomizeTable);
+
+        JPanel buttonPane = new JPanel();
+        add(buttonPane, BorderLayout.SOUTH);
+    }
+
+    private JTableCustomized getrunsCustomizeTab1le() {
+        if (runsCustomizeTable == null) {
+            runsCustomizeTable = new JTableCustomized();
+            Object[] columns = { "Site", "Team", "Run Id", "Time", "Status", "ElementId" };
+            runsTableModel = new DefaultTableModel(columns, 0);
+            runsCustomizeTable.setModel(runsTableModel);
+
+            TableColumnModel tableColumnModel = runsCustomizeTable.getColumnModel();
+            // Remove ElementID from display - this does not REMOVE the column, just makes it so it doesn't show
+            tableColumnModel.removeColumn(tableColumnModel.getColumn(columns.length - 1));
+        }
+
+        return runsCustomizeTable;
+    }
+
+    private Object[] buildJudgeRow(AvailableAJ availableAJ) {
+
+        // Object[] columns = { "Site", "login", "Display Name", "Problems", "TripletKey" };
+        int cols = runsTableModel.getColumnCount();
+        Object[] s = new Object[cols];
+
+        ClientId judgeClient = availableAJ.getClientId();
+
+        s[0] = new Integer(judgeClient.getSiteNumber());
+        s[1] = judgeClient.getName();
+        s[2] = judgeClient.getName(); // TODO 496 get Judge display name or remove column
+        s[3] = toString(availableAJ.getProblemList());
+        s[4] = judgeClient.getTripletKey();
+
+        return s;
+
+    }
+
+    private Object toString(ProblemList problemList) {
+        String s = "";
+        Problem[] problems = problemList.getList();
+        return Arrays.toString(problems);
+    }
+
+    private Object[] buildRunRow(AvailableAJRun availableAJRun) {
+
+//        Object[] columns = { "Site", "Team", "Run Id", "Time", "Status" };
+
+        int cols = runsTableModel.getColumnCount();
+        Object[] s = new Object[cols];
+
+        ElementId id = availableAJRun.getRunId();
+        Run run = getContest().getRun(id);
+
+        s[0] = new Integer(run.getSiteNumber());
+        s[1] = run.getSubmitter().getName();
+        s[2] = new Integer(run.getNumber());
+        s[3] = new Long(run.getElapsedMins());
+        s[4] = run.getStatus().toString();
+        s[5] = run.getElementId();
+
+        return s;
+    }
+
+    /**
+     * This method initializes the runTable
+     * 
+     * @return JTableCustomized
+     */
+    private JTableCustomized getjudgeCustomizeTable() {
+        if (judgeCustomizeTable == null) {
+            judgeCustomizeTable = new JTableCustomized();
+            Object[] columns = { "Site", "login", "Display Name", "Problems", "TripletKey" };
+
+            judgesTableModel = new DefaultTableModel(columns, 0);
+            judgesTableModel.setRowCount(0);
+            judgeCustomizeTable.setModel(judgesTableModel);
+
+            TableColumnModel tableColumnModel = judgeCustomizeTable.getColumnModel();
+            // Remove ElementID from display - this does not REMOVE the column, just makes it so it doesn't show
+            tableColumnModel.removeColumn(tableColumnModel.getColumn(columns.length - 1));
+        }
+        return judgeCustomizeTable;
+    }
+
+    @Override
+    public String getPluginTitle() {
+        return "Autojudge Available Runs and Judges";
+    }
+
+    public void updateJudgeRow(AvailableAJ availableAJ) {
+        Object[] objects = buildJudgeRow(availableAJ);
+        judgesTableModel.addRow(objects);
+    }
+
+    public void updateRunRow(AvailableAJRun availableAJRun) {
+        Object[] objects = buildRunRow(availableAJRun);
+        runsTableModel.addRow(objects);
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePane.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePane.java
@@ -23,10 +23,16 @@ import edu.csus.ecs.pc2.core.list.ProblemList;
 import edu.csus.ecs.pc2.core.model.AvailableAJ;
 import edu.csus.ecs.pc2.core.model.AvailableAJRun;
 import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientSettingsEvent;
 import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.IClientSettingsListener;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.ILoginListener;
+import edu.csus.ecs.pc2.core.model.IRunListener;
+import edu.csus.ecs.pc2.core.model.LoginEvent;
 import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.RunEvent;
 
 /**
  * Pane to show Autojudge Runs and Judges that are available to be autojudged.
@@ -35,13 +41,14 @@ import edu.csus.ecs.pc2.core.model.Run;
  *
  */
 // TODO 496 Add sort/column header
-// TODO 496 auto size, esp Problems
+// TODO 496 auto size, esp Problems List
 // TODO 496 if judge's auto judge settings, problem list or on/off change update judge list
 // TODO 496 dynamic update when judge available
 // TODO 496 dynamic update runs table
 // TODO 496 add count for # judges
 // TODO 496 add count for number of problems
 // TODO 496 on judges table, get Judge display name or remove column
+// TODO 496 add view details button
 public class AutoJudgeAvailablePane extends JPanePlugin {
     /**
      * 
@@ -236,6 +243,15 @@ public class AutoJudgeAvailablePane extends JPanePlugin {
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         super.setContestAndController(inContest, inController);
         populateGUI();
+        
+        IClientSettingsListener clientSettingsListener = new ClientSettingsListener();
+        inContest.addClientSettingsListener(clientSettingsListener);
+        
+        ILoginListener loginListener = new LoginListener();
+        inContest.addLoginListener(loginListener);
+        
+        IRunListener runListener = new RunListener();
+        inContest.addRunListener(runListener);
     }
 
     @Override
@@ -243,14 +259,149 @@ public class AutoJudgeAvailablePane extends JPanePlugin {
         return "Autojudge Available Runs and Judges";
     }
 
+    /**
+     * Update available judge row, add, remove or update judge row.
+     * 
+     * @param availableAJ
+     */
     public void updateJudgeRow(AvailableAJ availableAJ) {
+        
+        // TODO 496 add code to update an existing row, or remove row/judge
+        
         Object[] objects = buildJudgeRow(availableAJ);
         judgesTableModel.addRow(objects);
     }
 
+    /**
+     * Update available run row, add, remove or update run row.
+     * @param run
+     */
+    private void updateRunRow(Run run) {
+        
+        AvailableAJRun availableAJRun = new AvailableAJRun(run.getElementId(), run.getElapsedMS(), run.getProblemId());
+        updateRunRow(availableAJRun);
+    }
+
+    /**
+     * Update available run row, add, remove or update run row.
+     * 
+     * @param availableAJRun
+     */
     public void updateRunRow(AvailableAJRun availableAJRun) {
+        // TODO 496 add code to update an existing row, or remove row/run
+        
+        // TODO 496 only add if can be computer judged
+        
         Object[] objects = buildRunRow(availableAJRun);
         runsTableModel.addRow(objects);
     }
 
+
+    /**
+     * Listener to dynamically change avalable run table.
+     * 
+     * @author Douglas A. Lane, PC^2 team pc2@ecs.csus.edu
+     */
+    class RunListener implements IRunListener  {
+
+        @Override
+        public void runAdded(RunEvent event) {
+
+            runChanged(event);
+        }
+
+        @Override
+        public void runChanged(RunEvent event) {
+            
+            try {
+                updateRunRow(event.getRun());
+            } catch (Exception e) {
+                // TODO 496 handle exception
+            }
+            
+            
+        }
+
+
+        @Override
+        public void runRemoved(RunEvent event) {
+            
+            runChanged(event);
+            
+        }
+
+        @Override
+        public void refreshRuns(RunEvent event) {
+            // TODO Auto-generated method stub
+            
+        }
+        
+    }
+
+    /**
+     * Login listener to update available judge list
+     * 
+     * @author Douglas A. Lane, PC^2 team pc2@ecs.csus.edu
+     */
+    class LoginListener implements ILoginListener {
+
+        @Override
+        public void loginAdded(LoginEvent event) {
+            
+            // TODO 496 Potentially add judge to avail liast
+            
+        }
+
+        @Override
+        public void loginRemoved(LoginEvent event) {
+            // TODO 496 remove judge from avail list
+            ;
+            
+            
+        }
+
+        @Override
+        public void loginDenied(LoginEvent event) {
+            ;  // nop 
+            
+        }
+
+        @Override
+        public void loginRefreshAll(LoginEvent event) {
+            ; // nop
+            
+        }
+        
+    }
+    class ClientSettingsListener implements  IClientSettingsListener{
+
+        @Override
+        public void clientSettingsAdded(ClientSettingsEvent event) {
+
+            clientSettingsChanged(event);
+        }
+
+        @Override
+        public void clientSettingsChanged(ClientSettingsEvent event) {
+            
+         // TODO 496 add/remove judge from avail list
+//          event.getClientId();
+            
+          
+        }
+
+        @Override
+        public void clientSettingsRemoved(ClientSettingsEvent event) {
+
+            clientSettingsChanged(event);
+            
+        }
+
+        @Override
+        public void clientSettingsRefreshAll(ClientSettingsEvent clientSettingsEvent) {
+           ; // nop 
+            
+        }
+        
+    }
 }

--- a/src/edu/csus/ecs/pc2/ui/PluginLoadPane.java
+++ b/src/edu/csus/ecs/pc2/ui/PluginLoadPane.java
@@ -214,6 +214,7 @@ public class PluginLoadPane extends JPanePlugin {
         plugins.add(new SubmissionBiffPane());
         plugins.add(new TeamStatusPane());
         plugins.add(new ViewPropertiesPane());
+        plugins.add(new AutoJudgeAvailablePane());
 
         JPanePlugin[] pluginList = (JPanePlugin[]) plugins.toArray(new JPanePlugin[plugins.size()]);
 

--- a/src/edu/csus/ecs/pc2/ui/ReportPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ReportPane.java
@@ -1,10 +1,12 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -45,6 +47,7 @@ import edu.csus.ecs.pc2.core.report.AccountsTSVReport;
 import edu.csus.ecs.pc2.core.report.AccountsTSVReportTeamAndJudges;
 import edu.csus.ecs.pc2.core.report.AllReports;
 import edu.csus.ecs.pc2.core.report.AutoJudgingSettingsReport;
+import edu.csus.ecs.pc2.core.report.AutojudgeListReport;
 import edu.csus.ecs.pc2.core.report.BalloonDeliveryReport;
 import edu.csus.ecs.pc2.core.report.BalloonSettingsReport;
 import edu.csus.ecs.pc2.core.report.BalloonSummaryReport;
@@ -108,8 +111,6 @@ import edu.csus.ecs.pc2.core.security.Permission.Type;
 import edu.csus.ecs.pc2.core.util.IMemento;
 import edu.csus.ecs.pc2.core.util.XMLMemento;
 import edu.csus.ecs.pc2.ui.EditFilterPane.ListNames;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
 
 /**
  * Report Pane, allows picking and viewing reports.
@@ -302,6 +303,8 @@ public class ReportPane extends JPanePlugin {
         reports.add(new ProblemGroupAssignmentReport());
         
         reports.add(new ContestCompareReport());
+        
+        reports.add(new AutojudgeListReport());
         
         if (isServer()){
             // SOMEDAY Bug 1166 remove this isServer when added to Admin. 

--- a/src/edu/csus/ecs/pc2/ui/TestingFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/TestingFrame.java
@@ -47,7 +47,7 @@ public class TestingFrame extends JFrame {
      * 
      */
     private void initialize() {
-        this.setSize(new java.awt.Dimension(456, 240));
+        this.setSize(new java.awt.Dimension(640, 480));
         this.setContentPane(getCenterPane());
         this.setDefaultCloseOperation(javax.swing.JFrame.EXIT_ON_CLOSE);
         // this.setContentPane(getPluginPane());

--- a/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
+++ b/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui.admin;
 
 import java.awt.BorderLayout;
@@ -34,6 +34,7 @@ import edu.csus.ecs.pc2.core.model.IProfileListener;
 import edu.csus.ecs.pc2.core.model.ProfileEvent;
 import edu.csus.ecs.pc2.ui.AboutPane;
 import edu.csus.ecs.pc2.ui.AccountsTablePane;
+import edu.csus.ecs.pc2.ui.AutoJudgeAvailablePane;
 import edu.csus.ecs.pc2.ui.AutoJudgesPane;
 import edu.csus.ecs.pc2.ui.BalloonSettingsPane;
 import edu.csus.ecs.pc2.ui.CategoriesPane;
@@ -76,10 +77,7 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * Administrator GUI.
  * 
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
-
-// $HeadURL$
 public class AdministratorView extends JFrame implements UIPlugin, ChangeListener {
 
     private static final long serialVersionUID = 1L;
@@ -294,6 +292,9 @@ public class AdministratorView extends JFrame implements UIPlugin, ChangeListene
 
                 AboutPane aboutPane = new AboutPane();
                 addUIPlugin(getConfigureContestTabbedPane(), "About", aboutPane);
+                
+                AutoJudgeAvailablePane autoJudgeAvailablePane= new AutoJudgeAvailablePane();
+                addUIPlugin(getRunContestTabbedPane(), "Auto Judging", autoJudgeAvailablePane);
 
                 /**
                  * add UI components involved with Running the contest to the RunContest tabbed pane

--- a/src/edu/csus/ecs/pc2/ui/judge/AutoJudgeModuleNew.java
+++ b/src/edu/csus/ecs/pc2/ui/judge/AutoJudgeModuleNew.java
@@ -142,12 +142,13 @@ public class AutoJudgeModuleNew implements UIPlugin {
             System.out.println("debug 22 runfiles ? " + (runFiles != null));
             System.out.println("debug 22 Sent to " + event.getSentToClientId());
 
-            if (event.getSentToClientId().equals(contest.getClientId())) {
+            if (event.getWhoModifiedRun().equals(contest.getClientId())) {
                 // run is for us.
 
                 if (!runJudger.isJudging()) {
                     try {
                         runJudger.executeAndAutoJudgeRun(run, runFiles);
+                        System.out.println("debug 22 judging "+run);
                     } catch (Exception e) {
                         warn("Problem trying to judge run " + run, e);
                     }

--- a/src/edu/csus/ecs/pc2/ui/judge/AutoJudgeModuleNew.java
+++ b/src/edu/csus/ecs/pc2/ui/judge/AutoJudgeModuleNew.java
@@ -1,0 +1,204 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.ui.judge;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.exception.MultipleIssuesException;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
+import edu.csus.ecs.pc2.core.execute.RunJudger;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.ContestInformation;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.IRunListener;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.RunEvent;
+import edu.csus.ecs.pc2.core.model.RunFiles;
+import edu.csus.ecs.pc2.ui.UIPlugin;
+
+/**
+ * A non-GUI Auto Judge Module.
+ * 
+ * @author pc2@ecs.csus.edu
+ */
+// TODO 496 handle judge reset (when server takes away run or expects to send a AVAILABLE_TO_AUTO_JUDGE packet
+public class AutoJudgeModuleNew implements UIPlugin {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -3004503436100790316L;
+
+    private IInternalContest contest;
+
+    private IInternalController controller;
+
+    private Log log;
+
+    RunJudger runJudger = null;
+
+    // private AutoJudgingMonitor autoJudgingMonitor = new AutoJudgingMonitor();
+
+    public String getPluginTitle() {
+        return "Server (non-GUI)";
+    }
+
+    public AutoJudgeModuleNew() {
+        VersionInfo versionInfo = new VersionInfo();
+        System.out.println(versionInfo.getSystemName());
+        System.out.println(versionInfo.getSystemVersionInfo());
+        System.out.println("Build " + versionInfo.getBuildNumber());
+        System.out.println("Date: " + getL10nDateTime());
+        System.out.println("Working directory is " + Utilities.getCurrentDirectory());
+        System.out.println();
+
+    }
+
+    public void setContestAndController(IInternalContest inContest, IInternalController inController) {
+        contest = inContest;
+        controller = inController;
+        log = controller.getLog();
+        runJudger = new RunJudger(contest, controller);
+
+        // autoJudgingMonitor.setContestAndController(getContest(), getController());
+        try {
+            ContestInformation ci = contest.getContestInformation();
+            if (ci != null) {
+                String cdpPath = ci.getJudgeCDPBasePath();
+                Utilities.validateCDP(contest, cdpPath);
+            }
+        } catch (MultipleIssuesException e) {
+            System.err.println("Cannot perform Judging");
+            String[] issueList = e.getIssueList();
+            StringBuffer message = new StringBuffer();
+            message.append("The following errors exist:\n");
+            for (int i = 0; i < issueList.length; i++) {
+                message.append(issueList[i] + "\n");
+            }
+            message.append("\nPlease correct and restart");
+            System.err.println(message);
+            System.exit(1);
+        }
+
+        // Listen for check outs
+        contest.addRunListener(new AJRunListener());
+
+        if (isAutoJudgingEnabled()) {
+            // TODO 496 send AVAILABLE_TO_AUTO_JUDGE to server
+            info("Sending AVAILABLE_TO_AUTO_JUDGE to server.");
+            controller.sendAvailableToAutoJudge(contest.getClientId());
+        }
+
+    }
+
+    protected String getL10nDateTime() {
+        DateFormat dateFormatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.getDefault());
+        return (dateFormatter.format(new Date()));
+    }
+
+    public Log getLog() {
+        return log;
+    }
+
+    /**
+     * Is Auto Judging turned On for this judge ?
+     * 
+     * @return
+     */
+    private boolean isAutoJudgingEnabled() {
+        return JudgementUtilites.judgeAutoJudgeEnabled(getContest(), getContest().getClientId());
+    }
+
+    public IInternalContest getContest() {
+        return contest;
+    }
+
+    public IInternalController getController() {
+        return controller;
+    }
+
+    public class AJRunListener implements IRunListener {
+
+        private boolean usingGui = false;
+
+        @Override
+        public void runAdded(RunEvent event) {
+            ; // ignore, run added handled by server
+
+        }
+
+        @Override
+        public void runChanged(RunEvent event) {
+
+            System.out.println("debug 22 runChanged " + event.getAction().toString());
+
+            Run run = event.getRun();
+            RunFiles runFiles = event.getRunFiles();
+            System.out.println("debug 22 run = " + run);
+            System.out.println("debug 22 runfiles ? " + (runFiles != null));
+            System.out.println("debug 22 Sent to " + event.getSentToClientId());
+
+            if (event.getSentToClientId().equals(contest.getClientId())) {
+                // run is for us.
+
+                if (!runJudger.isJudging()) {
+                    try {
+                        runJudger.executeAndAutoJudgeRun(run, runFiles);
+                    } catch (Exception e) {
+                        warn("Problem trying to judge run " + run, e);
+                    }
+                } else {
+                    // TODO 496 How to handle when we get a new run when already judging run
+                    warn("Warning got run " + run + " but already judging " + runJudger.getRunBeingJudged());
+                }
+
+            }
+
+        }
+
+        @Override
+        public void runRemoved(RunEvent event) {
+            ; // ignore
+
+        }
+
+        @Override
+        public void refreshRuns(RunEvent event) {
+            ; // ignore
+
+        }
+
+        public void info(String s) {
+            controller.getLog().info(s);
+            if (!usingGui) {
+                System.out.println(s);
+            }
+
+        }
+
+        public void warn(String s) {
+            controller.getLog().warning(s);
+            if (!usingGui) {
+                System.err.println(s);
+            }
+
+        }
+
+        public void warn(String s, Exception exception) {
+            controller.getLog().log(Log.WARNING, s, exception);
+            System.err.println(Thread.currentThread().getName() + " " + s);
+            System.err.flush();
+            exception.printStackTrace(System.err);
+        }
+
+    }
+
+    public void info(String s) {
+        controller.getLog().info(s);
+        System.out.println(s);
+    }
+}

--- a/src/edu/csus/ecs/pc2/ui/server/ServerView.java
+++ b/src/edu/csus/ecs/pc2/ui/server/ServerView.java
@@ -1,11 +1,12 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui.server;
 
 import java.awt.BorderLayout;
+import java.awt.Dialog.ModalityType;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Frame;
-import java.awt.Dialog.ModalityType;
 import java.awt.event.KeyEvent;
 import java.util.Date;
 
@@ -41,6 +42,7 @@ import edu.csus.ecs.pc2.core.model.RunEvent;
 import edu.csus.ecs.pc2.core.model.SiteEvent;
 import edu.csus.ecs.pc2.core.report.ContestSummaryReports;
 import edu.csus.ecs.pc2.ui.AboutPane;
+import edu.csus.ecs.pc2.ui.AutoJudgeAvailablePane;
 import edu.csus.ecs.pc2.ui.ConnectionsTablePane;
 import edu.csus.ecs.pc2.ui.ContestTimesPane;
 import edu.csus.ecs.pc2.ui.EventFeedServerPane;
@@ -59,19 +61,13 @@ import edu.csus.ecs.pc2.ui.ProfilesPane;
 import edu.csus.ecs.pc2.ui.ReportPane;
 import edu.csus.ecs.pc2.ui.SitesPane;
 import edu.csus.ecs.pc2.ui.UIPlugin;
-import java.awt.Dimension;
 
 /**
  * GUI for Server.
  * 
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
-
-// $HeadURL$
 public class ServerView extends JFrame implements UIPlugin {
-
-    public static final String SVN_ID = "$Id$";
 
     private IInternalContest model = null;  //  @jve:decl-index=0:
 
@@ -482,6 +478,9 @@ public class ServerView extends JFrame implements UIPlugin {
 
         ServerListeners serverListeners = new ServerListeners();
         registerPlugin(serverListeners);
+        
+        AutoJudgeAvailablePane autoJudgeAvailablePane= new AutoJudgeAvailablePane();
+        addUIPlugin(getMainTabbedPane(), "Auto Judging", autoJudgeAvailablePane);
 
         ConnectionsTablePane connectionsPane = new ConnectionsTablePane();
         addUIPlugin(getMainTabbedPane(), "Connections", connectionsPane);

--- a/test/edu/csus/ecs/pc2/core/AutoJudgeListsManagerTest.java
+++ b/test/edu/csus/ecs/pc2/core/AutoJudgeListsManagerTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.csus.ecs.pc2.core.exception.RunUnavailableException;
+import edu.csus.ecs.pc2.core.list.AutoJudgeListsManager;
 import edu.csus.ecs.pc2.core.model.AvailableAJ;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientSettings;

--- a/test/edu/csus/ecs/pc2/core/list/AutoJudgeListsManagerTest.java
+++ b/test/edu/csus/ecs/pc2/core/list/AutoJudgeListsManagerTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.csus.ecs.pc2.core.exception.RunUnavailableException;
-import edu.csus.ecs.pc2.core.list.AutoJudgeListsManager;
 import edu.csus.ecs.pc2.core.model.AvailableAJ;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientSettings;

--- a/test/edu/csus/ecs/pc2/core/list/AvailableAJListTest.java
+++ b/test/edu/csus/ecs/pc2/core/list/AvailableAJListTest.java
@@ -1,0 +1,47 @@
+package edu.csus.ecs.pc2.core.list;
+
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientType.Type;
+import edu.csus.ecs.pc2.core.util.AbstractTestCase;
+
+/**
+ * Unit test.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ *
+ */
+public class AvailableAJListTest extends AbstractTestCase {
+    
+    /**
+     * Test Add/remove from list.
+     * @throws Exception
+     */
+    public void testAddRemove() throws Exception {
+        
+        AvailableAJList list = new AvailableAJList();
+        
+        ProblemList probList = new ProblemList();
+        
+        for (int i = 1; i < 22; i++) {
+            ClientId judgeClient = new ClientId(3, Type.JUDGE, i);
+            
+            AvailableAJ aj = new AvailableAJ(judgeClient, probList);
+            list.add(aj);
+        }
+
+        assertEquals("Expecting count in list", 21, list.size());
+        
+        for (int i = 1; i < 22; i++) {
+            
+            ClientId newjudgeClient = new ClientId(3, Type.JUDGE, i);
+            AvailableAJ newAJ = new AvailableAJ(newjudgeClient, probList);
+            list.remove(newAJ);
+        }
+        
+        assertEquals("Expecting count in list", 0, list.size());
+        
+    }
+    
+
+}

--- a/test/edu/csus/ecs/pc2/core/list/AvailableAJRunListTest.java
+++ b/test/edu/csus/ecs/pc2/core/list/AvailableAJRunListTest.java
@@ -1,0 +1,45 @@
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.list;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientType.Type;
+import edu.csus.ecs.pc2.core.model.Language;
+import edu.csus.ecs.pc2.core.model.Problem;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.util.AbstractTestCase;
+
+public class AvailableAJRunListTest extends AbstractTestCase {
+
+    public void testAddRemove() throws Exception {
+
+        AvailableAJRunList list = new AvailableAJRunList();
+
+        List<Run> runList = new ArrayList<Run>();
+
+        Problem problemA = new Problem("A");
+        Language language = new Language("APL");
+
+        for (int i = 1; i < 22; i++) {
+            ClientId submitter = new ClientId(3, Type.TEAM, i + 1);
+            Run run = new Run(submitter, language, problemA);
+            runList.add(run);
+            AvailableAJRun ajrun = new AvailableAJRun(run.getElementId(), 3400, problemA.getElementId());
+            list.add(ajrun);
+        }
+
+        assertEquals("Expecting count in list", 21, list.size());
+
+        for (Run run : runList) {
+            AvailableAJRun ajrun = new AvailableAJRun(run.getElementId(), 3400, problemA.getElementId());
+            list.remove(ajrun);
+        }
+
+        assertEquals("Expecting count in list", 0, list.size());
+
+    }
+
+}

--- a/test/edu/csus/ecs/pc2/core/log/NullController.java
+++ b/test/edu/csus/ecs/pc2/core/log/NullController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.log;
 
 import java.io.IOException;
@@ -43,10 +43,8 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * A controller that does nothing.
  *  
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
 
-// $HeadURL$
 public class NullController implements IInternalController{
 
 
@@ -668,5 +666,10 @@ public class NullController implements IInternalController{
     @Override
     public boolean isSuppressLoginsPaneDisplay() {
         return false;
+    }
+
+    @Override
+    public void sendAvailableToAutoJudge(ClientId judgeClientId) {
+        ;
     }
 }

--- a/test/edu/csus/ecs/pc2/core/report/ReportsTest.java
+++ b/test/edu/csus/ecs/pc2/core/report/ReportsTest.java
@@ -277,6 +277,7 @@ public class ReportsTest extends AbstractTestCase {
                 "Groups for Problems Report", //
                 "Problem Group Assignment", //
                 "Compare Primary with model Report", //
+                "Autojudge Lists", //
         };
 
         IReport [] reportList = Reports.getReports();

--- a/test/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePaneTest.java
+++ b/test/edu/csus/ecs/pc2/ui/AutoJudgeAvailablePaneTest.java
@@ -1,0 +1,152 @@
+package edu.csus.ecs.pc2.ui;
+
+import java.util.Vector;
+
+import edu.csus.ecs.pc2.core.list.ProblemList;
+import edu.csus.ecs.pc2.core.log.NullController;
+import edu.csus.ecs.pc2.core.log.StaticLog;
+import edu.csus.ecs.pc2.core.model.Account;
+import edu.csus.ecs.pc2.core.model.AvailableAJ;
+import edu.csus.ecs.pc2.core.model.AvailableAJRun;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientSettings;
+import edu.csus.ecs.pc2.core.model.ClientType.Type;
+import edu.csus.ecs.pc2.core.model.Filter;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Problem;
+import edu.csus.ecs.pc2.core.model.Run;
+import edu.csus.ecs.pc2.core.model.Run.RunStates;
+import edu.csus.ecs.pc2.core.model.SampleContest;
+import edu.csus.ecs.pc2.core.util.AbstractTestCase;
+
+/**
+ * Unit test.
+ * 
+ * @author laned
+ *
+ */
+public class AutoJudgeAvailablePaneTest extends AbstractTestCase {
+    /**
+     * Update account to auto judge all problems, update model with new settings.
+     * 
+     * @param contest
+     * @param account
+     * @return 
+     */
+    private static ClientSettings updateAsAutoJudge(IInternalContest contest, Account account) {
+
+        ClientSettings settings = contest.getClientSettings(account.getClientId());
+        if (settings == null) {
+            settings = new ClientSettings(account.getClientId());
+        }
+        settings.setAutoJudging(true);
+
+        // auto judge all problems
+        Filter autoJudgeFilter = new Filter();
+        Problem[] problems = contest.getProblems();
+        for (Problem problem : problems) {
+            autoJudgeFilter.addProblem(problem);
+        }
+        settings.setAutoJudgeFilter(autoJudgeFilter);
+        contest.updateClientSettings(settings);
+        return contest.getClientSettings(account.getClientId());
+    }
+
+    public static IInternalContest create16RunContest() throws Exception {
+
+        SampleContest sampleContest = new SampleContest();
+
+        String [] runsData = {
+
+                "1,1,A,1,No",  //20
+                "2,1,A,3,Yes",  //3 (first yes counts Minutes only)
+                "3,1,A,5,No",  //20
+                "4,1,A,7,Yes",  //20  
+                "5,1,A,9,No",  //20
+
+                "6,1,B,11,No",  //20  (all runs count)
+                "7,1,B,13,No",  //20  (all runs count)
+
+                "8,2,A,30,Yes",  //30
+
+                "9,2,B,35,No",  //20 (all runs count)
+                "10,2,B,40,No",  //20 (all runs count)
+                "11,2,B,45,No",  //20 (all runs count)
+                "12,2,B,50,No",  //20 (all runs count)
+                "13,2,B,55,No",  //20 (all runs count)
+
+                "14,2,A,30, ", // doesn't count, no after yes
+                "15,2,A,25, ", // doesn't count, no after yes
+
+                "16,2,A,330, ",  // doesn't count, yes after yes
+        };
+
+        IInternalContest contest = new SampleContest().createContest(1, 3, 12, 12, true);
+
+        for (String runInfoLine : runsData) {
+            sampleContest.addARun(contest, runInfoLine);      
+        }
+        return contest;
+
+    }
+
+
+    public static void main(String[] args) throws Exception {
+
+
+        try {
+            IInternalContest contest = create16RunContest();
+            //        IInternalController controller = sample.createController(contest, false, false);
+            NullController controller = new NullController("AutoJudgeAvailablePaneTest.log");
+            StaticLog.setLog(controller.getLog());
+
+            ClientId adminClient = contest.getAccounts(Type.ADMINISTRATOR).firstElement().getClientId();
+
+            // update all runs to QUEUED_FOR_COMPUTER_JUDGEMENT
+
+            Run[] runs = contest.getRuns();
+            for (Run run : runs) {
+                run.setStatus(RunStates.QUEUED_FOR_COMPUTER_JUDGEMENT);
+                contest.updateRun(run, adminClient);
+            }
+
+            // Update all judges to auto judget all
+
+            Vector<Account> judges = contest.getAccounts(Type.JUDGE);
+            for (Account account : judges) {
+                updateAsAutoJudge(contest, account);
+            }
+
+            AutoJudgeAvailablePane pane = new AutoJudgeAvailablePane();
+            pane.setContestAndController(contest, controller);
+
+            for (Run run : runs) {
+                AvailableAJRun availableAJRun = new AvailableAJRun(run.getElementId(), run.getElapsedMS(), run.getProblemId());
+                pane.updateRunRow(availableAJRun);
+            }
+            Problem[] problems = contest.getProblems();
+            ProblemList probList = new ProblemList();
+            for (Problem problem : problems) {
+                probList.add(problem);
+            }
+            
+            for (Account account : judges) {
+                AvailableAJ availableAJ = new AvailableAJ(account.getClientId(), probList);
+                pane.updateJudgeRow(availableAJ);
+            }
+
+            TestingFrame frame = new TestingFrame(pane);
+
+            //        JFrame frame = new JFrame();
+            //        frame.setContentPane(pane);
+            frame.setVisible(true);
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
Add methods to add/remove/fetch AJ lists to InternalContest Add methods to find AJ or Run in AJ Lists to InternalContest

Add support for Available AJ and Run Lists
Add methods to find Run or Judge  in class AutoJudgeListsManager
      public ClientId findAutoJudgeForRun(Run run)
      public Run findRunToAutoJudge(IInternalContest contest, ClientId)
judgeClientId)

Add AVAILABLE_TO_AUTO_JUDGE packet

Add AutojudgeListReport to list AJ lists.

### Description of what the PR does

Adds infrastructure classes.
Add Available AJ/Judge list
Add Available AJ/Judge list
Add "find" methods in AutoJudgeListsManager
      public ClientId findAutoJudgeForRun(Run run)
      public Run findRunToAutoJudge(IInternalContest contest, ClientId)
Add Add AVAILABLE_TO_AUTO_JUDGE packet
Add AutojudgeListReport to list AJ lists.

### Issue which the PR fixes

Partial #496

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Run unit tests.