### PR TITLE
I796 Allow modification or addition of institution codes from accounts TSV file

### DIFF
--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -169,6 +169,8 @@ public final class Constants {
     public static final String COUNTRY_CODE_COLUMN_NAME = "countrycode";
 
     public static final String SCORING_ADJUSTMENT_COLUMN_NAME = "scoreadjustment";
+    
+    public static final String INST_CODE_COLUMN_NAME = "institution";
 
     public static final String DEFAULT_INSTITUTIONNAME = "undefined";
 

--- a/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
@@ -105,6 +105,10 @@ public class LoadAccounts {
         account.setInstitutionCode(new String(accountClean.getInstitutionCode()));
         account.setInstitutionName(new String(accountClean.getInstitutionName()));
         account.setInstitutionShortName(new String(accountClean.getInstitutionShortName()));
+        String [] existingMembers = accountClean.getMemberNames();
+        if(existingMembers != null) {
+            account.setMemberNames(StringUtilities.cloneStringArray(existingMembers));
+        }
         
         // now start changing
         if (passwordColumn != -1 && values.length > passwordColumn) {

--- a/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
@@ -354,7 +354,7 @@ public class LoadAccounts {
     /**
      * Returns a list of accounts updated from the input load accounts file.
      * 
-     * @see #fromTSVFile(String, Account[], Group[])
+     * @see #fromTSVFile(IInternalContest, String)
      * 
      * @param contest
      * @param filename updates model accounts from file 
@@ -562,6 +562,20 @@ public class LoadAccounts {
         return accountMap.values().toArray(new Account[accountMap.size()]);
     }
 
+    /**
+     * Legacy routine for unit tests.  Does not take an IInternalContest, meaning, institution codes will not work since we
+     * have to validate them.
+     *  
+     * @param filename
+     * @param existingAccounts
+     * @param groupList
+     * @return
+     * @throws Exception
+     */
+    public Account[] fromTSVFile(String filename, Account[] existingAccounts, Group[] groupList) throws Exception  {
+        return(fromTSVFile(null, filename, existingAccounts, groupList));
+    }
+    
     /**
      * Update accounts from accounts load file.
      * 
@@ -789,12 +803,19 @@ public class LoadAccounts {
         return(found);
     }
     
+    /**
+     * Load the cdp institutions.tsv file, if present.  This is so we can validate institution codes supplied.
+     * 
+     * @param contest - may be null, in which case we do not load institutions, and any attempt to change/set a new institution code will fail later
+     */
     public static void loadInstitutions(IInternalContest contest) {
-        if(!loadInstitutions(contest.getContestInformation().getAdminCDPBasePath() + File.separator + LoadICPCTSVData.INSTITUTIONS_FILENAME)) {
-            if(!loadInstitutions(contest.getContestInformation().getJudgeCDPBasePath() + File.separator + LoadICPCTSVData.INSTITUTIONS_FILENAME)) {
-                StaticLog.warning("Can not load " + LoadICPCTSVData.INSTITUTIONS_FILENAME + " from "
-                    + contest.getContestInformation().getAdminCDPBasePath() + "or "
-                    + contest.getContestInformation().getJudgeCDPBasePath());
+        if(contest != null) {
+            if(!loadInstitutions(contest.getContestInformation().getAdminCDPBasePath() + File.separator + LoadICPCTSVData.INSTITUTIONS_FILENAME)) {
+                if(!loadInstitutions(contest.getContestInformation().getJudgeCDPBasePath() + File.separator + LoadICPCTSVData.INSTITUTIONS_FILENAME)) {
+                    StaticLog.warning("Can not load " + LoadICPCTSVData.INSTITUTIONS_FILENAME + " from "
+                        + contest.getContestInformation().getAdminCDPBasePath() + "or "
+                        + contest.getContestInformation().getJudgeCDPBasePath());
+                }
             }
         }
     }

--- a/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
@@ -423,10 +423,8 @@ public class LoadAccounts {
                 existingAccountsMap.put(existingAccounts[i].getClientId(), existingAccounts[i]);
             }
         }
-        groups.clear();
-        for (Group group : groupList) {
-            groups.put(group.toString(),group);
-        }
+        createGroupMap(groupList);
+        
         int lineCount = 0;
         String[] columns;
         BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(filename), "UTF8"));
@@ -648,10 +646,8 @@ public class LoadAccounts {
                 existingAccountsMap.put(existingAccounts[i].getClientId(), existingAccounts[i]);
             }
         }
-        groups.clear();
-        for (Group group : groupList) {
-            groups.put(group.toString(),group);
-        }
+        createGroupMap(groupList);
+        
         int lineCount = 0;
         String[] columns;
         BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(filename), "UTF8"));
@@ -780,6 +776,25 @@ public class LoadAccounts {
         in.close();
         in = null;
         return accountMap.values().toArray(new Account[accountMap.size()]);
+    }
+    
+    /**
+     * Creates a hash map of group ids and group display names to the group object
+     * Used for mapping TSV group column value to a group
+     * 
+     * @param groupList List of groups used to populate the map
+     * @throws NumberFormatException if getGroupId() does not return an int (should not happen)
+     */
+    private void createGroupMap(Group[] groupList)
+    {
+        groups.clear();
+        for (Group group : groupList) {
+            groups.put(group.toString(),group);
+            //accept the group ID in the TSV as well as the group display name
+            //this should never throw an exception since getGroupId() returns 'int'
+            //if it does, we want to abort the account load since something is really wrong.
+            groups.put(Integer.toString(group.getGroupId()), group);
+        }        
     }
     
     /**

--- a/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadAccounts.java
@@ -358,7 +358,7 @@ public class LoadAccounts {
     /**
      * Returns a list of accounts updated from the input load accounts file.
      * 
-     * @see #fromTSVFile(IInternalContest, String)
+     * @see #fromTSVFile(IInternalContest, String, Account[], Group[])
      * 
      * @param contest
      * @param filename updates model accounts from file 
@@ -409,6 +409,7 @@ public class LoadAccounts {
 
      * </pre>
      * 
+     * @param contest needed if institutions are to be used
      * @param filename
      * @param existingAccounts 
      * @param groupList
@@ -839,6 +840,13 @@ public class LoadAccounts {
         }
     }
 
+    /**
+     * Set an account's institution (school) information (formal and normal names based on institution ID.
+     * 
+     * @param account The account whose institution is to be set
+     * @param instCode Institution code, eg. 1474, INST-1474 or INST-U-1474 (all work - but
+     *        what a mess.  Someone has to decide what an institution code IS.
+     */
     private static void setInstitutionInformation(Account account, String instCode) {
         try {
             String [] institutionInfo = ICPCTSVLoader.getInstitutionNames(instCode);

--- a/src/edu/csus/ecs/pc2/core/imports/LoadICPCTSVData.java
+++ b/src/edu/csus/ecs/pc2/core/imports/LoadICPCTSVData.java
@@ -39,6 +39,8 @@ public class LoadICPCTSVData implements UIPlugin {
     public static final String GROUPS_FILENAME = "groups.tsv";
 
     private static final String ACCOUNTS_FILENAME = "accounts.tsv";
+    
+    public static final String INSTITUTIONS_FILENAME = "institutions.tsv";
 
     private String teamsFilename = "";
 
@@ -82,7 +84,7 @@ public class LoadICPCTSVData implements UIPlugin {
 
         if (checkFiles(filename)) {
 
-            String instFilename = groupsFilename.replaceFirst(GROUPS_FILENAME,"institutions.tsv");
+            String instFilename = groupsFilename.replaceFirst(GROUPS_FILENAME, INSTITUTIONS_FILENAME);
             // this must be loaded before accounts, and no harm before groups
             ICPCTSVLoader.loadInstitutions(instFilename);
             Group[] groups = ICPCTSVLoader.loadGroups(groupsFilename, contest.getGroups());

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -3480,7 +3480,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
         Group[] groups = contest.getGroups();
 
-        Account[] accList = loader.fromTSVFileWithNewAccounts(loadfilename, teamAccounts, groups);
+        Account[] accList = loader.fromTSVFileWithNewAccounts(contest, loadfilename, teamAccounts, groups);
 
         List<Account> newAccounts = new ArrayList<Account>();
         List<Account> updatedAccount = new ArrayList<Account>();

--- a/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
@@ -158,8 +158,8 @@ public final class ICPCTSVLoader {
         String institutionFormalName = "";
         if (fields.length == TEAM2_TSV_FIELDS) {
             institutionCode = fields[fieldnum++];
-            if (institutionsMap.containsKey(institutionCode)) {
-                String[] fieldArray = institutionsMap.get(institutionCode);
+            String[] fieldArray = getInstitutionNames(institutionCode);
+            if (fieldArray != null) {
                 institutionFormalName = fieldArray[1];
                 institutionName = fieldArray[2];
             }
@@ -396,6 +396,35 @@ public final class ICPCTSVLoader {
         }
     }
     
+    /**
+     * Returns the corresponding institution information for the supplied institution code.
+     * If the code is not recognized, a null array is returned.
+     * Due to the non-specificity of the format of an institution code, we have to check if
+     * it has the INST-U- or INST- prefixes, if so, remove them and try again.
+     * The map must be filled in via loadInstitutions() first or it will always return false.
+     * 
+     * @param instCode (number, INST-U-number or INST-number)
+     * @return array of 3 strings: [0]=code, [1]=formal name [2]=short name, or null if not found
+     */
+    public static String[] getInstitutionNames(String instCode) {
+        String[] names = null;
+        
+        if(institutionsMap.containsKey(instCode)) {
+            names = institutionsMap.get(instCode);
+        } else {
+            // ugh.  because no one can decide on what an institution ID is, we have this nonsense.
+            if (instCode.startsWith("INST-U-")) {
+                instCode = instCode.substring(7);
+            }
+            if (instCode.startsWith("INST-")) {
+                instCode = instCode.substring(5);
+            }
+            if(institutionsMap.containsKey(instCode)) {
+                names = institutionsMap.get(instCode);
+            }
+        }
+        return(names);
+    }
     
     public static HashMap<Integer, String> loadPasswordsFromAccountsTSV(String filename) throws Exception {
         String[] lines = CCSListUtilities.filterOutCommentLines(Utilities.loadFile(filename));

--- a/src/edu/csus/ecs/pc2/ui/ReviewAccountLoadFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/ReviewAccountLoadFrame.java
@@ -252,7 +252,7 @@ public class ReviewAccountLoadFrame extends JFrame implements UIPlugin {
         getAcceptButton().setEnabled(false);
         getShowAllAccountsCheckBox().setSelected(false);
         try {
-            accounts = loadAccounts.fromTSVFile(filename, getAllAccounts(), contest.getGroups());
+            accounts = loadAccounts.fromTSVFile(contest, filename, getAllAccounts(), contest.getGroups());
             refreshList();
         } catch (Exception e) {
             log.warning(e.getMessage());


### PR DESCRIPTION
### Description of what the PR does
It is sometimes necessary to add or change a team's institution information after a contest has been loaded.  Before this PR there was no way to do that without reloading the entire contest from scratch.  

From the _Accounts_ tab on an administrator client, the _Load_ button allows you to load updated team account information using a **TSV** file after a contest has started.   A new column, `institution`, has been added that can now be specified in the **TSV** file.  This column may contain the new institution code (_number_, _INST-U-number_, _INST-number_) for the team.

This PR also includes a few CI's:
CI: fix bug where institution information was not being copied if accounts were loaded after the contest was created
CI: create a constant for the institutions **TSV** file: `institutions.tsv`
CI: allow group ID to be specified in addition to group name in accounts **TSV** files
CI: copy member names on clone of an account during an account update

### Issue which the PR addresses
Fixes #796 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
OS              : Windows 11 10.0 (amd64)
Java Version    : 1.8.0_321

### Precise steps for _testing_ the PR 
1) From scratch, load a contest that has `teams2.tsv`, `groups.tsv` and an `institutions.tsv` file (sample files have been attached that you can put in `samps/contests/sumithello/config` if you so desire.  There are currently no samples that have an `institutions.tsv` file.  I wonder how it was tested when it was added in the first place?)
[institutions.txt](https://github.com/pc2ccs/pc2v9/files/12767683/institutions.txt)
[groups.txt](https://github.com/pc2ccs/pc2v9/files/12767754/groups.txt)
[teams2.txt](https://github.com/pc2ccs/pc2v9/files/12767756/teams2.txt)
Yes, all those files are needed.  Do not ask why. I did not write the original code.  Seems to me that you should be able to load  groups without teams and institutions without groups or teams, etc. but no.  It's all or nothing.  (you'll have to rename them from .txt to .tsv).
2) Create a **TSV** file to update some teams, I have attached one here for your convenience:
[accts_update.txt](https://github.com/pc2ccs/pc2v9/files/12767842/accts_update.txt)
(rename it `.tsv`)  This file updates **team1** and **team3** with, among other things, _institution_ information.
3) Open an administrator client and on the _Accounts_ tab, _Load_ the `accts_update.tsv` file.
4) _Accept_ the changes
5) Generate an accounts report and look for the institution names for **team1** and **team3**.  Compare against **team2**.  Note that **team1** has an institution name set (_Southern Connecticut State University_) as well as an institution code (_INST-1751_).  Similarly, **team3** has an institution name set (_Ramapo College of New Jersey_) as well as an institution code (_INST-1521_).  **Team2** and the other teams do not have any institution information since the `accts_update.tsv` file only updated team1 and team3.

Note: Yes, writing this PR and testing the test procedure, gathering the necessary sample files, took longer than making the fix described in the PR. *sigh*