### PR TITLE
I 799 load cdp sample data sets by default

### DIFF
--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -440,8 +440,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             setCcsTestMode(contest, ccsTestMode);
         }
         
-        // TODO 701 change LOAD_SAMPLE_JUDGES_DATA, false); to , true);
-        boolean loadSamples = fetchBooleanValue(content, LOAD_SAMPLE_JUDGES_DATA, false);
+        boolean loadSamples = fetchBooleanValue(content, LOAD_SAMPLE_JUDGES_DATA, true);
         setLoadSampleJudgesData(contest, loadSamples);
         
         boolean stopOnFirstFail = fetchBooleanValue(content, STOP_ON_FIRST_FAILED_TEST_CASE_KEY, false);

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitesTest.java
@@ -427,21 +427,17 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         }
         recs = JudgementUtilites.getLastTestCaseArray(contest, run);
         
-        // TODO 701 change from expected 7 files to 10 files
-//        assertEquals("Expected test cases ", 10, recs.length);
-        assertEquals("Expected test cases ", 7, recs.length);
+        assertEquals("Expected test cases ", 10, recs.length);
+        
         // Add second set of test cases - all WA
         for (int testCaseNum = 1; testCaseNum <= problem.getNumberTestCases(); testCaseNum++) {
             addRunTestCase(contest, run, testCaseNum, waJudgement, judges[0].getClientId());
         }
-     // TODO 701 change from expected 14 files to 20 files
-//        assertEquals("Expected total test cases ", 20, run.getRunTestCases().length);
-        assertEquals("Expected total test cases ", 14, run.getRunTestCases().length);
+        
+        assertEquals("Expected total test cases ", 20, run.getRunTestCases().length);
         recs = JudgementUtilites.getLastTestCaseArray(contest, run);
         
-        // TODO 701 change from expected 7 files to 10 files
-//        assertEquals("Expected test cases ", 10, recs.length);
-        assertEquals("Expected test cases ", 7, recs.length);
+        assertEquals("Expected test cases ", 10, recs.length);
         
         // Test that all judgements are WA
         for (RunTestCase runTestCase : recs) {

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -3873,9 +3873,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
 //            }
         }
 
-        // TODO 701 change from expected 7 files to 10 files
-//        assertEquals("In " + MINI_CONTEST_DIR + " expecting sample and secret data files", 10, totalTestCases);
-        assertEquals("In " + MINI_CONTEST_DIR + " expecting sample and secret data files", 7, totalTestCases);
+        assertEquals("In " + MINI_CONTEST_DIR + " expecting sample and secret data files", 10, totalTestCases);
 
     }
     


### PR DESCRIPTION
### Description of what the PR does

When loading from CDP, --load, will now load both secret and sample test data sets.

### Issue which the PR addresses

#799

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Load sample mini contest
Start admin

Test: are there 10 data sets for problem sumit?

Ten data sets are (in and ans)
sumit-samp-0.in
sumit-samp-1.in
sumit-samp-2.in
sumit.in
sumit1.in
sumit2.in
sumit3.in
sumit4.in
sumit5.in
sumit6.in


Load files from mini sumit problem
data\sample\sumit-samp-0.in
data\sample\sumit-samp-1.in
data\sample\sumit-samp-2.in
data\secret\sumit.in
data\secret\sumit1.in
data\secret\sumit2.in
data\secret\sumit3.in
data\secret\sumit4.in
data\secret\sumit5.in
data\secret\sumit6.in