### PR TITLE
I810 Make sure to kill off all processes in cgroup at start

### DIFF
--- a/scripts/pc2_interactive.sh
+++ b/scripts/pc2_interactive.sh
@@ -114,7 +114,7 @@ HandleTerminateFromPC2()
 	pkill -9 -P $$
 	if test -n "$submissionpid"
 	then
-		kill -9 -"$submissionpid"
+		pkill -9 -s "$submissionpid"
 	fi
 	DEBUG echo $0: Wall time exceeded - exiting with code $FAIL_WALL_TIME_LIMIT_EXCEEDED
 	exit $FAIL_WALL_TIME_LIMIT_EXCEEDED 
@@ -254,7 +254,7 @@ do
 		fi
 
 		# Kill off submission pgrp
-		kill -9 -"$submissionpid"
+		pkill -9 -s "$submissionpid"
 
 		if test "$wstat" -eq $EXITCODE_AC
 		then
@@ -310,9 +310,9 @@ REPORT "________________________________________"
 rm -f "$INFIFO" "$OUTFIFO"
 
 # Kill pgrp
-kill -9 -"$submissionpid"
+pkill -9 -s "$submissionpid"
 
-# Kill off stragglers
+# Kill off stragglers with us as a parent
 pkill -9 -P $$
 
 # TODO: determine how to pass more detailed pc2sandbox.sh results back to PC2... Perhaps in a file...

--- a/scripts/pc2_interactive.sh
+++ b/scripts/pc2_interactive.sh
@@ -108,11 +108,13 @@ KillValidator()
 HandleTerminateFromPC2()
 {
 	DEBUG echo "Received TERMINATE signal from PC2"
+	DEBUG echo "Killing off submission process group $submissionpid and all children"
 	KillValidator
-	if test -n "$submissionpid" -a -d /proc/$submissionpid
+	# Kill off all our kids
+	pkill -9 -P $$
+	if test -n "$submissionpid"
 	then
-		DEBUG echo "Killing off submission process $submissionpid"
-		kill -9 "$submissionpid"
+		kill -9 -"$submissionpid"
 	fi
 	DEBUG echo $0: Wall time exceeded - exiting with code $FAIL_WALL_TIME_LIMIT_EXCEEDED
 	exit $FAIL_WALL_TIME_LIMIT_EXCEEDED 
@@ -209,9 +211,9 @@ REPORT Started interactive validator PID $intv_pid
 starttime=`GetTimeInMicros`
 
 # run the command
-REPORT_DEBUG Executing "taskset $CPUMASK $COMMAND $* < $INFIFO > $OUTFIFO"
+REPORT_DEBUG Executing "setsid taskset $CPUMASK $COMMAND $* < $INFIFO > $OUTFIFO"
 
-taskset $CPUMASK $COMMAND $* < $INFIFO > $OUTFIFO  &
+setsid taskset $CPUMASK $COMMAND $* < $INFIFO > $OUTFIFO  &
 # Remember child's PID for possible killing off later
 submissionpid=$!
 
@@ -244,13 +246,16 @@ do
 			if test -d /proc/$contestantpid
 			then
 				REPORT Contestant PID $submissionpid has not finished - killing it
-				kill -9 "$submissionpid"
 			fi
 			# This is just determines if the program ran, not if it's correct.
 			# The result file has the correctness in it.
 			# We only do this if the contestant program has not finished yet.
 			COMMAND_EXIT_CODE=0
 		fi
+
+		# Kill off submission pgrp
+		kill -9 -"$submissionpid"
+
 		if test "$wstat" -eq $EXITCODE_AC
 		then
 			GenXML Accepted ""
@@ -303,6 +308,12 @@ DEBUG echo
 REPORT "________________________________________"
 
 rm -f "$INFIFO" "$OUTFIFO"
+
+# Kill pgrp
+kill -9 -"$submissinpid"
+
+# Kill off stragglers
+kill -9 -P $$
 
 # TODO: determine how to pass more detailed pc2sandbox.sh results back to PC2... Perhaps in a file...
 

--- a/scripts/pc2_interactive.sh
+++ b/scripts/pc2_interactive.sh
@@ -310,10 +310,10 @@ REPORT "________________________________________"
 rm -f "$INFIFO" "$OUTFIFO"
 
 # Kill pgrp
-kill -9 -"$submissinpid"
+kill -9 -"$submissionpid"
 
 # Kill off stragglers
-kill -9 -P $$
+pkill -9 -P $$
 
 # TODO: determine how to pass more detailed pc2sandbox.sh results back to PC2... Perhaps in a file...
 

--- a/scripts/pc2sandbox.sh
+++ b/scripts/pc2sandbox.sh
@@ -216,7 +216,7 @@ then
 	if ! rmdir $PC2_SANDBOX_CGROUP_PATH
 	then
 		DEBUG echo Cannot remove previous sandbox: $PC2_SANDBOX_CGROUP_PATH
-		exit $FAIL_INVALID_CGROUP_INSTALLATION
+		exit $FAIL_SANDBOX_ERROR
 	fi
 fi
 

--- a/scripts/pc2sandbox.sh
+++ b/scripts/pc2sandbox.sh
@@ -99,7 +99,7 @@ KillChildProcs()
 	# Kill off process group
 	if test -n "$submissionpid"
 	then
-		kill -9 -$submissionpid
+		pkill -9 -s $submissionpid
 	fi
 	# and... extra stragglers
 	pkill -9 -P $$

--- a/scripts/pc2sandbox_interactive.sh
+++ b/scripts/pc2sandbox_interactive.sh
@@ -145,9 +145,9 @@ KillChildProcs()
         # Kill off process group
         if test -n "$submissionpid"
         then
-                kill -9 -$submissionpid
+                pkill -9 -s $submissionpid
         fi
-        # and... extra stragglers
+        # and... extra stragglers with us as a parent
         pkill -9 -P $$
 }
 
@@ -413,6 +413,7 @@ do
 			if test -d /proc/$contestantpid
 			then
 				REPORT Contestant PID $submissionpid has not finished - killing it
+				# TODO: We should kill and wait for it here and print out the stats
 			fi
 			# This just determines if the program ran, not if it's correct.
 			# The result file has the correctness in it.

--- a/scripts/pc2sandbox_interactive.sh
+++ b/scripts/pc2sandbox_interactive.sh
@@ -294,7 +294,7 @@ then
 	if ! rmdir $PC2_SANDBOX_CGROUP_PATH
 	then
 		DEBUG echo Cannot purge old sandbox: $PC2_SANDBOX_CGROUP_PATH
-		exit $FAIL_INVALID_CGROUP_INSTALLATION
+		exit $FAIL_SANDBOX_ERROR
 	fi
 fi
 


### PR DESCRIPTION
### Description of what the PR does
1) Put submission in its own progress group (session) to make it easier to kill off later
2) Kill off all members of the process group upon termination
3) Kill off all processes that have the script as its parent (catches some stragglers)
4) Purge cgroup at startup to prevent left over stragglers from previous runs
5) CI: Add shell function to nicely print out resource usage for each test case
ex:
```
Resources used for this run:
   CPU ms  Limit ms    Wall ms   Memory Used Memory Limit
 2011.360  2000.000   2012.259      98971648   2147483648
The command was killed because it exceeded the CPU Time limit

```
6) CI: If process was killed due to a signal, show the signal number in the sandbox log
7) More robust reporting of time limit exceeded


Put the Issue Number in this section.
#810 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Ubuntu 22.04
Linux 5.19.0

### Precise steps for _testing_ the PR
1) Load up the `wfsharm/contests/wf46/systest0` contest
2) Replay the contest (exceedingly time consuming)
3) Note that contest plays through (previously it would hang after all the AJ's were occupied with infinite loop fork bombs that created separate process groups
To test CI's:
1) Load up a contest that has problems that use sandboxes (preferably some that have interactive problems such as the sample contest **interactve**
2) Submit runs
3) Judge runs
4) Look in the `executesite*` folder at the sandbox.log file, and if it's an interactive problem look in the `executesite*/reports` folder for per-case log files.


A typical report file looks like this for an interactive problem:
```
$ cat reports/testcase_004.log
Setting memory limit to 2048 MB
Starting: ./output_validator_out /home/ubuntu/pc2/current/config/guessingprimes/data/secret/04-random_1000.in /home/ubuntu/pc2/current/config/guessingprimes/data/secret/04-random_1000.ans interactive_feedback > fin < fout &
Started interactive validator PID 583391
Setting cpu limit to 10000000 microseconds (ulimit -t 10 )
Setting maximum user processes to 171
Putting 583376 into /sys/fs/cgroup/pc2/sandbox_pc2_550201 cgroup
Executing setsid taskset 0x08 /usr/bin/pypy3 ragnar-manual-begin.py < fin > fout
Contestant PID 583397 finished with status 0
Resources used for this run:
   CPU ms  Limit ms    Wall ms   Memory Used Memory Limit
 1092.647 10000.000   1129.340      54059008   2147483648
The command terminated normally.
Finished executing /usr/bin/pypy3 ragnar-manual-begin.py
/usr/bin/pypy3 exited with exit code 0
Waiting for interactive validator to finish...
Validator finishes with status 42
________________________________________

----------------------------------
Results XML File for testcase #4:
----------------------------------
<?xml version="1.0"?>
<result outcome="Accepted" security="174613XRSAM.4.txt"></result>
```

A typical report file looks like this for a timelimit exceeded run:

```
$ cat sandbox.log
checking PC2 CGroup V2 installation...
...done.
Removing existing sandbox to start clean
Purging cgroup /sys/fs/cgroup/pc2/sandbox_pc2_550201/cgroup.kill of processes
Creating sandbox /sys/fs/cgroup/pc2/sandbox_pc2_550201
checking memory limit
setting memory limit to 2048 MB
setting cpu limit to 5000000 microseconds (ulimit -t 5 )
setting maximum user processes to 170
putting 583976 into /sys/fs/cgroup/pc2/sandbox_pc2_550201 cgroup
Executing setsid taskset 0x08 /usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xss64m -Xms1920m -Xmx1920m Main
Killing off submission process group 583990 and all children
Resources used for this run:
   CPU ms  Limit ms    Wall ms   Memory Used Memory Limit
 5008.318  5000.000   5009.582      15613952   2147483648
The command was killed because it exceeded the CPU Time limit
Finished executing /usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xss64m -Xms1920m -Xmx1920m Main
/usr/bin/java exited with exit code 244


```