### PR TITLE
i626: remove load-data-files json key from problem yaml files

### DIFF
--- a/src/edu/csus/ecs/pc2/core/export/ExportYAML.java
+++ b/src/edu/csus/ecs/pc2/core/export/ExportYAML.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.export;
 
 import java.io.File;
@@ -439,8 +439,6 @@ public class ExportYAML {
                 writer.println(PAD4 + "rgb: "+ quote(colorRGB));
             }
 
-            writer.println(PAD4 + IContestLoader.PROBLEM_LOAD_DATA_FILES_KEY + ": " + (!problem.isUsingExternalDataFiles()));
-
             String[] filesWritten = writeProblemYAML(contest, directoryName, problem, shortName);
 
             if (filesWritten.length > 0) {
@@ -597,7 +595,6 @@ public class ExportYAML {
         problemWriter.println(IContestLoader.SHOW_OUTPUT_WINDOW+": "+!problem.isHideOutputWindow());
         problemWriter.println(IContestLoader.SHOW_COMPARE_WINDOW+": " + problem.isShowCompareWindow());
         problemWriter.println(IContestLoader.SHOW_VALIDATION_RESULTS+": "+problem.isShowValidationToJudges());
-        problemWriter.println(IContestLoader.PROBLEM_LOAD_DATA_FILES_KEY + ": " + (!isExternalFiles(problemDataFiles)));
         problemWriter.println(IContestLoader.STOP_ON_FIRST_FAILED_TEST_CASE_KEY + ": " + problem.isStopOnFirstFailedTestCase());
         
         problemWriter.println();

--- a/testdata/ExportYAMLTest/problemset.yaml
+++ b/testdata/ExportYAMLTest/problemset.yaml
@@ -6,7 +6,6 @@ problems:
     short-name: sumit
     name: 'Sumit'
     color: Alice Blue
-    load-data-files: true
 #     2 data files written
 #     wrote ./testout/ExportYAMLTest/testOne/sumit/data/secret/sumit.dat
 #     wrote ./testout/ExportYAMLTest/testOne/sumit/data/secret/sumit.ans
@@ -15,7 +14,6 @@ problems:
     short-name: quadrangles
     name: 'Quadrangles'
     color: Antique White
-    load-data-files: true
 #     2 data files written
 #     wrote ./testout/ExportYAMLTest/testOne/quadrangles/data/secret/quads.in
 #     wrote ./testout/ExportYAMLTest/testOne/quadrangles/data/secret/quads.ans
@@ -24,19 +22,16 @@ problems:
     short-name: routing
     name: 'Routing'
     color: Aqua
-    load-data-files: true
 
   - letter: D
     short-name: faulty
     name: 'Faulty Towers'
     color: Aquamarine
-    load-data-files: true
 
   - letter: E
     short-name: london
     name: 'London Bridge'
     color: Azure
-    load-data-files: true
 #     2 data files written
 #     wrote ./testout/ExportYAMLTest/testOne/london/data/secret/london.dat
 #     wrote ./testout/ExportYAMLTest/testOne/london/data/secret/london.ans
@@ -45,5 +40,4 @@ problems:
     short-name: finnigans
     name: 'Finnigans Bluff'
     color: Beige
-    load-data-files: true
 


### PR DESCRIPTION
### Description of what the PR does

remove load-data-files key/line from export to problem.yaml
remove load-data-files key/line from export to problemset.yaml

keep load-data-files key/line in export to contest.yaml

### Issue which the PR fixes

Fixes 626 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)


start server, --load problemflagtest
start admin
export using Run Contest -> Export -> Export Yaml
Select Save

### Expected

There should be no load-data-files line 
in sumit/problem.yaml nor in problemset.yaml

### Actual

in sumit/problem.yaml
```
   load-data-files: true
```

in sumit/problemset.yaml
```
   load-data-files: true
```
