### PR TITLE
I46 add entry point support, fixes #46

### DIFF
--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -109,11 +109,11 @@ public final class Constants {
      * This can be used for languages (such as Kotlin), that has a different main class name than the basename of
      * the source.  eg.  MyClass.kt  uses MyClassKt as the main class name.  This is conditional in that if the
      * trailing string (suffix) isn't already immediately to the left of the operand of this substitution variable, then it gets added.
-     * eg. {:basename}{:ifsuffix=Kt}  if {:basename} is MyClassKt then, the {:ifsuffix=Kt} is a no-op (empty string).  If
-     * {:basename} is MyClass then the {:ifsuffix=Kt} evaluates to "Kt" making the result: MyClassKt.
+     * eg. {:basename}{:ensuresuffix=Kt}  if {:basename} is MyClassKt then, the {:ensuresuffix=Kt} is a no-op (empty string).  If
+     * {:basename} is MyClass then the {:ensuresuffix=Kt} evaluates to "Kt" making the result: MyClassKt.
      * Use of this is not just restricted to executables or basename; it can be used anywhere in the string.
      */
-    public static final String CMDSUB_COND_SUFFIX = "{:ifsuffix=}";
+    public static final String CMDSUB_COND_SUFFIX = "{:ensuresuffix=}";
     
     /**
      * Default file name for judgement ini file.

--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -100,6 +100,22 @@ public final class Constants {
     
     
     /**
+     * Command substitution variable for name of thing to execute (basename of source file)
+     */
+    public static final String CMDSUB_BASENAME_VARNAME = "{:basename}";
+    
+    /**
+     * Command substitution variable for conditional suffix
+     * This can be used for languages (such as Kotlin), that has a different main class name than the basename of
+     * the source.  eg.  MyClass.kt  uses MyClassKt as the main class name.  This is conditional in that if the
+     * trailing string (suffix) isn't already immediately to the left of the operand of this substitution variable, then it gets added.
+     * eg. {:basename}{:ifsuffix=Kt}  if {:basename} is MyClassKt then, the {:ifsuffix=Kt} is a no-op (empty string).  If
+     * {:basename} is MyClass then the {:ifsuffix=Kt} evaluates to "Kt" making the result: MyClassKt.
+     * Use of this is not just restricted to executables or basename; it can be used anywhere in the string.
+     */
+    public static final String CMDSUB_COND_SUFFIX = "{:ifsuffix=}";
+    
+    /**
      * Default file name for judgement ini file.
      */
     public static final String JUDGEMENT_INIT_FILENAME = "reject.ini";

--- a/src/edu/csus/ecs/pc2/core/IInternalController.java
+++ b/src/edu/csus/ecs/pc2/core/IInternalController.java
@@ -761,4 +761,17 @@ public interface IInternalController {
      */
     void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId);
 
+    /**
+     * Submit a run to the server for a different client with entry_point
+     * 
+     * @param submitter - override submitter, if used the logged in client must have  Permission.Type.SHADOW_PROXY_TEAM selected.
+     * @param problem
+     * @param language
+     * @param entry_point Java/Kotlin main class entry point
+     * @param mainSubmissionFile
+     * @param additionalFiles
+     * @param overrideTimeMS
+     * @param overrideRunId
+     */
+    void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId);
 }

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -4657,11 +4657,18 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
     @Override
     public void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
         
+        submitRun(submitter, problem, language, null, mainSubmissionFile, additionalFiles, overrideTimeMS, overrideRunId);
+    }
+
+    @Override
+    public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideSubmissionId) {
+        
         ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
         Run run = new Run(submitter, language, problem);
+        run.setEntryPoint(entry_point);
         RunFiles runFiles = new RunFiles(run, mainSubmissionFile, additionalFiles);
 
-        Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideRunId);
+        Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideSubmissionId);
         sendToLocalServer(packet);
         
     }

--- a/src/edu/csus/ecs/pc2/core/MockController.java
+++ b/src/edu/csus/ecs/pc2/core/MockController.java
@@ -582,6 +582,25 @@ public class MockController implements IInternalController {
         
     }
 
+    @Override
+    public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
+        System.out.println("submitRun "+submitter+" "+problem+" "+language+" " +mainSubmissionFile.getName()+" aux file count "+additionalFiles.length+" entry_point ="+entry_point+" time ="+overrideTimeMS+" run id ="+overrideRunId);
+        
+        ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
+        Run run = new Run(submitter, language, problem);
+        run.setEntryPoint(entry_point);
+        
+        try {
+        
+            RunFiles runFiles = new RunFiles(run, mainSubmissionFile, additionalFiles);
+            Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideRunId);
+            handler.handlePacket(packet, null);
+
+        } catch (Exception e) {
+            rethrow (e);
+        }
+    }
+
     private void rethrow(Exception e) {
         throw new RuntimeException(e);
     }

--- a/src/edu/csus/ecs/pc2/core/NullController.java
+++ b/src/edu/csus/ecs/pc2/core/NullController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.IOException;
@@ -540,6 +540,12 @@ public class NullController implements IInternalController {
 
     @Override
     public void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
         // TODO Auto-generated method stub
         
     }

--- a/src/edu/csus/ecs/pc2/core/NullController.java
+++ b/src/edu/csus/ecs/pc2/core/NullController.java
@@ -534,25 +534,21 @@ public class NullController implements IInternalController {
 
     @Override
     public IInternalContest getContest() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
-        // TODO Auto-generated method stub
         
     }
 
     @Override
     public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
-        // TODO Auto-generated method stub
         
     }
 
     @Override
     public void submitJudgeRun(Problem problem, Language language, SerializedFile mainFile, SerializedFile[] otherFiles, long overrideSubmissionTimeMS, long overrideRunId) throws Exception {
-        // TODO Auto-generated method stub
         
     }
 

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1818,7 +1818,7 @@ public class Executable extends Plugin implements IExecutable {
              * We only do this substition for execution of the run, not compiles or validators, so it can't
              * be done by substitutionAllStrings without refactoring.
              */
-            if (run.getEntryPoint() != null) {
+            if (!StringUtilities.isEmpty(run.getEntryPoint())) {
                 // change Constants.CMDSUB_BASENAME_VARNAME to entry_point rather than basename from {:mainfile} before
                 // other substitutions (overrides :mainfile)
                 cmdline = replaceString(cmdline, Constants.CMDSUB_BASENAME_VARNAME, run.getEntryPoint());
@@ -2193,7 +2193,7 @@ public class Executable extends Plugin implements IExecutable {
             String programName = language.getExecutableIdentifierMask();
             
             // the "executable" program name is the entry point, if one exists, so try to substitute that first
-            if (run.getEntryPoint() != null) {
+            if (!StringUtilities.isEmpty(run.getEntryPoint())) {
                 // change Constants.CMDSUB_BASENAME_VARNAME to entry_point rather than basename from {:mainfile} before
                 // other substitutions (overrides :mainfile)
                 programName = replaceString(programName, Constants.CMDSUB_BASENAME_VARNAME, run.getEntryPoint());

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1812,6 +1812,15 @@ public class Executable extends Plugin implements IExecutable {
             }
 
             log.log(Log.DEBUG, "before substitution: " + cmdline);
+
+            /**
+             * Special substitution for entry_point
+             */
+            if (run.getEntryPoint() != null) {
+                // change {:basename} to entry_point rather than basename from {:mainfile} before
+                // other substitutions (overrides :mainfile)
+                cmdline = replaceString(cmdline, "{:basename}", run.getEntryPoint());
+            }
             cmdline = substituteAllStrings(run, cmdline, dataSetNumber+1);
             log.log(Log.DEBUG, "after  substitution: " + cmdline);
 

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2438,72 +2438,6 @@ public class Executable extends Plugin implements IExecutable {
 
         return buf.toString();
     }
-
-    /**
-     * Perform conditional subtititions
-     * 
-     * @param origString
-     * @param condVar
-     * @return - possibly modified string
-     */
-    public String replaceStringConditional(String origString, String condVar) {
-        
-        int subStartIdx, endIdx, suffLen;
-        String suffString;
-        
-        if (origString == null || condVar == null) {
-            return origString;
-        }
-        // if substitute variable has an = sign, we try to match the substring up to and including the
-        // equals sign, eg: {:ifsuffix=Kt}, we want to match: {:ifsuffix=
-        int subIdx = condVar.indexOf('=');
-        
-        // Need at least two chars to left of =
-        if(subIdx < 2) {
-            return origString;
-        }
-        
-
-        // don't care about anything after the =
-        String subMatch = condVar.substring(0, subIdx+1);
-        
-        int startIdx = origString.lastIndexOf(subMatch);
-
-        if (startIdx == -1) {
-            return origString;
-        }
-
-        StringBuffer buf = new StringBuffer(origString);
-
-        while (startIdx != -1) {
-            subStartIdx = startIdx + subMatch.length();
-            endIdx = origString.indexOf('}', subStartIdx);
-            
-            // Missing closing } for substitute variable?
-            if(endIdx == -1) {
-                log.warning("Missing closing brace for conditional subtitution variable in " + origString);
-                break;
-            }
-            
-            // this is the string we may have to add, but first see if it's there already
-            suffString = origString.substring(subStartIdx, endIdx);
-            suffLen = suffString.length();
-            
-            // if there are not enough chars before the substitute var to compare, or, the trailing characters
-            // don't match, then we have to replace the substitute var with the new suffix string, otherwise, we
-            // we just delete the substitute var altogether
-            if(startIdx < suffLen || origString.substring(startIdx - suffLen, startIdx).compareTo(suffString) != 0) {
-                // suffix does not match, so we have to insert it
-                buf.replace(startIdx,  endIdx+1, suffString);
-            } else {
-                buf.delete(startIdx,  endIdx+1);
-            }
-            
-            startIdx = origString.lastIndexOf(subMatch, startIdx - 1);
-        }
-
-        return buf.toString();
-    }
     
     /**
      * Replace beforeString with int.
@@ -2678,7 +2612,7 @@ public class Executable extends Plugin implements IExecutable {
                 newString = replaceString(newString, "{:pc2home}", pc2home);
             }
             // Check for conditional suffix (that is, the previous chars match), if not, add them
-            newString = replaceStringConditional(newString, Constants.CMDSUB_COND_SUFFIX);
+            newString = ExecuteUtilities.replaceStringConditional(newString, Constants.CMDSUB_COND_SUFFIX);
             
         } catch (Exception e) {
             log.log(Log.CONFIG, "Exception substituting strings ", e);

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1814,12 +1814,14 @@ public class Executable extends Plugin implements IExecutable {
             log.log(Log.DEBUG, "before substitution: " + cmdline);
 
             /**
-             * Special substitution for entry_point
+             * Special substitution for entry_point.
+             * We only do this substition for execution of the run, not compiles or validators, so it can't
+             * be done by substitutionAllStrings without refactoring.
              */
             if (run.getEntryPoint() != null) {
-                // change {:basename} to entry_point rather than basename from {:mainfile} before
+                // change Constants.CMDSUB_BASENAME_VARNAME to entry_point rather than basename from {:mainfile} before
                 // other substitutions (overrides :mainfile)
-                cmdline = replaceString(cmdline, "{:basename}", run.getEntryPoint());
+                cmdline = replaceString(cmdline, Constants.CMDSUB_BASENAME_VARNAME, run.getEntryPoint());
             }
             cmdline = substituteAllStrings(run, cmdline, dataSetNumber+1);
             log.log(Log.DEBUG, "after  substitution: " + cmdline);
@@ -2424,6 +2426,72 @@ public class Executable extends Plugin implements IExecutable {
     }
 
     /**
+     * Perform conditional subtititions
+     * 
+     * @param origString
+     * @param condVar
+     * @return - possibly modified string
+     */
+    public String replaceStringConditional(String origString, String condVar) {
+        
+        int subStartIdx, endIdx, suffLen;
+        String suffString;
+        
+        if (origString == null || condVar == null) {
+            return origString;
+        }
+        // if substitute variable has an = sign, we try to match the substring up to and including the
+        // equals sign, eg: {:ifsuffix=Kt}, we want to match: {:ifsuffix=
+        int subIdx = condVar.indexOf('=');
+        
+        // Need at least two chars to left of =
+        if(subIdx < 2) {
+            return origString;
+        }
+        
+
+        // don't care about anything after the =
+        String subMatch = condVar.substring(0, subIdx+1);
+        
+        int startIdx = origString.lastIndexOf(subMatch);
+
+        if (startIdx == -1) {
+            return origString;
+        }
+
+        StringBuffer buf = new StringBuffer(origString);
+
+        while (startIdx != -1) {
+            subStartIdx = startIdx + subMatch.length();
+            endIdx = origString.indexOf('}', subStartIdx);
+            
+            // Missing closing } for substitute variable?
+            if(endIdx == -1) {
+                log.warning("Missing closing brace for conditional subtitution variable in " + origString);
+                break;
+            }
+            
+            // this is the string we may have to add, but first see if it's there already
+            suffString = origString.substring(subStartIdx, endIdx);
+            suffLen = suffString.length();
+            
+            // if there are not enough chars before the substitute var to compare, or, the trailing characters
+            // don't match, then we have to replace the substitute var with the new suffix string, otherwise, we
+            // we just delete the substitute var altogether
+            if(startIdx < suffLen || origString.substring(startIdx - suffLen, startIdx).compareTo(suffString) != 0) {
+                // suffix does not match, so we have to insert it
+                buf.replace(startIdx,  endIdx+1, suffString);
+            } else {
+                buf.delete(startIdx,  endIdx+1);
+            }
+            
+            startIdx = origString.lastIndexOf(subMatch, startIdx - 1);
+        }
+
+        return buf.toString();
+    }
+    
+    /**
      * Replace beforeString with int.
      * 
      * For details see {@link #replaceString(String, String, String)}
@@ -2463,6 +2531,7 @@ public class Executable extends Plugin implements IExecutable {
      *              {:outfile}
      *              {:ansfile}
      *              {:pc2home}
+     *              {:ifsuffix=...} - add supplied suffix if not present already
      * </pre>
      * 
      * @param dataSetNumber
@@ -2594,6 +2663,9 @@ public class Executable extends Plugin implements IExecutable {
             if (pc2home != null && pc2home.length() > 0) {
                 newString = replaceString(newString, "{:pc2home}", pc2home);
             }
+            // Check for conditional suffix (that is, the previous chars match), if not, add them
+            newString = replaceStringConditional(newString, Constants.CMDSUB_COND_SUFFIX);
+            
         } catch (Exception e) {
             log.log(Log.CONFIG, "Exception substituting strings ", e);
             // carrying on not required to save exception

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2189,13 +2189,27 @@ public class Executable extends Plugin implements IExecutable {
 
             packageName = "";
             packagePath = "";
-            String programName = replaceString(language.getExecutableIdentifierMask(), "{:basename}", removeExtension(runFiles.getMainFile().getName()));
+            
+            String programName = language.getExecutableIdentifierMask();
+            
+            // the "executable" program name is the entry point, if one exists, so try to substitute that first
+            if (run.getEntryPoint() != null) {
+                // change Constants.CMDSUB_BASENAME_VARNAME to entry_point rather than basename from {:mainfile} before
+                // other substitutions (overrides :mainfile)
+                programName = replaceString(programName, Constants.CMDSUB_BASENAME_VARNAME, run.getEntryPoint());
+            }
+
+            // This used to just replace the {:basename}, but there is no reason not to run it
+            // through the substituteAllStrings() especially since we now have conditional suffix
+            // substitution string.
+            programName = substituteAllStrings(run, programName);
+            
             if (runFiles.getMainFile().getName().endsWith("java")) {
                 packageName = searchForPackage(prefixExecuteDirname(runFiles.getMainFile().getName()));
                 packagePath = replaceString(packageName, ".", File.separator);
             }
 
-            // Check whether the team submitted a executable, if they did remove
+            // Check whether the team submitted an executable, if they did remove
             // it.
             File program = new File(prefixExecuteDirname(programName));
             if (program.exists()) {

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.BufferedInputStream;
@@ -2479,7 +2479,7 @@ public class Executable extends Plugin implements IExecutable {
      *              {:outfile}
      *              {:ansfile}
      *              {:pc2home}
-     *              {:ifsuffix=...} - add supplied suffix if not present already
+     *              {:ensuresuffix=...} - add supplied suffix if not present already
      * </pre>
      * 
      * @param dataSetNumber

--- a/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
@@ -360,6 +360,70 @@ public class ExecuteUtilities extends Plugin {
 
         return newString;
     }
+
+    /**
+     * Perform conditional substitutions
+     * 
+     * @param origString
+     * @param condVar
+     * @return - possibly modified string
+     */
+    public static String replaceStringConditional(String origString, String condVar) {
+        
+        int subStartIdx, endIdx, suffLen;
+        String suffString;
+        
+        if (origString == null || condVar == null) {
+            return origString;
+        }
+        // if substitute variable has an = sign, we try to match the substring up to and including the
+        // equals sign, eg: {:ifsuffix=Kt}, we want to match: {:ifsuffix=
+        int subIdx = condVar.indexOf('=');
+        
+        // Need at least two chars to left of =
+        if(subIdx < 2) {
+            return origString;
+        }       
+
+        // don't care about anything after the =
+        String subMatch = condVar.substring(0, subIdx+1);
+        
+        int startIdx = origString.lastIndexOf(subMatch);
+
+        if (startIdx == -1) {
+            return origString;
+        }
+
+        StringBuffer buf = new StringBuffer(origString);
+
+        while (startIdx != -1) {
+            subStartIdx = startIdx + subMatch.length();
+            endIdx = origString.indexOf('}', subStartIdx);
+            
+            // Missing closing } for substitute variable?
+            if(endIdx == -1) {
+                break;
+            }
+            
+            // this is the string we may have to add, but first see if it's there already
+            suffString = origString.substring(subStartIdx, endIdx);
+            suffLen = suffString.length();
+            
+            // if there are not enough chars before the substitute var to compare, or, the trailing characters
+            // don't match, then we have to replace the substitute var with the new suffix string, otherwise, we
+            // we just delete the substitute var altogether
+            if(startIdx < suffLen || origString.substring(startIdx - suffLen, startIdx).compareTo(suffString) != 0) {
+                // suffix does not match, so we have to insert it
+                buf.replace(startIdx,  endIdx+1, suffString);
+            } else {
+                buf.delete(startIdx,  endIdx+1);
+            }
+            
+            startIdx = origString.lastIndexOf(subMatch, startIdx - 1);
+        }
+
+        return buf.toString();
+    }
     
     public static String getPC2Home() {
         String pc2home = new VersionInfo().locateHome();

--- a/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
@@ -377,7 +377,7 @@ public class ExecuteUtilities extends Plugin {
             return origString;
         }
         // if substitute variable has an = sign, we try to match the substring up to and including the
-        // equals sign, eg: {:ifsuffix=Kt}, we want to match: {:ifsuffix=
+        // equals sign, eg: {:ensuresuffix=Kt}, we want to match: {:ensuresuffix=
         int subIdx = condVar.indexOf('=');
         
         // Need at least two chars to left of =

--- a/src/edu/csus/ecs/pc2/core/model/Run.java
+++ b/src/edu/csus/ecs/pc2/core/model/Run.java
@@ -469,9 +469,11 @@ public class Run extends Submission {
      * @param name
      */
     public void setEntryPoint(String name) {
-        name = Utilities.getFileBaseName(name);
-        if (name != null){
-            entryPoint = name.toCharArray();
+        if(name != null) {
+            name = Utilities.getFileBaseName(name);
+            if (name != null){
+                entryPoint = name.toCharArray();
+            }
         }
     }
     

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -484,11 +484,12 @@ public class RemoteEventFeedMonitor implements Runnable {
                                                 logAndDebugPrint(log, Level.INFO, "Invoking submitter.submitRun() for team " + runSubmission.getTeam_id() 
                                                     + " problem " + runSubmission.getProblem_id() 
                                                     + " language " +  runSubmission.getLanguage_id()
+                                                    + " entry_point " + runSubmission.getEntry_point()
                                                     + " time " + overrideTimeMS 
                                                     + " submissionID " + overrideSubmissionID);
                                                 try {
-                                                    submitter.submitRun(runSubmission.getTeam_id(), runSubmission.getProblem_id(), runSubmission.getLanguage_id(), mainFile, auxFiles,
-                                                            overrideTimeMS, overrideSubmissionID);
+                                                    submitter.submitRun(runSubmission.getTeam_id(), runSubmission.getProblem_id(), runSubmission.getLanguage_id(),
+                                                            runSubmission.getEntry_point(), mainFile, auxFiles, overrideTimeMS, overrideSubmissionID);
                                                 } catch (Exception e) {
                                                     // TODO design error handling reporting
                                                     logAndDebugPrint(log, Level.WARNING, "Exception submitting run for event: " + event, e);

--- a/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
@@ -52,6 +52,22 @@ public class RemoteRunSubmitter {
      * @param overrideRunId - override run id
      */
     public void submitRun(String clientIdString, String problemID, String languageID, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) {
+        submitRun(clientIdString, problemID, languageID, null, mainFile, auxFiles, overrideTimeMS, overrideRunId);
+    }
+    
+    /**
+     * Submit a run to the server.
+     * 
+     * @param clientIdString - "teamN" client name
+     * @param problemID - problem id
+     * @param languageID - CLICS language id
+     * @param entry_point - java/kotlin entry point, null if default or none
+     * @param mainFile - main file name
+     * @param auxFiles - other submittted files 
+     * @param overrideTimeMS - override submission time in MS
+     * @param overrideRunId - override run id
+     */
+    public void submitRun(String clientIdString, String problemID, String languageID, String entry_point, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) {
 
         isEmptyString(clientIdString, "ClientId parameter is null");
         isEmptyString(problemID, "Parameter problemID is null or empty");
@@ -108,7 +124,7 @@ public class RemoteRunSubmitter {
             }
         }
 
-        controller.submitRun(submitter, problem, language, mainSubmissionFile, additionalFiles, overrideTimeMS, overrideRunId);
+        controller.submitRun(submitter, problem, language, entry_point, mainSubmissionFile, additionalFiles, overrideTimeMS, overrideRunId);
     }
 
     private Language getLanguageByName(IInternalContest contest2, String languageName) {

--- a/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
@@ -61,7 +61,7 @@ public class RemoteRunSubmitter {
      * @param clientIdString - "teamN" client name
      * @param problemID - problem id
      * @param languageID - CLICS language id
-     * @param entry_point - java/kotlin entry point, null if default or none
+     * @param entry_point - entry point, null if default or none
      * @param mainFile - main file name
      * @param auxFiles - other submittted files 
      * @param overrideTimeMS - override submission time in MS

--- a/src/edu/csus/ecs/pc2/ui/RunsTablePane.java
+++ b/src/edu/csus/ecs/pc2/ui/RunsTablePane.java
@@ -2229,6 +2229,10 @@ public class RunsTablePane extends JPanePlugin {
                             MultipleFileViewer mfv = new MultipleFileViewer(log, "Source files for Site " + run.getSiteNumber() + " Run " + run.getNumber());
                             mfv.setContestAndController(getContest(), getController());
     
+                            // if entry point was specified, add a tab for it
+                            if(run.getEntryPoint() != null) {
+                                mfv.addTextPane("Entry Point", run.getEntryPoint());
+                            }
                             // add any other files to the MFV (these are added first so that the mainFile will appear at index 0)
                             boolean otherFilesPresent = false;
                             boolean otherFilesLoadedOK = false;

--- a/src/edu/csus/ecs/pc2/ui/team/SubmitterFromEF.java
+++ b/src/edu/csus/ecs/pc2/ui/team/SubmitterFromEF.java
@@ -266,7 +266,7 @@ public class SubmitterFromEF {
 //                    Run debugRun = new Run(submitter, language, problem);
                     SerializedFile[] auxFiles = new SerializedFile[0];
 
-                    getController().submitRun(submitter, problem, language, mainFile, auxFiles, overrideTimeMS, overrideSubmissionID);
+                    getController().submitRun(submitter, problem, language, runSubmission.getEntry_point(), mainFile, auxFiles, overrideTimeMS, overrideSubmissionID);
                     count++;
                     System.out.println("Submission " + count + " run id = " + overrideSubmissionID);
       

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1196,7 +1196,7 @@ public class ExecutableTest extends AbstractTestCase {
         
         String actual = executable.substituteAllStrings(run, "foo {files}");
         
-        assertEquals("Expected substitution", actual, "foo ISumit.java");
+        assertEquals("Expected substitution", "foo ISumit.java", actual);
     }
     
     /**
@@ -1224,15 +1224,15 @@ public class ExecutableTest extends AbstractTestCase {
         
         String actual = executable.substituteAllStrings(run, "foo {:basename}{:ifsuffix=it}");
         
-        assertEquals("Expected substitution", actual, "foo ISumit");
+        assertEquals("Expected substitution", "foo ISumit", actual);
         
         actual = executable.substituteAllStrings(run, "{:basename}{:ifsuffix=Kt}");
         
-        assertEquals("Expected substitution", actual, "ISumitKt");
+        assertEquals("Expected substitution", "ISumitKt", actual);
         
         actual = executable.substituteAllStrings(run, "kotlin {:basename}{:ifsuffix=Kt}{:ifsuffix=Kt} {:basename}{:ifsuffix=ISumit}{:ifsuffix=Kt}");
         
-        assertEquals("Expected substitution", actual, "kotlin ISumitKtKt ISumitKt");
+        assertEquals("Expected substitution", "kotlin ISumitKtKt ISumitKt", actual);
     }
 
     private String stripSpace(String cmdline) throws IOException {

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1222,15 +1222,15 @@ public class ExecutableTest extends AbstractTestCase {
         executable.setExecuteDirectoryName(executeDirectoryName);
         executable.setUsingGUI(false);
         
-        String actual = executable.substituteAllStrings(run, "foo {:basename}{:ifsuffix=it}");
+        String actual = executable.substituteAllStrings(run, "foo {:basename}{:ensuresuffix=it}");
         
         assertEquals("Expected substitution", "foo ISumit", actual);
         
-        actual = executable.substituteAllStrings(run, "{:basename}{:ifsuffix=Kt}");
+        actual = executable.substituteAllStrings(run, "{:basename}{:ensuresuffix=Kt}");
         
         assertEquals("Expected substitution", "ISumitKt", actual);
         
-        actual = executable.substituteAllStrings(run, "kotlin {:basename}{:ifsuffix=Kt}{:ifsuffix=Kt} {:basename}{:ifsuffix=ISumit}{:ifsuffix=Kt}");
+        actual = executable.substituteAllStrings(run, "kotlin {:basename}{:ensuresuffix=Kt}{:ensuresuffix=Kt} {:basename}{:ensuresuffix=ISumit}{:ensuresuffix=Kt}");
         
         assertEquals("Expected substitution", "kotlin ISumitKtKt ISumitKt", actual);
     }

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1198,6 +1198,42 @@ public class ExecutableTest extends AbstractTestCase {
         
         assertEquals("Expected substitution", actual, "foo ISumit.java");
     }
+    
+    /**
+     * test {:ifsuff=xxx} substitution.
+     * 
+     * @throws Exception
+     */
+    public void testCondSuffixSubstitute() throws Exception {
+        
+        String executeDirectoryName = getOutputDataDirectory(getName());
+        ensureDirectory(executeDirectoryName);
+        
+        String sumitFilename = getSamplesSourceFilename("ISumit.java");
+        ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
+        Problem problem = createHelloProblemNoJudgesData(contest);
+        
+        Run run = createRun(submitter, javaLanguage, problem, 2, 2);
+        assertFileExists(sumitFilename);
+        
+        RunFiles runFiles = new RunFiles(run, sumitFilename);
+        
+        Executable executable = new Executable(contest, controller, run, runFiles);
+        executable.setExecuteDirectoryName(executeDirectoryName);
+        executable.setUsingGUI(false);
+        
+        String actual = executable.substituteAllStrings(run, "foo {:basename}{:ifsuffix=it}");
+        
+        assertEquals("Expected substitution", actual, "foo ISumit");
+        
+        actual = executable.substituteAllStrings(run, "{:basename}{:ifsuffix=Kt}");
+        
+        assertEquals("Expected substitution", actual, "ISumitKt");
+        
+        actual = executable.substituteAllStrings(run, "kotlin {:basename}{:ifsuffix=Kt}{:ifsuffix=Kt} {:basename}{:ifsuffix=ISumit}{:ifsuffix=Kt}");
+        
+        assertEquals("Expected substitution", actual, "kotlin ISumitKtKt ISumitKt");
+    }
 
     private String stripSpace(String cmdline) throws IOException {
         /**

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -1200,7 +1200,7 @@ public class ExecutableTest extends AbstractTestCase {
     }
     
     /**
-     * test {:ifsuff=xxx} substitution.
+     * test {:ensuresuffix=xxx} substitution.
      * 
      * @throws Exception
      */

--- a/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
@@ -546,19 +546,19 @@ public class ExecuteUtilitiesTest extends AbstractTestCase {
     public void testReplaceStringConditional() throws Exception {
         
         // tests detection suffix at start of string and do not duplicate it
-        String actual = ExecuteUtilities.replaceStringConditional("foo{:ifsuffix=foo}", "{:ifsuffix=}");
+        String actual = ExecuteUtilities.replaceStringConditional("foo{:ensuresuffix=foo}", "{:ensuresuffix=}");
         
         assertEquals("Expected substitution", "foo", actual);
         
         // tests missing suffix and adds it
-        actual = ExecuteUtilities.replaceStringConditional("ISumit{:ifsuffix=Kt}", "{:ifsuffix=}");
+        actual = ExecuteUtilities.replaceStringConditional("ISumit{:ensuresuffix=Kt}", "{:ensuresuffix=}");
         
         assertEquals("Expected substitution", "ISumitKt", actual);
         
         // tests that evaluation is right to left and we do not use a conditional
         // substitute suffix as a comparision for the another conditional suffix
         // also tests longer suffix string matching
-        actual = ExecuteUtilities.replaceStringConditional("kotlin ISumit{:ifsuffix=Kt}{:ifsuffix=Kt} ISumit{:ifsuffix=ISumit}{:ifsuffix=Kt}", "{:ifsuffix=}");
+        actual = ExecuteUtilities.replaceStringConditional("kotlin ISumit{:ensuresuffix=Kt}{:ensuresuffix=Kt} ISumit{:ensuresuffix=ISumit}{:ensuresuffix=Kt}", "{:ensuresuffix=}");
         
         assertEquals("Expected substitution", "kotlin ISumitKtKt ISumitKt", actual);
     }

--- a/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
@@ -538,4 +538,29 @@ public class ExecuteUtilitiesTest extends AbstractTestCase {
         }
     }
 
+    /**
+     * test {:ifsuff=xxx} substitution.
+     * 
+     * @throws Exception
+     */
+    public void testReplaceStringConditional() throws Exception {
+        
+        // tests detection suffix at start of string and do not duplicate it
+        String actual = ExecuteUtilities.replaceStringConditional("foo{:ifsuffix=foo}", "{:ifsuffix=}");
+        
+        assertEquals("Expected substitution", "foo", actual);
+        
+        // tests missing suffix and adds it
+        actual = ExecuteUtilities.replaceStringConditional("ISumit{:ifsuffix=Kt}", "{:ifsuffix=}");
+        
+        assertEquals("Expected substitution", "ISumitKt", actual);
+        
+        // tests that evaluation is right to left and we do not use a conditional
+        // substitute suffix as a comparision for the another conditional suffix
+        // also tests longer suffix string matching
+        actual = ExecuteUtilities.replaceStringConditional("kotlin ISumit{:ifsuffix=Kt}{:ifsuffix=Kt} ISumit{:ifsuffix=ISumit}{:ifsuffix=Kt}", "{:ifsuffix=}");
+        
+        assertEquals("Expected substitution", "kotlin ISumitKtKt ISumitKt", actual);
+    }
+    
 }

--- a/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecuteUtilitiesTest.java
@@ -539,7 +539,7 @@ public class ExecuteUtilitiesTest extends AbstractTestCase {
     }
 
     /**
-     * test {:ifsuff=xxx} substitution.
+     * test {:ensuresuffix=xxx} substitution.
      * 
      * @throws Exception
      */

--- a/test/edu/csus/ecs/pc2/core/log/NullController.java
+++ b/test/edu/csus/ecs/pc2/core/log/NullController.java
@@ -655,6 +655,13 @@ public class NullController implements IInternalController{
     }
 
     @Override
+    public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainFile, SerializedFile[] auxFiles, long overrideTimeMS,
+            long overrideSubmissionID) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
     public void submitJudgeRun(Problem problem, Language language, SerializedFile mainFile, SerializedFile[] otherFiles, long overrideSubmissionTimeMS, long overrideRunId) throws Exception {
         // TODO Auto-generated method stub
         


### PR DESCRIPTION
### Description of what the PR does
Obeys the **CLICS** spec for the event feed submissions object when an `entry_point `property is present.  The `entry_point`, if specified on the event feed, replaces the main source file basename when substituting the `{:basename}` substitution variable.  This allows submissions that are in a java package to work properly, in addition to Kotlin submissions.  

Also added a new _conditional_ substitution variable, `{:ensuresuffix=_xxx_}`, that provides a mechanism to conditionally add text to an execute command (Executable.java).   This is necessary, for example, if PC2 is shadowing and the event feed provides an `entry_point ` for a submission, but PC2 _also_ accepts submissions from **WTI** or the _fat-team_ client.  If this is a Kotlin submission (for example), and the event feed provides a valid `entry_point` of, say, **MyClassKt**, and a submission is made to PC2 via WTI or the fat-team client, we want to be able to add the trailing **Kt** in the execute command in the latter case but not the former case.  A string such as: `{:basename}{:ensuresuffix=Kt}` could be used in this case, and it will work for both event feed submissions AND WTI/fat-client submissions.

### Issue which the PR addresses
#46 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11/Linux Ubuntu 22.04
Java 1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
This is very complicated to test as it requires an event feed (shadowing) that contains submissions that have `entry_point`'s specified.
Assuming that you have a contest set up and you have access to a shadow event feed that has submissions with `entry_point`'s that are something OTHER than the main source file _basename_ (such as ANY Kotlin submission), the process is straight forward.
1) Define the language execute string use `{:basename}{:ensuresuffix=Kt}` 
2) Connect to the shadow server (primary)
3) Wait for a Kotlin run to be submitted on the event feed that correctly specifies an `entry_point`.
4) Verify that the run executes properly.  That is, that it correctly used the supplied entry_point and got a valid (expected) judgement.
5) Attempt to re-judge the submission from an administrator account (for example).
6) Verify that the run executes properly (this tests the retention of the supplied `entry_point`)
7) Make a Kotlin submission using the _fat-client_ (see Note 1 below).
8) Verify that it executes properly and gives a valid (expected) judgement .

Note 1: Kotlin has a rather unique way of naming it's classes.  If the source file is named **test-hello.kt**, the main class produced by the Kotlin compiler is: **Test_helloKt**   If the source is named **Test-hello.kt**, the same main class is produced.  If the source is named **Test_hello.kt**, again, **Test_helloKt** is the main class name produced.  So, all three of those source files produce the same main class name (and consequently, the same **Test_helloKt.class** file).  Of course, this means if the source file is case and hyphen different from the main class file produced, then a **WTI**/_fat-client_ submission will not work.  It will only work if the main source file is case/underscore identical to the main class name produced.  Keep this in mind when testing.

Note 2: For submissions in java where the source files are all part of a user defined package, an entry point is required on the event feed, and this works fine for submissions received on the event feed using this PR.  There is (currently) no way, however, for a user to specify the entry point from **WTI** or the _fat-client_, as such, there is no way to test this case.

Note 3: Thanks to @lane55 for providing a starting code base for this PR.  Any mistakes are mine, not his!
 
A **JUnit** test was added to test the new conditional string substitution code.

The image below shows the language configuration for Kotlin using the new conditional substitution variable.

<img width="414" alt="langpage" src="https://user-images.githubusercontent.com/5657363/233396722-307eb715-bcde-4812-ba61-ae5d1093c81e.png">

If you need assistance setting up a test environment, @johnbrvc can provide guidance on how testing was performed, and help you set up the same contest and environment.

