### PR TITLE
i700: change default to not load sample data sets

### DIFF
--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -410,7 +410,8 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             setCcsTestMode(contest, ccsTestMode);
         }
         
-        boolean loadSamples = fetchBooleanValue(content, LOAD_SAMPLE_JUDGES_DATA, true);
+        // TODO 701 change LOAD_SAMPLE_JUDGES_DATA, false); to , true);
+        boolean loadSamples = fetchBooleanValue(content, LOAD_SAMPLE_JUDGES_DATA, false);
         setLoadSampleJudgesData(contest, loadSamples);
         
         boolean stopOnFirstFail = fetchBooleanValue(content, STOP_ON_FIRST_FAILED_TEST_CASE_KEY, false);

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitesTest.java
@@ -426,14 +426,23 @@ public class JudgementUtilitesTest extends AbstractTestCase {
             addRunTestCase(contest, run, testCaseNum, acJudgement, judges[0].getClientId());
         }
         recs = JudgementUtilites.getLastTestCaseArray(contest, run);
-        assertEquals("Expected test cases ", 10, recs.length);
+        
+        // TODO 701 change from expected 7 files to 10 files
+//        assertEquals("Expected test cases ", 10, recs.length);
+        assertEquals("Expected test cases ", 7, recs.length);
         // Add second set of test cases - all WA
         for (int testCaseNum = 1; testCaseNum <= problem.getNumberTestCases(); testCaseNum++) {
             addRunTestCase(contest, run, testCaseNum, waJudgement, judges[0].getClientId());
         }
-        assertEquals("Expected total test cases ", 20, run.getRunTestCases().length);
+     // TODO 701 change from expected 14 files to 20 files
+//        assertEquals("Expected total test cases ", 20, run.getRunTestCases().length);
+        assertEquals("Expected total test cases ", 14, run.getRunTestCases().length);
         recs = JudgementUtilites.getLastTestCaseArray(contest, run);
-        assertEquals("Expected test cases ", 10, recs.length);
+        
+        // TODO 701 change from expected 7 files to 10 files
+//        assertEquals("Expected test cases ", 10, recs.length);
+        assertEquals("Expected test cases ", 7, recs.length);
+        
         // Test that all judgements are WA
         for (RunTestCase runTestCase : recs) {
             ElementId judgementId = runTestCase.getJudgementId();

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3815,7 +3815,9 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
 //            }
         }
 
-        assertEquals("In " + MINI_CONTEST_DIR + " expecting sample and secret data files", 10, totalTestCases);
+        // TODO 701 change from expected 7 files to 10 files
+//        assertEquals("In " + MINI_CONTEST_DIR + " expecting sample and secret data files", 10, totalTestCases);
+        assertEquals("In " + MINI_CONTEST_DIR + " expecting sample and secret data files", 7, totalTestCases);
 
     }
 }


### PR DESCRIPTION
Disable loading data/sample files.  Short term fix, long term fix is #701 

Added "TODO 701" todo items into source

### Description of what the PR does

The PR does not load data/sample/ test data sets into a Problem,
only files from secret/ are loaded.

### Issue which the PR fixes

#700


### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

--load mini
view problem is Problem tab

submit a run
judge a run (source from accepted/ dir)

**Expected behavior**:

There should be 7 data files (not 10)
sumit.in
sumit1.in
sumit2.in
sumit3.in
sumit4.in
sumit5.in
sumit6.in

run should be judged Yes.