### PR TITLE
I793 Manual run status change to JUJDGED or BEING_RE_JUDGED can causes NPE

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -337,6 +337,10 @@ public class InternalContest implements IInternalContest {
                 } else if (status.equals(RunStates.BEING_RE_JUDGED)) {
                     status = RunStates.JUDGED;
                 }
+                // Can not have a judged run with no judgment records - set to NEW as above
+                if(status == RunStates.JUDGED && runs[i].getJudgementRecord() == null) {
+                    status = RunStates.NEW;                    
+                }
                 if (!runs[i].getStatus().equals(status)) {
                     StaticLog.info("Changing Run " + runs[i].getElementId() + " from " + runs[i].getStatus() + "to NEW");
 


### PR DESCRIPTION
### Description of what the PR does
Prevents the user from setting a run's status to one of the JUDGED statuses if there is no JudgementRecord.
CI: On server startup, when runs are scanned, make sure that any run that has a JUDGED status also has at least one JudgementRecord.  If not, set the status to NEW.

### Issue which the PR addresses
Fixes #793 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load the sumithello sample contest.
2) Start the contest
3) Run the team client and submit a run for "Hello"
4) Start an administrator client
5) Select the Runs tab
6) Select the first run (which should be marked as QUEUED_FOR_COMPUTER_JUDGEMENT
7) Edit the run (press the Edit button)
8) Change the Status to "BEING_RE_JUDGED"
9) Press the Update button
10) Note the error dialog that pops up telling you you are not allowed to set the Run Status
11) Press OK to dismiss the dialog.
12) Change the Status to "JUDGED"
13) Press the Update button
14) Note the error dialog that pops up telling you the run does not have any judgment records
15) Press OK to dismiss the dialog.
16) Select a "Judgement" value of "Yes" (this creates a judgement record in the Edit Run dialog)
17) Set the Status to "JUDGED"
18) Press the Update button
19) Note that it is now accepted.
20 Dismiss the edit dialog by pressing the Close button
21) Select the "Standings" tab and note that the correct judgment worked (first team has 1 solved)


The CI portion is not testable unless you have a contest where a non-judged run had its state changed to run.
You can create one of these yourself by using an older version of PC2 to change the status of a NEW or QFCJ run
to "JUDGED".  Then, stop the server and restart and it should appear as NEW. (This has been tested using the
contest provided by the AAST guys).
