### PR TITLE
I 795 Remove unnecessary restriction on properties in contest PAUSE message

### DIFF
--- a/src/edu/csus/ecs/pc2/services/web/ContestService.java
+++ b/src/edu/csus/ecs/pc2/services/web/ContestService.java
@@ -153,13 +153,6 @@ public class ContestService implements Feature {
             return Response.status(Status.BAD_REQUEST).entity("Missing 'starttime' key in /contest request").build();
         }
 
-        // verify the JSON didn't contain any OTHER key/value information
-        if (requestMap.size() != 2) {
-            controller.getLog().log(Log.WARNING, "Contest Service PATCH: JSON input contains illegal extra data: '" + jsonInputString + "'");
-            // return HTTP 400 response code per CLICS spec
-            return Response.status(Status.BAD_REQUEST).entity("Extra data in contest patch request").build();
-        }
-
         // if we get here the JSON is valid and contains exactly one element: starttime
         // get the Object corresponding to "start_time"
         String startTimeValueString = requestMap.get("start_time");


### PR DESCRIPTION
A non-compliant restriction requiring only 2 properties in the contest start time PAUSE JSON was causing 405 errors to be reported to remote clients indicating the presence of extra data in the request.  Specifically, the `contest_pause_time` property was present.  Even if PC2 does not use the property, it should be allowed - extra properties should not preclude the success of the call.


### Description of what the PR does
Removes the restriction requiring only 2 properties to be in the PAUSE (set start time) API PATCH call.

### Issue which the PR addresses
Fixes #795 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS : Windows 11 10.0 (amd64)
Java Version : 1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Load the **sumithello** sample contest.
2. Set the contest start time to some future date
3. **DO NOT START THE CONTEST**
4. Add a _feeder_ account
5. Make sure your **realm.properties** file exists in the PC2 install folder and has an entry for: `admin: admin,admin`
6. Log in to the event feeder PC2 application.
7. Click Start to start CLICS Contest API.
8. Confirm that it is started by checking the server log or standard output in eclipse.
```
Wed Aug 16 09:26:25 EDT 2023 Binding to port 50443
2023-08-16 09:26:25.197:INFO::AWT-EventQueue-0: Logging initialized @17850ms
Wed Aug 16 09:26:25 EDT 2023 Starting /starttime web service
Wed Aug 16 09:26:25 EDT 2023 Starting /fetchRun web service
**_Wed Aug 16 09:26:25 EDT 2023 Starting /contest web service_**
Wed Aug 16 09:26:25 EDT 2023 Starting /contest/scoreboard web service
Wed Aug 16 09:26:25 EDT 2023 Starting /contest/languages web service
Wed Aug 16 09:26:25 EDT 2023 Starting /contest/teams web service

```
9. From another system, enter the following "`curl`" command to force a `PATCH `message sending the _PAUSE_ API call.  Of course, replace the IP address (`10.0.0.244`) with the IP address of where the PC2 server is running.

`curl -X PATCH -H "Content-Type: application/json" -d '{"id":null,"start_time":null,"extra_field":"hello"}' -k "https://admin:admin@10.0.0.244:50443/contest"`

The following message should be printed by the curl command:

`Contest start time updated to "null" (no scheduled start)`

Previously, an error would be returned and the start time would not be set.  The error was a result of the "**extra_field**" being in the JSON request causing more than 2 properities to be present.
