### PR TITLE
i660: Handle Cancel confirmation response properly - fixes issue #660

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/AutoJudgeSettingsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgeSettingsPane.java
@@ -286,31 +286,24 @@ public class AutoJudgeSettingsPane extends JPanePlugin {
     }
 
     protected void handleCancelButton() {
-
-        if (getAddButton().isEnabled() || getUpdateButton().isEnabled()) {
+        
+        boolean dismissSettings = true;
+        
+        if (getUpdateButton().isEnabled()) {
 
             // Something changed, are they sure ?
 
             int result = FrameUtilities.yesNoCancelDialog(getParentFrame(), "Auto Judge modified, save changes?", "Confirm Choice");
 
             if (result == JOptionPane.YES_OPTION) {
-                if (getAddButton().isEnabled()) {
-                    addClientSettings();
-                } else {
-                    updateClientSettings();
-                }
-                if (getParentFrame() != null) {
-                    getParentFrame().setVisible(false);
-                }
-            } else if (result == JOptionPane.NO_OPTION) {
-                if (getParentFrame() != null) {
-                    getParentFrame().setVisible(false);
-                }
+                updateClientSettings();
+            } else if(result != JOptionPane.NO_OPTION) {
+                // in the case of Cancel, do not dismiss settings
+                dismissSettings = false;
             }
-        } else {
-            if (getParentFrame() != null) {
-                getParentFrame().setVisible(false);
-            }
+        }
+        if (dismissSettings && getParentFrame() != null) {
+            getParentFrame().setVisible(false);
         }
     }
 


### PR DESCRIPTION
If you Cancel the edit of an Auto Judge, and respond Yes to save changes on the confirmation dialog, it will now save the changes. Remove dependency on the no longer used Add button which caused changes to be ignored on the cancel confirmation dialog.
Fixes #660 

### Description of what the PR does
Correctly handles responding "Yes" to the Cancel confirmation dialog by saving any changes.  Previously, changes were ignored and not saved.

### Issue which the PR fixes
#660 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Java 1.8

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) From an Administrator instance, set up Auto Judging on a problem from the Auto Judge tab.
2) Select an Auto Judge and press the Edit button.
3 Change the state of the "Enable Auto Judging" check box (check it if it is unchecked, uncheck it if it is checked).
4) Select the Cancel button.
5) A dialog will appear asking you to either save the changes (Yes), ignore the changes (No), or Cancel the cancel request and
go back to editting.
6) Choose "Yes".
7) Observe that the state of "Enable Auto Judging" has changed on the Auto Judge tab.
8) Repeat steps 2-5 and choose "No" - observe that the change to the "Enable Auto Judging" check box is not saved.
9) Repeat steps 2-5 and choose "Cancel" and observe you are returned to the Edit dialog to make more changes.
