### PR TITLE
i656: expand Admin clockLabel and clockPane to avoid truncation.

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
+++ b/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
@@ -577,11 +577,11 @@ public class AdministratorView extends JFrame implements UIPlugin, ChangeListene
         if (clockPane == null) {
             clockLabel = new JLabel();
             clockLabel.setText("STOPPED");
-            clockLabel.setPreferredSize(new Dimension(100, 24));
+            clockLabel.setPreferredSize(new Dimension(200, 24));
             clockLabel.setFont(new java.awt.Font("Dialog", java.awt.Font.BOLD, 18));
             clockPane = new JPanel();
             clockPane.setLayout(new BorderLayout());
-            clockPane.setPreferredSize(new java.awt.Dimension(85,34));
+            clockPane.setPreferredSize(new Dimension(220, 34));
             clockPane.add(clockLabel, BorderLayout.WEST);
         }
         return clockPane;


### PR DESCRIPTION
### Description of what the PR does
Expands the width of the AdministratorView `clockLabel` and `clockPane` fields to avoid truncation of large "future start time" values.

### Issue which the PR fixes
Fixes #656 

### Environment in which the PR was developed:
- Windows 10.1
- Eclipse Version: 2019-12 (4.14.0)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Start a server configured with a contest having a Scheduled Start time that is at least 10 days (but not more than 30 days) in the future
- Start an Admin.
- Examine the "Countdown to start of contest" field in the upper left corner of the Admin view.  Note that it displays `xx Days hh:mm:ss`, where `xx` is a two-digit number of days.  Note also that the entire countdown (that is, the days, hours, minutes, and seconds) is displayed (i.e. that it is not truncated.
