### PR TITLE
i748: allow team to pick multiple files in file dialog

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -42,11 +42,7 @@ import edu.csus.ecs.pc2.core.security.Permission;
  * A submit run pane.
  * 
  * @see edu.csus.ecs.pc2.Starter
- * @version $Id$
- * @author pc2@ecs.csus.edu
  */
-
-// $HeadURL$
 public class SubmitRunPane extends JPanePlugin {
 
     /**
@@ -925,42 +921,36 @@ public class SubmitRunPane extends JPanePlugin {
             addAdditionalFilesButton.setToolTipText("Add an additional file");
             addAdditionalFilesButton.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    addFile();
+                    addAuxillaryFiles();
                 }
             });
         }
         return addAdditionalFilesButton;
     }
 
-    protected void addFile() {
+    protected void addAuxillaryFiles() {
 
         JFileChooser chooser = new JFileChooser(lastOpenedFile);
         try {
-            chooser.setDialogTitle("Open Additional Source Code File");
+            chooser.setDialogTitle("Open Additional Source Code File(s)");
+            chooser.setMultiSelectionEnabled(true);
             int returnVal = chooser.showOpenDialog(this);
             if (returnVal == JFileChooser.APPROVE_OPTION) {
-                File newFile = chooser.getSelectedFile().getCanonicalFile();
-                boolean newFileProblem = true;
-                if (newFile.exists()) {
-                    if (newFile.isFile()) {
-                        if (newFile.canRead()) {
-                            lastOpenedFile = chooser.getCurrentDirectory().toString();
-                            String[] cols = new String[1];
-                            cols[0] = newFile.getCanonicalFile().toString();
-                            additionalFilesMCLB.addRow(cols);
-                            additionalFilesMCLB.autoSizeAllColumns();
-                            newFileProblem = false;
-                        }
+                File [] newFiles = chooser.getSelectedFiles();
+
+                for (File newFile : newFiles) {
+                    if (newFile.exists() && newFile.isFile()) {
+                        String[] cols = new String[1];
+                        cols[0] = newFile.getCanonicalFile().toString();
+                        additionalFilesMCLB.addRow(cols);
                     }
                 }
-                if (newFileProblem) {
-                    log.warning("Problem reading additional file selection " + newFile.getCanonicalPath() + ", file not added");
-                    JOptionPane.showMessageDialog(getParentFrame(), "File not added, could not open file " + newFile, "Warning", JOptionPane.WARNING_MESSAGE);
-                }
+
+                additionalFilesMCLB.autoSizeAllColumns();
             }
         } catch (Exception e) {
-            System.err.println("Error getting selected file, try again.");
             e.printStackTrace(System.err);
+            showMessage("Unable to add file(s) " + e.getMessage());
         }
         chooser = null;
     }


### PR DESCRIPTION
### Description of what the PR does

Team can now multi select additional files (to submit) 
if exception show message to user (was only printing stack trace)

### Issue which the PR addresses

Fixes #748

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)


Submit run, select multiple additional files.

start server, use --load sumithello

Start clock

Login into team 3

Click Add for Additional Files

Passes if allows selection of more than 1 file

Click OK

Passes if selected files are added to the Additional Files list