### PR TITLE
i772: remove test connection message boxes

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -900,10 +900,8 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                     remoteContestAPIAdapter = createRemoteContestAPIAdapter(remoteURL, remoteLogin, remotePW);
                                     boolean isConnected = remoteContestAPIAdapter.testConnection();
                                     if (isConnected) {
-                                        showMessage ("Connection to remote CCS is successful");
                                         addConnectTableEntry(ShadowStatus.SUCCESS, "Test connection to remote CCS");
                                     } else {
-                                        showErrorMessage("Connection to remote CCS failed", "Connection failed");
                                         addConnectTableEntry(ShadowStatus.FAILURE, "Test connection to remote CCS");
                                     }
                                     


### PR DESCRIPTION

### Description of what the PR does

removed info message boxes, now the pass/fail info is added to the connection list box

### Issue which the PR addresses

Fixes #772

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

start server with mini contest
start feeder1
```
pc2ef --login ef1
```

Select Shadow Mode tab

Test 1:

Enter the Primary CCS URL: http://localhost/contest
login/pass: foo/foo

Click Update
Click Test Connection

Expected:

No message box shown
adds FAILURE row to connections listbox


Test 2:

Enter a valid primary CCS URL/login/Password

Click Update
Click Test Connection

Expected:

No message box shown
adds SUCCESS row to connections listbox
