### PR TITLE
i778 Add problem fails due to NPE in sandbox pane, fixes #778

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/Problem.java
+++ b/src/edu/csus/ecs/pc2/core/model/Problem.java
@@ -386,6 +386,7 @@ public class Problem implements IElementObject {
         clone.setActive(isActive());
         clone.setReadInputDataFromSTDIN(isReadInputDataFromSTDIN());
         clone.setTimeOutInSeconds(getTimeOutInSeconds());
+        clone.setMaxOutputSizeKB(getMaxOutputSizeKB());
         
         //output validator settings
         clone.setValidatorType(this.getValidatorType());

--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -2118,8 +2118,6 @@ public class EditProblemPane extends JPanePlugin {
         this.newProblemDataFiles = null;
         originalProblemDataFiles = problemDataFiles;
         
-        getProblemSandboxPane().setProblem(inProblem);
-
         if (debug22EditProblem) {
             fileNameOne = createProblemReport(inProblem, problemDataFiles, "stuf1");
             Utilities.dump(originalProblemDataFiles, "debug   ORIGINAL  setProblem");
@@ -2272,8 +2270,6 @@ public class EditProblemPane extends JPanePlugin {
         this.newProblemDataFiles = null;
         this.originalProblemDataFiles = null;
         
-        getProblemSandboxPane().setProblem(problem);
-
         if (debug22EditProblem) {
             fileNameOne = createProblemReport(problem, originalProblemDataFiles, "stuf1");
         }

--- a/src/edu/csus/ecs/pc2/ui/EditProblemSandboxPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemSandboxPane.java
@@ -131,33 +131,12 @@ public class EditProblemSandboxPane extends JPanePlugin {
         return "Edit Problem Sandbox Pane";
     }
     
+    /**
+     * Set's problem specific data fields
+     * @param problem - the problem to use for the sandbox data (may be null)
+     */
     public void setProblem(Problem problem) {
-        
-        // If adding a problem, we have to determine a default sandbox type
-        if(problem == null) {
-            // If sandboxes are desried and supported, we make the internal sandbox the default
-            if(Problem.DEFAULT_SANDBOX_TYPE == SandboxType.PC2_INTERNAL_SANDBOX && isCheckSandboxSupport()) {
-                getUsePC2SandboxRadioButton().setSelected(true);
-            } else {
-                getUseNoSandboxRadioButton().setSelected(true);
-            }
-            getPC2SandboxOptionMemLimitTextbox().setText(Integer.toString(Problem.DEFAULT_MEMORY_LIMIT_MB));
-       } else {
-            //activate the appropriate sandbox selection button (the buttons are in a group so selecting one will deselect the others)
-            if (problem.getSandboxType() == SandboxType.NONE) {
-                getUseNoSandboxRadioButton().setSelected(true);
-                
-            } else if (problem.getSandboxType() == SandboxType.PC2_INTERNAL_SANDBOX) {
-                isCheckSandboxSupport();
-                getUsePC2SandboxRadioButton().setSelected(true);
-                getPC2SandboxOptionMemLimitTextbox().setText(Integer.toString(problem.getMemoryLimitMB()));
-                
-            } else if (problem.getSandboxType() == SandboxType.EXTERNAL_SANDBOX) {
-                getLog().severe("Problem has 'Custom sandbox' selected -- should not be possible in this version of PC^2!");
-                //default to "None"
-                getUseNoSandboxRadioButton().setSelected(true);
-            }
-        }
+        populateGUI(problem);
     }
 
     public void setParentPane(EditProblemPane editProblemPane) {
@@ -199,6 +178,40 @@ public class EditProblemSandboxPane extends JPanePlugin {
             } else {
                 getLog().warning("EditProblemSandboxPane.initializeFields() called with Problem containing unknown sandbox type '" 
                                     + sandboxType + "'; cannot initialize pane");
+            }
+        }
+    }
+    
+    /**
+     * Populate controls with problem's sandbox information
+     * 
+     * @param problem - the problem to use to populate the controls.  If null, uses defaults
+     */
+    private void populateGUI(Problem problem) {
+        
+        // If adding a problem, we have to determine a default sandbox type
+        if(problem == null) {
+            // If sandboxes are desired and supported, we make the internal sandbox the default
+            if(Problem.DEFAULT_SANDBOX_TYPE == SandboxType.PC2_INTERNAL_SANDBOX && isCheckSandboxSupport()) {
+                getUsePC2SandboxRadioButton().setSelected(true);
+            } else {
+                getUseNoSandboxRadioButton().setSelected(true);
+            }
+            getPC2SandboxOptionMemLimitTextbox().setText(Integer.toString(Problem.DEFAULT_MEMORY_LIMIT_MB));
+       } else {
+            //activate the appropriate sandbox selection button (the buttons are in a group so selecting one will deselect the others)
+            if (problem.getSandboxType() == SandboxType.NONE) {
+                getUseNoSandboxRadioButton().setSelected(true);
+                
+            } else if (problem.getSandboxType() == SandboxType.PC2_INTERNAL_SANDBOX) {
+                isCheckSandboxSupport();
+                getUsePC2SandboxRadioButton().setSelected(true);
+                getPC2SandboxOptionMemLimitTextbox().setText(Integer.toString(problem.getMemoryLimitMB()));
+                
+            } else if (problem.getSandboxType() == SandboxType.EXTERNAL_SANDBOX) {
+                getLog().severe("Problem has 'Custom sandbox' selected -- should not be possible in this version of PC^2!");
+                //default to "None"
+                getUseNoSandboxRadioButton().setSelected(true);
             }
         }
     }

--- a/src/edu/csus/ecs/pc2/ui/EditProblemSandboxPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemSandboxPane.java
@@ -100,7 +100,7 @@ public class EditProblemSandboxPane extends JPanePlugin {
     
     //setting this to True will override the prohibition on selecting a Sandbox when running on Windows.
     // Note that THIS IS FOR DEBUGGING PURPOSES; it does NOT imply any support for Windows sandboxing.
-    private boolean debugAllowSandboxSelectionOnWindows = false;
+    private boolean debugAllowSandboxSelectionOnWindows = true;
 
 
 

--- a/src/edu/csus/ecs/pc2/ui/EditProblemSandboxPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemSandboxPane.java
@@ -6,6 +6,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -23,6 +24,7 @@ import javax.swing.ButtonGroup;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -971,9 +973,15 @@ public class EditProblemSandboxPane extends JPanePlugin {
     {
         boolean bSupported = OSCompatibilityUtilities.areSandboxesSupported(getContest(), getLog());
         if(!bSupported){
-            if(!noSandboxNagMessage) {        
-                JOptionPane.showMessageDialog(getParentPane(), "You should be aware of the fact that this system does not support sandboxes.\nTherefore, you are not able to configure problems that do require a sandbox.", "Sandbox Not Available Notice", JOptionPane.WARNING_MESSAGE);
-                noSandboxNagMessage = true;
+            if(!noSandboxNagMessage) {
+                String msgWarning = "You should be aware of the fact that this system does not support sandboxes.\n"
+                        + "Therefore, you are not able to configure problems that do require a sandbox.";
+                JCheckBox checkbox = new JCheckBox("Do not show this message again.");
+
+                Object [] oMsg = { msgWarning, checkbox };
+                checkbox.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 10));
+                JOptionPane.showMessageDialog(getParentPane(), oMsg, "Sandbox Not Available Notice", JOptionPane.WARNING_MESSAGE);
+                noSandboxNagMessage = checkbox.isSelected();
            }
         }
         return(bSupported);

--- a/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -550,7 +550,12 @@ public class ProblemsPane extends JPanePlugin {
             addButton.setToolTipText("Add new Problem definition");
             addButton.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    addProblem();
+                    try {
+                        addProblem();
+                    } catch (Exception eAdd) {
+                        log.log(Log.SEVERE, "Unable to add new problem ", eAdd);
+                        showMessage("Unable to add new problem, check log (" + eAdd.getMessage() + ")");
+                    }
                 }
             });
         }

--- a/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
@@ -292,7 +292,7 @@ public class ProblemsPane extends JPanePlugin {
         long outputLimit = problem.getMaxOutputSizeKB();
         if (outputLimit == 0) {
             //use global value
-            outputLimit = getContest().getContestInformation().getMaxOutputSizeInBytes();
+            outputLimit = getContest().getContestInformation().getMaxOutputSizeInBytes() / 1024;
         }
         c[i++] = Long.toString(outputLimit);
 


### PR DESCRIPTION
### Description of what the PR does
Fixes the bug where new problem could not be added by the GUI.
CI for incorrectly displayed max output size and not copying max output K bytes when copying a problem.

### Issue which the PR addresses
Fixes #778 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
```
Application     : CSUS Programming Contest Control System
Version         : 9.9build 20221222
Build Date      : Thursday, December 22nd 2022 18:07 UTC
OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321

```
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Bring up the pc2server
2) Bring up the pc2admin
3) Select the Problems tab
4) Click on the "Add" button.  Note that the Add problem dialog correctly displays.

To test the CI:
After step 3) above:
4) Select an existing problem.
5) Click on Copy.
6) Select a new name at the prompt
7) Note that the max output size is the same as the copied problem and not 8388608
