### PR TITLE
I801 Fix wrong units for CLICS per-problem output limit

### DIFF
--- a/samps/contests/mini/config/sumit/problem.yaml
+++ b/samps/contests/mini/config/sumit/problem.yaml
@@ -15,7 +15,7 @@ rights_owner:
 max-output-size-K: 162
 limits: 
    timeout: 30
-   output: 778
+   output: 1
 
 validator: 
    validatorProg: pc2.jar edu.csus.ecs.pc2.validator.Validator

--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -186,7 +186,9 @@ public final class Constants {
     
     public static final String ACCOUNTS_LOAD_FILENAME = "accounts_load.tsv";
 
-    public static final int BYTES_PER_KIBIBYTE = 1024;   
+    public static final int BYTES_PER_KIBIBYTE = 1024;
+    
+    public static final int KIBIBYTE_PER_MEBIBYTE = 1024;
     
     /**
      * Sandbox constants

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1526,10 +1526,10 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                 problem.setTimeOutInSeconds(clicsTimeout);
             }
             
-            //check for a CLICS maxoutput limit
+            //check for a CLICS maxoutput limit - the value is in MiB
             Integer clicsMaxOutput = fetchIntValue(limitsContent, CLICS_MAX_OUTPUT_KEY);
             if (clicsMaxOutput != null) {
-                problem.setMaxOutputSizeKB(clicsMaxOutput);
+                problem.setMaxOutputSizeKB(clicsMaxOutput * Constants.KIBIBYTE_PER_MEBIBYTE);
             }
             
             Integer clicsMemoryLimit = fetchIntValue(limitsContent, MEMORY_LIMIT_CLICS, Problem.DEFAULT_MEMORY_LIMIT_MB);


### PR DESCRIPTION
CLICS Problem Package Formats states the output limit units are MiB.  PC2 was using KiB.

### Description of what the PR does
Interprets the output property of the limits object in the per-problem problem.yaml file as **MiB** instead of **KiB**.  This may be related to Issue #564 and PR #639.  
### Issue which the PR addresses
#801 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Java(TM) SE Runtime Environment (build 1.8.0_351-b10)
Windows 11

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Delete any prior contest configuration you may have loaded from the `profiles `folder.  And delete `profiles.properties`.
2) Load the `samps/contests/sumithello/config/mini` sample contest.  Note that the `limits:` object looks like this in the `problem.yaml `file:

```
limits: 
   timeout: 30
   output: 1

```
3) Start an `admin `client
4) View the `sumit`problem and note the output limit of 1024 as opposed to 1.
