### PR TITLE
i695: adjust submissions event "files" href (add /contest)

### DIFF
--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -89,7 +89,7 @@ public class JSONTool {
         // TODO shadow add time and mime elements to submission
 //        element.put("mime","application/zip");
         
-        String pathValue = "/submissions/" + submission.getNumber() + "/files";
+        String pathValue = "/contest/submissions/" + submission.getNumber() + "/files";
         
         ObjectMapper mymapper = new ObjectMapper();
         ArrayNode arrayNode = mymapper.createArrayNode();


### PR DESCRIPTION
### Description of what the PR does
  Changes the hardcoded `href` entry in the `files` field of a `submissions` event from `/submissions` to `/contest/submissions` (one-line change).   This is necessary to provide an href that matches what the PC2 SubmissionsService is providing as an endpoint.

### Issue which the PR fixes
Fixes #695 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.1, Java 1.8_271

### Precise steps for _testing_ the PR
- Start a contest with multiple submissions.
- Start an Event Feed client.
- Start a CDS hitting the EF.
- Verify that the CDS can pull submissions (previously it was getting 404s on every submission files access request)
