### PR TITLE
I528 shadow unable to fetch submission files

### DIFF
--- a/src/edu/csus/ecs/pc2/core/StringUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/StringUtilities.java
@@ -296,4 +296,17 @@ public final class StringUtilities implements Serializable {
         return null;
     }
     
+    /**
+     * Removes the last character from the given String and returns the resulting String.
+     * If the given String is null or empty, returns null.
+     * 
+     * @param s the String whose last char is to be removed.
+     * @return a String identical to the input String except with the last character removed, or null.
+     */
+    public static String removeLastChar(String s) {
+        return (s == null || s.length() == 0) ? null : (s.substring(0, s.length()-1));
+    }
+    
+
+    
 }

--- a/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.core.model.IFileImpl;
 import edu.csus.ecs.pc2.shadow.AbstractRemoteConfigurationObject.REMOTE_CONFIGURATION_ELEMENT;
@@ -244,14 +245,30 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
      * {@link #getRemoteSubmissionFiles(URL)} with that URL, returning the result
      * of that method call.
      * 
+     * Note that if the "Primary CCS URL" ends with a "/" character then this method
+     * avoids adding a duplicate "/" when concatenating the "submissions" endpoint to the URL;
+     * see https://github.com/pc2ccs/pc2v9/issues/528.
+     * 
      * @param submissionID a String representation of the submission ID from the remote system
      * @return the result of calling {@link #getRemoteSubmissionFiles(URL)} with the constructed URL,
      *         or null if an exception is thrown during URL construction
      */
     @Override
     public List<IFile> getRemoteSubmissionFiles(String submissionID) {
+        
+        //define the CLICS endpoint for fetching the files associated with a submission
         String endpoint = "/submissions/" + submissionID + "/files";
-        String urlString = remoteURL.toString() + endpoint;
+        
+        //get the configured Primary CCS URL
+        String urlString = remoteURL.toString();
+        //ensure the URL doesn't end with "/" (because we're going to add a "/" as part of the "endpoint")
+        if (urlString.endsWith("/")){
+            urlString = StringUtilities.removeLastChar(urlString);
+        }
+        
+        //build the full URL to the submissions/files endpoint
+        urlString = urlString + endpoint;
+        
         URL url;
         try {
             url = new URL(urlString);


### PR DESCRIPTION
### Description of what the PR does

Ensures that the URL used by a PC2 Shadow to request a remote Primary CCS to send the files associated with a given submission does not contain an extraneous "/" character between the "Primary CCS URL" and the "submission endpoint name".  This is done by checking the Primary CCS URL (from the current "Contest Settings") and removing any trailing "/" character prior to appending the "submission endpoint name" (which has the form `/submissions/<id>/files`).

### Issue which the PR addresses

Fixes #528

NOTE:  Issue #528 contains very confusing/sketchy information in the "Steps to Reproduce the Issue" section; it has multiple statements marked "todo" which apparently never got done, and it's very vague as to what the actual conditions to reproduce the issue should be.  As a result, the actual issue was very hard (read: unable) to be reproduced based on the information given.  In particular, the Issue references accessing a "Primary CCS" contest running at [http://10.0.0.169/domjudge/api/v4/contests/2](http://10.0.0.169/domjudge/api/v4/contests/2//submissions/1/files), which is clearly some sort of local network contest which can't be replicated (at least, I don't know how).

Since the referenced contest was being run by DOMjudge, I requested (and was granted) access to an available DOMjudge contest running at `https://judge.gehack.nl/api/contests/bapc2022` and tested against that by adding a trailing "/" to the Primary CCS URL in the Admin Settings screen.  Unfortunately, the error listed in the Issue was not reproduced.

Discussions with Nicky brought up the fact that since the original issue was filed (August 2022), DOMjudge has made some updates to the library which they use to process URLs.  The current theory is that their new library handles the "//" sequence in a URL.  As noted in the original issue, Kattis also apparently handled a URL containing "//" correctly.  Therefore, it's possible that the issue which triggered Issue #528 is no longer either present nor is it testable (because there's no longer any remote CCS which can reproduce the problem.

In any case, the fix applied by this PR should not cause any issues (should be benign).  The PR was tested (against the above-mentioned DOMjudge contest, using login "pc2" and a password which won't be documented here but is available from the PR author) both _with_  and _without_ a trailing "/" on the Primary CCS URL; it worked either way.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 10.1, Java version 11.0.16.1 2022-08-18 LTS

### Precise steps for _testing_ the PR

#### Test 1
1. Start a PC2 server.  with bapc2022 CDP config
2. Start a PC2 admin 
  - Create 300 team accounts (because the DOMjudge contest has this many teams)
  - Change the "alias" of team 300 to "domjudge"  (because the DOMjudge contest will submit a bunch of "test" runs to this account)
  -  create 1 FEEDER account
  - Specify a "Primary CCS URL" of `https://judge.gehack.nl/api/contests/bapc2022/` (note the extra "/" at the end).
  - Check Enable CCS Test mode
  - Check Enable Shadow mode
 - Start Contest Clock
4. Start a PC2 Feeder client
5. On the Feeder client, start Shadowing
6. Wait a while until the Feeder pulls all the DOMjudge "test" runs and then starts fetching "real submissions"
7. On the Admin, verify that team submissions are received.  In particular, trying judging a submission and verify that the "submission files" were properly fetched.
8. Examine the FEEDER log; verify that the Exception which was documented in the original Issue:
```
220830 172111.227|INFO|RemoteEventFeedMonitorThread|log|Fetching files from remote system using id 1
220830 172111.246|WARNING|RemoteEventFeedMonitorThread|log|Exception processing event: {"id":"59","type":"submissions","op":"create","data":{"language_id":"cpp","time":"2022-08-30T16:28:01.626-04:00","contest_time":"14553:28:01.626","team_id":"4","problem_id":"3","id":"1","external_id":null,"entry_point":null,"files":[{"href":"contests/2/submissions/1/files","mime":"application/zip"}]},"time":"2022-08-30T16:28:01.680-04:00"}
|java.lang.RuntimeException: java.io.FileNotFoundException: http://10.0.0.169/domjudge/api/v4/contests/2//submissions/1/files
|    at edu.csus.ecs.pc2.shadow.RemoteContestAPIAdapter.getRemoteSubmissionFiles (RemoteContestAPIAdapter.java:281)
|    at edu.csus.ecs.pc2.shadow.RemoteContestAPIAdapter.getRemoteSubmissionFiles (RemoteContestAPIAdapter.java:250)
|    at edu.csus.ecs.pc2.shadow.RemoteEventFeedMonitor.run (RemoteEventFeedMonitor.java:369)
|    at java.lang.Thread.run (Thread.java:750)
```
is not present in the log.

#### Test 2
1. Repeat the above, except remove the trailing "/" from the Primary CCS URL string.
2. Verify that submission files are still properly received on the PC2 Server.
3. Verify that the FEEDER log does not contain exceptions when fetching submission files.