### PR TITLE
i756: replace/fix report JSON class with StandingsJSON2016 for JSON 2016 Scoreboard report 

### DIFF
--- a/src/edu/csus/ecs/pc2/core/report/JSON2016Report.java
+++ b/src/edu/csus/ecs/pc2/core/report/JSON2016Report.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.FileOutputStream;
@@ -12,7 +12,6 @@ import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.exports.ccs.StandingsJSON;
 import edu.csus.ecs.pc2.exports.ccs.StandingsJSON2016;
 
 /**
@@ -92,8 +91,8 @@ public class JSON2016Report implements IReportFile {
     }
 
     public void writeReport(PrintWriter printWriter) throws Exception {
-        StandingsJSON standingsJSON = new StandingsJSON();
-        printWriter.print(standingsJSON.createJSON(contest));
+        StandingsJSON2016 standingsJSON = new StandingsJSON2016();
+        printWriter.print(standingsJSON.createJSON(contest, controller));
         standingsJSON = null;
     }
 


### PR DESCRIPTION



### Description of what the PR does

 JSON 2016 Scoreboard report  incorrectly using StandingsJSON class,
replace with StandingsJSON2016 class.

### Issue which the PR addresses

#756 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)


Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Run  JSON 2016 Scoreboard report 