### PR TITLE
I 725 add version endpoint at root endpoint and api

### DIFF
--- a/src/edu/csus/ecs/pc2/api/IContest.java
+++ b/src/edu/csus/ecs/pc2/api/IContest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.api;
 
 import edu.csus.ecs.pc2.api.listener.IConfigurationUpdateListener;
@@ -13,10 +13,8 @@ import edu.csus.ecs.pc2.api.listener.IRunEventListener;
  * This documentation describes the current <I>draft</i> of the PC<sup>2</sup> API, which is subject to change.
  *  
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
 
-// $HeadURL$
 public interface IContest {
 
     /**
@@ -487,5 +485,12 @@ public interface IContest {
      * @return an IRun object describing the requested run
      */
     IRun getRun(int siteNumber, int runNumber);
+    
+    /**
+     * Provide version information for system.
+     * 
+     * @return an IVersionInfo object describing the system version information.
+     */
+    IVersionInfo getVersionInfo();
 
 }

--- a/src/edu/csus/ecs/pc2/api/IVersionInfo.java
+++ b/src/edu/csus/ecs/pc2/api/IVersionInfo.java
@@ -1,0 +1,36 @@
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.api;
+
+import edu.csus.ecs.pc2.VersionInfo;
+
+/**
+ * Provide version info.
+ * 
+ * @see VersionInfo
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ */
+public interface IVersionInfo {
+
+    String getContactEMail();
+
+    String getSystemName();
+
+    String getSystemVersionInfo();
+
+    String[] getSystemVersionInfoMultiLine();
+
+    String getOperatingSystemInformation();
+
+    String getPC2Version();
+
+    String getJavaVersion();
+
+    String getVersionDate();
+
+    String getVersionNumber();
+
+    String getBuildNumber();
+
+    String getSystemURL();
+
+}

--- a/src/edu/csus/ecs/pc2/api/implementation/Contest.java
+++ b/src/edu/csus/ecs/pc2/api/implementation/Contest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.api.implementation;
 
 import java.util.ArrayList;
@@ -23,6 +23,7 @@ import edu.csus.ecs.pc2.api.IRun;
 import edu.csus.ecs.pc2.api.ISite;
 import edu.csus.ecs.pc2.api.IStanding;
 import edu.csus.ecs.pc2.api.ITeam;
+import edu.csus.ecs.pc2.api.IVersionInfo;
 import edu.csus.ecs.pc2.api.RunStates;
 import edu.csus.ecs.pc2.api.listener.IConfigurationUpdateListener;
 import edu.csus.ecs.pc2.api.listener.IConnectionEventListener;
@@ -49,8 +50,6 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
-
-// $HeadURL$
 public class Contest implements IContest, UIPlugin {
 
     /**
@@ -77,6 +76,8 @@ public class Contest implements IContest, UIPlugin {
     private GenerateStandings generateStandings = new GenerateStandings();
     
     private Log log = null;
+    
+    private VersionInfoImplementation versionInfoImplementation = null;
 
     public Contest(IInternalContest contest, IInternalController controller, Log log) {
         this.log = log;
@@ -501,5 +502,12 @@ public class Contest implements IContest, UIPlugin {
     public IInternalContest getInternalContest() {
         return contest ;
     }
-    
+
+    @Override
+    public IVersionInfo getVersionInfo() {
+        if (versionInfoImplementation == null) {
+            versionInfoImplementation = new VersionInfoImplementation();
+        }
+        return versionInfoImplementation;
+    }
 }

--- a/src/edu/csus/ecs/pc2/api/implementation/VersionInfoImplementation.java
+++ b/src/edu/csus/ecs/pc2/api/implementation/VersionInfoImplementation.java
@@ -1,0 +1,102 @@
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.api.implementation;
+
+import javax.json.bind.annotation.JsonbProperty;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.api.IVersionInfo;
+import edu.csus.ecs.pc2.services.core.JSONUtilities;
+
+/**
+ * Implementation for IVersionInfo
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ */
+public class VersionInfoImplementation implements IVersionInfo {
+
+    //    public RunImplementation(Run inRun, IInternalContest internalContest, IInternalController controller) {
+
+    @JsonbProperty
+    private VersionInfo versionInfo = new VersionInfo();
+
+    public VersionInfoImplementation(VersionInfo versionInfo) {
+        this.versionInfo = versionInfo;
+    }
+
+    public VersionInfoImplementation() {
+        // no code neeeded
+    }
+
+    @Override
+    public String getContactEMail() {
+        return versionInfo.getContactEMail();
+    }
+
+    @Override
+    public String getSystemName() {
+        return versionInfo.getSystemName();
+    }
+
+    @Override
+    public String getSystemVersionInfo() {
+        return versionInfo.getSystemVersionInfo();
+    }
+
+    @Override
+    public String[] getSystemVersionInfoMultiLine() {
+        return versionInfo.getSystemVersionInfoMultiLine();
+    }
+
+    @Override
+    public String getOperatingSystemInformation() {
+        return versionInfo.getOperatingSystemInformation();
+    }
+
+    @Override
+    public String getPC2Version() {
+        return versionInfo.getPC2Version();
+    }
+
+    @Override
+    public String getJavaVersion() {
+        return versionInfo.getJavaVersion();
+    }
+
+    @Override
+    public String getVersionDate() {
+        return versionInfo.getVersionDate();
+    }
+
+    @Override
+    public String getVersionNumber() {
+        return versionInfo.getVersionNumber();
+    }
+
+    @Override
+    public String getBuildNumber() {
+        return versionInfo.getBuildNumber();
+    }
+
+    @Override
+    public String getSystemURL() {
+        return versionInfo.getSystemURL();
+    }
+    
+    public String toJSON()  {
+        try {
+            ObjectMapper mapper = JSONUtilities.getObjectMapper();
+            return mapper.writeValueAsString(this);
+        } catch (Exception e) {
+            return "Error creating JSON for version info "+e.getMessage();
+        }
+
+    }
+    
+    @Override
+    public String toString() {
+        return toJSON();
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/util/CLICSVerionInfo.java
+++ b/src/edu/csus/ecs/pc2/core/util/CLICSVerionInfo.java
@@ -1,0 +1,60 @@
+package edu.csus.ecs.pc2.core.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.services.core.JSONUtilities;
+
+/**
+ * CLICS Version Info.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ *
+ */
+public class CLICSVerionInfo {
+
+    public CLICSVerionInfo(VersionInfo versionInfo) {
+        version = versionInfo.getPC2Version() + " build " + versionInfo.getBuildNumber();
+        version_url = "https://ccs-specs.icpc.io/2022-07/contest_api";
+    }
+
+    @JsonProperty
+    private String version;
+
+    @JsonProperty
+    private String version_url;
+
+    @JsonProperty
+    private String name;
+
+    // TODO Add logo when we have olne to supply
+    //    @JsonProperty
+    //    private String logo;
+
+    //{
+    //   "version": "2022-07",
+    //   "version_url": "https://ccs-specs.icpc.io/2022-07/contest_api",
+    //   "name": "Kattis",
+    //   "logo": [{
+    //      "href": "/api/logo",
+    //      "hash": "36dcf7975b179447783cdfc857ce9ae0",
+    //      "filename": "logo.png",
+    //      "mime": "image/png",
+    //      "width": 600,
+    //      "height": 600
+    //   }]
+    //}
+
+    public String toJSON() {
+
+        try {
+            ObjectMapper mapper = JSONUtilities.getObjectMapper();
+            return mapper.writeValueAsString(this);
+        } catch (Exception e) {
+            return "Error creating JSON for version info " + e.getMessage();
+        }
+
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/util/CLICSVerionInfo.java
+++ b/src/edu/csus/ecs/pc2/core/util/CLICSVerionInfo.java
@@ -1,3 +1,4 @@
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,10 +15,13 @@ import edu.csus.ecs.pc2.services.core.JSONUtilities;
  */
 public class CLICSVerionInfo {
 
-    public CLICSVerionInfo(VersionInfo versionInfo) {
-        version = versionInfo.getPC2Version() + " build " + versionInfo.getBuildNumber();
-        version_url = "https://ccs-specs.icpc.io/2022-07/contest_api";
-    }
+    /**
+     * The CLICS version number.
+     */
+    public  static final String CLICS_VERSION_NUMBER = "2022-07";
+
+    @JsonProperty
+    private String ccs_version;
 
     @JsonProperty
     private String version;
@@ -27,6 +31,13 @@ public class CLICSVerionInfo {
 
     @JsonProperty
     private String name;
+    
+    public CLICSVerionInfo(VersionInfo versionInfo) {
+        version = CLICS_VERSION_NUMBER;
+        version_url = "https://ccs-specs.icpc.io/2022-07/contest_api";
+        ccs_version = versionInfo.getPC2Version() + " build " + versionInfo.getBuildNumber(); 
+        name = "pc2";
+    }
 
     // TODO Add logo when we have olne to supply
     //    @JsonProperty
@@ -54,7 +65,5 @@ public class CLICSVerionInfo {
         } catch (Exception e) {
             return "Error creating JSON for version info " + e.getMessage();
         }
-
     }
-
 }

--- a/src/edu/csus/ecs/pc2/services/core/JSONUtilities.java
+++ b/src/edu/csus/ecs/pc2/services/core/JSONUtilities.java
@@ -7,7 +7,10 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.Utilities;
@@ -51,6 +54,8 @@ public class JSONUtilities {
     public static final String AWARD_KEY = "awards";
     
     public static final String ORGANIZATION_KEY = "organizations";
+    
+    public static ObjectMapper mapper = null;
 
     /**
      * ISO 8601 Date format for SimpleDateFormat.
@@ -367,5 +372,36 @@ public class JSONUtilities {
             return null;
         }
     }
-    
+
+    /**
+     * Get an object mapper.
+     * 
+     * SerializationFeature.WRAP_ROOT_VALUE is false which means that the classname will
+     * not preceed the rest of the object values.
+     * 
+     * @return oibject mapper with no FAIL_ON_UNKNOWN_PROPERTIES and no WRAP_ROOT_VALUE
+     */
+    public final static ObjectMapper getObjectMapper() {
+        if (mapper == null) {
+            mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+            mapper.disableDefaultTyping();
+
+        }
+        return mapper;
+    }
+
+    /**
+     * Pretty print json object.
+     * 
+     * @param JSONObject
+     * @return formatted listing for input json object.
+     * @throws JsonProcessingException
+     */
+    public static String prettyPrint(Object JSONObject) throws JsonProcessingException {
+        String json = getObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(JSONObject);
+        return json;
+    }
+
 }

--- a/src/edu/csus/ecs/pc2/services/eventFeed/WebServer.java
+++ b/src/edu/csus/ecs/pc2/services/eventFeed/WebServer.java
@@ -64,6 +64,7 @@ import edu.csus.ecs.pc2.services.web.StarttimeService;
 import edu.csus.ecs.pc2.services.web.StateService;
 import edu.csus.ecs.pc2.services.web.SubmissionService;
 import edu.csus.ecs.pc2.services.web.TeamService;
+import edu.csus.ecs.pc2.services.web.VersionService;
 import edu.csus.ecs.pc2.ui.UIPlugin;
 
 /**
@@ -179,6 +180,8 @@ public class WebServer implements UIPlugin {
 
         try {
             int port = getIntegerProperty(PORT_NUMBER_KEY, DEFAULT_WEB_SERVER_PORT_NUMBER);
+            
+            showMessage("Binding to port "+port);
 
             File keystoreFile = new File(PC2_KEYSTORE_FILE);
 
@@ -365,6 +368,9 @@ public class WebServer implements UIPlugin {
             showMessage("Starting /contest/event-feed web service");
             resConfig.register(new StateService(getContest(), getController()));
             showMessage("Starting /contest/state web service");
+            resConfig.register(new VersionService(getContest(), getController()));
+            showMessage("Starting /contest/version web service");
+            
         }
         
         return resConfig;

--- a/src/edu/csus/ecs/pc2/services/eventFeed/WebServer.java
+++ b/src/edu/csus/ecs/pc2/services/eventFeed/WebServer.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.eventFeed;
 
 import java.io.File;
@@ -73,7 +73,6 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
  * This server listens on the input port and when a connection is made it creates a service that for each contest event will do REST web services.
  * 
  * @author pc2@ecs.csus.edu
- * @version $Id$
  */
 public class WebServer implements UIPlugin {
 
@@ -369,7 +368,7 @@ public class WebServer implements UIPlugin {
             resConfig.register(new StateService(getContest(), getController()));
             showMessage("Starting /contest/state web service");
             resConfig.register(new VersionService(getContest(), getController()));
-            showMessage("Starting /contest/version web service");
+            showMessage("Starting /version web service");
             
         }
         

--- a/src/edu/csus/ecs/pc2/services/eventFeed/WebServer.java
+++ b/src/edu/csus/ecs/pc2/services/eventFeed/WebServer.java
@@ -368,7 +368,7 @@ public class WebServer implements UIPlugin {
             resConfig.register(new StateService(getContest(), getController()));
             showMessage("Starting /contest/state web service");
             resConfig.register(new VersionService(getContest(), getController()));
-            showMessage("Starting /version web service");
+            showMessage("Starting / endpoint for version web service");
             
         }
         

--- a/src/edu/csus/ecs/pc2/services/web/VersionService.java
+++ b/src/edu/csus/ecs/pc2/services/web/VersionService.java
@@ -22,14 +22,16 @@ import edu.csus.ecs.pc2.core.util.CLICSVerionInfo;
  * @author pc2@ecs.csus.edu
  *
  */
-@Path("/contest/version")
+@Path("/version")
 @Produces(MediaType.APPLICATION_JSON)
 @Provider
 @Singleton
 public class VersionService implements Feature {
 
+    @SuppressWarnings("unused")
     private IInternalContest model;
 
+    @SuppressWarnings("unused")
     private IInternalController controller;
 
     private CLICSVerionInfo clicsVerionInfo = new CLICSVerionInfo(new VersionInfo());

--- a/src/edu/csus/ecs/pc2/services/web/VersionService.java
+++ b/src/edu/csus/ecs/pc2/services/web/VersionService.java
@@ -1,0 +1,59 @@
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.services.web;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.util.CLICSVerionInfo;
+
+/**
+ * Web Service to handle "version" REST endpoint as described by the CLICS wiki.
+ * 
+ * @author pc2@ecs.csus.edu
+ *
+ */
+@Path("/contest/version")
+@Produces(MediaType.APPLICATION_JSON)
+@Provider
+@Singleton
+public class VersionService implements Feature {
+
+    private IInternalContest model;
+
+    private IInternalController controller;
+
+    private CLICSVerionInfo clicsVerionInfo = new CLICSVerionInfo(new VersionInfo());
+
+    public VersionService(IInternalContest inModel, IInternalController inController) {
+        super();
+        this.model = inModel;
+        this.controller = inController;
+    }
+
+    /**
+     * This method returns a representation of the current contest version in JSON format as described on the CLICS wiki.
+     * 
+     * @return a {@link Response} object containing a JSON String 
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getVersion() {
+        String versionJson = clicsVerionInfo.toJSON();
+        return Response.ok(versionJson, MediaType.APPLICATION_JSON).build();
+    }
+
+    @Override
+    public boolean configure(FeatureContext arg0) {
+        return false;
+    }
+}

--- a/src/edu/csus/ecs/pc2/services/web/VersionService.java
+++ b/src/edu/csus/ecs/pc2/services/web/VersionService.java
@@ -22,7 +22,7 @@ import edu.csus.ecs.pc2.core.util.CLICSVerionInfo;
  * @author pc2@ecs.csus.edu
  *
  */
-@Path("/version")
+@Path("/")
 @Produces(MediaType.APPLICATION_JSON)
 @Provider
 @Singleton

--- a/test/edu/csus/ecs/pc2/api/implementation/ContestTest.java
+++ b/test/edu/csus/ecs/pc2/api/implementation/ContestTest.java
@@ -14,9 +14,11 @@ import edu.csus.ecs.pc2.api.IProblemDetails;
 import edu.csus.ecs.pc2.api.IRun;
 import edu.csus.ecs.pc2.api.IStanding;
 import edu.csus.ecs.pc2.api.ITeam;
+import edu.csus.ecs.pc2.api.IVersionInfo;
 import edu.csus.ecs.pc2.api.RunStates;
 import edu.csus.ecs.pc2.api.ServerConnection;
 import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.NullController;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.Clarification;
@@ -675,6 +677,36 @@ public class ContestTest extends AbstractTestCase {
             println("Problem name = " + problem.getDisplayName() + " ele = " + problem.getElementId()+" newstr '"+stripped+"'");
         }
         
+    }
+    
+    /**
+     * Test IVersionInfo.
+     * 
+     * @throws Exception
+     */
+    public void testGetIVersionInfo() throws Exception {
+
+        IInternalContest internal = sampleContest.createContest(1, 3, 170, 12, true);
+        assertNotNull(internal);
+
+        IInternalController controller = new NullController();
+        Log log = createLog(getName());
+
+        Account team151 = internal.getAccount(new ClientId(1, Type.TEAM, 151));
+        assertNotNull(team151);
+        internal.setClientId(team151.getClientId());
+
+        Contest contest = new Contest(internal, controller, log);
+
+        IVersionInfo verinfo = contest.getVersionInfo();
+        assertNotNull(verinfo);
+
+        assertEquals("expected getContactEMail ", "mailto:pc2@ecs.csus.edu", verinfo.getContactEMail());
+        assertEquals("expected getSystemName ", "CSUS Programming Contest Control System", verinfo.getSystemName());
+        assertEquals("expected getSystemURL ", "http://pc2.ecs.csus.edu/", verinfo.getSystemURL());
+
+        //        System.out.println("debug  "+JSONUtilities.prettyPrint(verinfo));
+        //        System.out.println("debug " + version info = "+verinfo);
     }
         
 }


### PR DESCRIPTION
### Description of what the PR does

Adds /version end point

### Issue which the PR addresses

#725 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Start server --load tenprobs
Start feeder 1, login ef1
Click Start  on WEb Services tab

Fetch the version JSON, expected similar to:
{"ccs_version":"9.9build 20230403 (Monday, April 3rd 2023 18:10 UTC) build 6402","version":"2022-07","version_url":"https://ccs-specs.icpc.io/2022-07/contest_api","name":"pc2"}

The version information should match the version information in the About tab

curl -u admin:admin --insecure https://localhost:50443/
{"ccs_version":"9.9build 20230403 (Monday, April 3rd 2023 18:10 UTC) build 6402","version":"2022-07","version_url":"https://ccs-specs.icpc.io/2022-07/contest_api","name":"pc2"}

Via browser https://localhost:50443/
admin / admin, and see it display
{"version":"9.9build 20230403 (Monday, April 3rd 2023 18:10 UTC) build 6402","version_url":"https://ccs-specs.icpc.io/2022-07/contest_api","name":null}