### PR TITLE
I 698 always output submission before judgement event

### DIFF
--- a/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
@@ -401,6 +401,12 @@ public class EventFeedStreamer extends JSONUtilities implements Runnable, UIPlug
                     sendJSON(json + NL);
                 } else {
                     if (run.isJudged()) {
+                        if (account.isAllowed(Permission.Type.DISPLAY_ON_SCOREBOARD) && !run.isDeleted()) {
+
+                            String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), EventFeedOperation.CREATE, jsonTool.convertToJSON(run, servletRequest, null).toString());
+                            sendJSON(json + NL);
+                        }
+                        
                         String json = getJSONEvent(JUDGEMENT_KEY, getNextEventId(), EventFeedOperation.UPDATE, jsonTool.convertJudgementToJSON(run).toString());
                         sendJSON(json + NL);
                         // Now send out the runcases (test cases).  Get most recent ones for this run.

--- a/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.web;
 
 import java.io.ByteArrayOutputStream;
@@ -401,6 +401,15 @@ public class EventFeedStreamer extends JSONUtilities implements Runnable, UIPlug
                     sendJSON(json + NL);
                 } else {
                     if (run.isJudged()) {
+                        /**
+                         * Likely due to the async nature of run judgements sometimes judgement events
+                         * were not preceded by a submissions event.
+                         * 
+                         * A hypothesis is that the Aj is so fast that the judgment event is sent
+                         * before the actual submissions event.
+                         * 
+                         * Force a submissions event before every judgement event. (issue 698)
+                         */
                         if (account.isAllowed(Permission.Type.DISPLAY_ON_SCOREBOARD) && !run.isDeleted()) {
 
                             String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), EventFeedOperation.CREATE, jsonTool.convertToJSON(run, servletRequest, null).toString());


### PR DESCRIPTION
### Description of what the PR does

Unconditionally outputs a submissions event before every judgement event.

This PR was tested during the PacNW Regional contest using the CDS.

### Issue which the PR fixes

#698

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Test with a CDS.

Configure CDS
Configure pc2 server with computer judge Problem
submit runs until CDS  <to be described,  Tim D needs to be asked.)
