### PR TITLE
I 763 add clar tab to shadow feeder frame

### DIFF
--- a/src/edu/csus/ecs/pc2/core/PermissionGroup.java
+++ b/src/edu/csus/ecs/pc2/core/PermissionGroup.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import edu.csus.ecs.pc2.core.model.ClientType;
@@ -142,7 +142,6 @@ public class PermissionGroup {
         feederPermissionList.addPermission(Type.TEST_RUN);
         feederPermissionList.addPermission(Type.VIEW_CLARIFICATIONS);
         feederPermissionList.addPermission(Type.VIEW_RUNS);
-        feederPermissionList.addPermission(Type.ANSWER_CLARIFICATION);
         feederPermissionList.addPermission(Type.SUBMIT_CLARIFICATION);
         feederPermissionList.addPermission(Type.VIEW_ALL_JUDGEMENTS);
         feederPermissionList.addPermission(Type.VIEW_STANDINGS);

--- a/src/edu/csus/ecs/pc2/core/PermissionGroup.java
+++ b/src/edu/csus/ecs/pc2/core/PermissionGroup.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import edu.csus.ecs.pc2.core.model.ClientType;
@@ -142,6 +142,7 @@ public class PermissionGroup {
         feederPermissionList.addPermission(Type.TEST_RUN);
         feederPermissionList.addPermission(Type.VIEW_CLARIFICATIONS);
         feederPermissionList.addPermission(Type.VIEW_RUNS);
+        feederPermissionList.addPermission(Type.ANSWER_CLARIFICATION);
         feederPermissionList.addPermission(Type.SUBMIT_CLARIFICATION);
         feederPermissionList.addPermission(Type.VIEW_ALL_JUDGEMENTS);
         feederPermissionList.addPermission(Type.VIEW_STANDINGS);

--- a/src/edu/csus/ecs/pc2/ui/eventfeed/ServicesView.java
+++ b/src/edu/csus/ecs/pc2/ui/eventfeed/ServicesView.java
@@ -1,7 +1,8 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui.eventfeed;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -23,6 +24,7 @@ import edu.csus.ecs.pc2.core.model.ContestTimeEvent;
 import edu.csus.ecs.pc2.core.model.IContestTimeListener;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.ui.AboutPane;
+import edu.csus.ecs.pc2.ui.ClarificationsPane;
 import edu.csus.ecs.pc2.ui.ContestClockDisplay;
 import edu.csus.ecs.pc2.ui.ContestClockDisplay.DisplayTimes;
 import edu.csus.ecs.pc2.ui.EventFeedServerPane;
@@ -34,7 +36,6 @@ import edu.csus.ecs.pc2.ui.PluginLoadPane;
 import edu.csus.ecs.pc2.ui.ShadowControlPane;
 import edu.csus.ecs.pc2.ui.UIPlugin;
 import edu.csus.ecs.pc2.ui.WebServerPane;
-import java.awt.Dimension;
 
 /**
  * This class presents a graphical user interface for controlling the services exposed to external clients.
@@ -206,6 +207,19 @@ public class ServicesView extends JFrame implements UIPlugin {
                         }
                     }
                 }
+               
+               
+               try {
+                   ClarificationsPane pane = new ClarificationsPane();
+                   addUIPlugin(getMainTabbedPane(), "Clarifications", pane);
+               } catch (Exception e) {
+                   if (StaticLog.getLog() != null) {
+                       StaticLog.getLog().log(Log.WARNING, "Exception", e);
+                       e.printStackTrace(System.err);
+                   } else {
+                       e.printStackTrace(System.err);
+                   }
+               }
                 
                 OptionsPane optionsPanel = new OptionsPane();
                 addUIPlugin(getMainTabbedPane(), "Options", optionsPanel);


### PR DESCRIPTION
### Description of what the PR does

Adds Clarificaiton tab to Feeder UI.

Also ensures that the shadow/feeder can NOT answer clars.


### Issue which the PR addresses

fixes #763 


### Environment in which the PR was developed (OS,IDE, Java version, etc.)


Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

start server using mini contest 
```
pc2server --login s --contestpassword contest  --load mini
```

start feeder
```
pc2ef --login ef1
```

Passes if:
1. Clarifications tab present
2. There is no Answer button on the Clarifications pane
