### PR TITLE
i739: fixed NPE bug now properly updates run grid

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/QuickJudgePane.java
+++ b/src/edu/csus/ecs/pc2/ui/QuickJudgePane.java
@@ -254,7 +254,7 @@ public class QuickJudgePane extends JPanePlugin implements UIPlugin {
         public void runChanged(RunEvent event) {
             updateRunRow(event.getRun(), event.getWhoModifiedRun());
 
-            if (event.getSentToClientId().equals(getContest().getClientId())) {
+            if (getContest().getClientId().equals(event.getSentToClientId())) {
                 // we checked out the run, let's try to judge it.
 
                 Run run = event.getRun();


### PR DESCRIPTION
### Description of what the PR does

When a run is re-judged, the runs tab is now updated (before was not updated)

### Issue which the PR addresses

Fixes #739 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

start server with sample, like --load mini
start admin, contest time
submit runs
On Judging Utilities (Pane)
select a set of runs
click Submit to judge them

then
for one of those judged runs
rejudge with a different judgement
runs tab does not update that run

Expected behavior:

When runs judged should update run.

Actual behavior:

Runs status/judgements are not updated.