### PR TITLE
include mode 755 for sandbox/** scripts.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -129,6 +129,7 @@
                 <include name="${release}/samps/sleep.exe"/>
                 <include name="${release}/samps/**/distribute_score**"/>
                 <include name="${release}/samps/**/rotate**"/>
+                <include name="${release}/sandbox/**"/>
             </tarfileset>
             <tarfileset mode="644" dir="${build.unpack.dir}">
                 <include name="${release}/samps/**"/>


### PR DESCRIPTION
fixes #754

to test: 
ant -f package.xml gzip

extract resulting tgz file to check the permissions of sandbox/ folder.

expected 755 executable bit is set.