### PR TITLE
i881: update scoreboard JSON to CLICS 2022-07

### DIFF
--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSContestState.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSContestState.java
@@ -1,0 +1,94 @@
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.imports.clics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+/**
+ * CLICS ContestState JSON element.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ */
+
+//The following annotation tells the Jackson ObjectMapper not to include "type information" when it serializes
+//objects of this class (the default is to include the fully-qualified class name as an additional JSON element).
+//(Note that exclusion of such type information means that generated JSON cannot subsequently be accurately DESERIALIZED...)
+@JsonTypeInfo(use = Id.NONE)
+
+// TODO REFACTOR Use this class to replace package edu.csus.ecs.pc2.core.standings.json.ContestState
+public class CLICSContestState {
+
+    //    String    "finalized": "2021-04-19T01:30:6.337+0000", 
+    //    String    "started": "2021-04-19T00:00:0.000+0000", 
+    //    String    "thawed": "2021-04-19T01:30:6.337+0000", 
+    //    String    "frozen": "2021-04-19T01:00:0.000+0000", 
+    //    String    "ended": "2021-04-19T01:30:0.000+0000", 
+    //    String    "end_of_updates": "2021-04-19T01:30:6.337+0000"
+
+    @JsonProperty
+    private String finalized;
+
+    @JsonProperty
+    private String started;
+
+    @JsonProperty
+    private String thawed;
+
+    @JsonProperty
+    private String frozen;
+
+    @JsonProperty
+    private String ended;
+
+    @JsonProperty
+    private String end_of_updates;
+
+    public String getFinalized() {
+        return finalized;
+    }
+
+    public void setFinalized(String finalized) {
+        this.finalized = finalized;
+    }
+
+    public String getStarted() {
+        return started;
+    }
+
+    public void setStarted(String started) {
+        this.started = started;
+    }
+
+    public String getThawed() {
+        return thawed;
+    }
+
+    public void setThawed(String thawed) {
+        this.thawed = thawed;
+    }
+
+    public String getFrozen() {
+        return frozen;
+    }
+
+    public void setFrozen(String frozen) {
+        this.frozen = frozen;
+    }
+
+    public String getEnded() {
+        return ended;
+    }
+
+    public void setEnded(String ended) {
+        this.ended = ended;
+    }
+
+    public String getEnd_of_updates() {
+        return end_of_updates;
+    }
+
+    public void setEnd_of_updates(String end_of_updates) {
+        this.end_of_updates = end_of_updates;
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboard.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboard.java
@@ -1,0 +1,230 @@
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+
+package edu.csus.ecs.pc2.core.imports.clics;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.log.StaticLog;
+import edu.csus.ecs.pc2.core.standings.ContestStandings;
+import edu.csus.ecs.pc2.core.standings.ProblemSummaryInfo;
+import edu.csus.ecs.pc2.core.standings.TeamStanding;
+import edu.csus.ecs.pc2.core.standings.json.ProblemScoreRow;
+import edu.csus.ecs.pc2.core.standings.json.StandingScore;
+import edu.csus.ecs.pc2.core.standings.json.TeamScoreRow;
+
+//The following annotation tells the Jackson ObjectMapper not to include "type information" when it serializes
+//objects of this class (the default is to include the fully-qualified class name as an additional JSON element).
+//(Note that exclusion of such type information means that generated JSON cannot subsequently be accurately DESERIALIZED...)
+@JsonTypeInfo(use = Id.NONE)
+
+//The following annotation tells the Jackson ObjectMapper the order in which it should output fields when serializing 
+//objects of this class into JSON.
+@JsonPropertyOrder({"event_id","time","contest_time", "state", "rows"})
+
+/**
+ * A representation of CLICS scoreboard
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ *
+ */
+// TODO REFACTOR use this/CLICSScoreboard replace package edu.csus.ecs.pc2.core.standings.json.ScoreboardJsonModel
+public class CLICSScoreboard {
+
+    @JsonProperty
+    private String event_id;
+
+    @JsonProperty
+    private String contest_time;
+
+    @JsonProperty
+    private CLICSContestState state = new CLICSContestState();
+
+    @JsonProperty
+    @JsonTypeInfo(use = Id.NONE)
+    private List<TeamScoreRow> rows;
+
+    @JsonProperty
+    private String time;
+
+    @JsonCreator
+    public CLICSScoreboard() {
+        ; // empty constructor
+    }
+
+    public CLICSScoreboard(ContestStandings contestStandings) {
+
+        //            "event_id": "3ee531c5-9aa9-4bf8-8a93-a00e12ab2907", 
+        //            "contest_time": "1:30:06.337", 
+
+        setEvent_id(UUID.randomUUID().toString());
+        setContest_time("");
+
+        //            "finalized": "2021-04-19T01:30:6.337+0000", 
+        //            "started": "2021-04-19T00:00:0.000+0000", 
+        //            "unfrozen": "2021-04-19T01:30:6.337+0000", 
+        //            "frozen": "2021-04-19T01:00:0.000+0000", 
+        //            "ended": "2021-04-19T01:30:0.000+0000", 
+        //            "end_of_updates": "2021-04-19T01:30:6.337+0000"
+
+        state.setEnded("");
+        state.setFinalized("");
+        state.setFrozen("");
+        state.setStarted("");
+        state.setThawed("");
+        state.setEnd_of_updates("");
+
+        //   "rows": [
+        //   {
+        //            "team_id": 325958, 
+        //            "score": {
+        //              "total_time": 145, 
+        //              "num_solved": 12
+        //            }, 
+        // 
+        //            List<ProblemScoreRow> problems
+        // 
+        //            "problems": [
+        //              {
+        //                "solved": true, 
+        //                "num_judged": 1, 
+        //                "time": 12, 
+        //                "problem_id": "candlebox", 
+        //                "num_pending": 0
+        //              },
+
+        rows = new ArrayList<TeamScoreRow>();
+
+        List<TeamStanding> teamStand = contestStandings.getTeamStandings();
+        for (TeamStanding teamStanding : teamStand) {
+            TeamScoreRow row = new TeamScoreRow();
+
+            row.setTeam_id(toInt(teamStanding.getTeamId()));
+            row.setRank(toInt(teamStanding.getRank()));
+
+            StandingScore score = new StandingScore();
+            score.setNum_solved(toInt(teamStanding.getSolved()));
+            score.setTotal_time(toLong(teamStanding.getPoints(), 0));
+            row.setScore(score);
+
+            List<ProblemScoreRow> problemList = new ArrayList<ProblemScoreRow>();
+            for (ProblemSummaryInfo psi : teamStanding.getProblemSummaryInfos()) {
+                ProblemScoreRow scoreRow = new ProblemScoreRow();
+
+                //  <problem attempts="50" bestSolutionTime="13" id="3" lastSolutionTime="87" numberSolved="35" title="Careful Ascent"/>
+
+                scoreRow.setNum_judged(toInt(psi.getAttempts()));
+
+                String problemIdNumber = psi.getProblemId();
+                // TODO FIX must get shortname from Problem rather than using id
+                String problemShortName = "Id = " + problemIdNumber;
+                scoreRow.setProblem_id(problemShortName); // problem short name
+
+                scoreRow.setNum_pending(toInt(psi.getIsPending()));
+
+                scoreRow.setSolved(toBool(psi.getIsSolved(), false));
+
+                problemList.add(scoreRow);
+            }
+
+            row.setProblems(problemList);
+            rows.add(row);
+        }
+    }
+
+    private long toLong(String string, int defaultLong) {
+
+        try {
+            return Long.parseLong(string.trim().toLowerCase());
+        } catch (Exception e) {
+            return defaultLong;
+        }
+    }
+
+    private boolean toBool(String string, boolean defaultBool) {
+        try {
+            return Boolean.parseBoolean(string.trim().toLowerCase());
+        } catch (Exception e) {
+            return defaultBool;
+        }
+    }
+
+    /**
+     * Null safe convert to integer
+     * @param string
+     * @return integer in string, or zero if there is an error
+     */
+    private int toInt(String string) {
+        return Utilities.nullSafeToInt(string, 0);
+    }
+
+    public String getEvent_id() {
+        return event_id;
+    }
+
+    public void setEvent_id(String event_id) {
+        this.event_id = event_id;
+    }
+
+    public String getContest_time() {
+        return contest_time;
+    }
+
+    public void setContest_time(String contest_time) {
+        this.contest_time = contest_time;
+    }
+
+    public CLICSContestState getState() {
+        return state;
+    }
+
+    public void setState(CLICSContestState state) {
+        this.state = state;
+    }
+
+    public List<TeamScoreRow> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<TeamScoreRow> rows) {
+        this.rows = rows;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+    /**
+     * Returns a JSON string representation of this ScoreboardJsonModel object.
+     */
+    @Override
+    public String toString() {
+
+        String retStr = "Undefined";
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            retStr = mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            StaticLog.getLog().log(Level.WARNING, "Error creating JSON string for CLICSScoreboard " + e.getMessage(), e);
+        }
+
+        return retStr;
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/report/ScoreboardJSONReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/ScoreboardJSONReport.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2020 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.FileOutputStream;
@@ -9,10 +9,12 @@ import java.util.GregorianCalendar;
 import edu.csus.ecs.pc2.VersionInfo;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.imports.clics.CLICSScoreboard;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.services.core.ScoreboardJson;
+import edu.csus.ecs.pc2.core.standings.ContestStandings;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
 
 /**
  * Print CLICS API Scoreboard JSON
@@ -95,8 +97,9 @@ public class ScoreboardJSONReport implements IReport {
 
     public String[] createReport(Filter inFilter) {
         try {
-            ScoreboardJson scoreboardJson = new ScoreboardJson();
-            String json = scoreboardJson.createJSON(contest);
+            ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(contest);
+            CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contestStandings);
+            String json = clicsScoreboard.toString();
             String[] sa = { json };
             return sa;
         } catch (Exception e) {


### PR DESCRIPTION
### Description of what the PR does

This change upgrades the Scoreboard JSON report to the standard.

The standard is at: https://ccs-specs.icpc.io/2022-07/contest_api#scoreboard-format

Adds event feed wrapper and rows array wrapper

### Issue which the PR addresses

#881

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.19044.2130]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Create a Scoreboard JSON report

Does the output JSON have the following 5 "new" elements?

1 contest_time
2 event_id
3 rows  - array of team scoring rows
4 state
5 time



A skel sample of new elements
```
{
    "contest_time": "5:10:26.783",
    "event_id": "23296",
    "rows": [
        {
            "problems": [
            ...

            "rank": 1,
            "score": {
                "num_solved": 11,
                "total_time": 1443
            },
            "team_id": "48"
        },
        ...

    "state": {
        "end_of_updates": null,
        "ended": "2023-05-29T14:46:55.000-04:00",
        "finalized": "2023-05-29T14:57:19.750-04:00",
        "frozen": "2023-05-29T13:46:55.000-04:00",
        "started": "2023-05-29T09:46:55.000-04:00",
        "thawed": null
    },
    "time": "2023-05-29T14:57:21.783-04:00"
}
```

fixes #811 