### PR TITLE
I816 coding style guidelines does not exist. hyperlink broken

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -70,7 +70,7 @@ For this reason, we have adopted a set of coding guidelines which we expect all 
 everyone on the original PC^2 core development team agreed on all the elements of our guidelines.  However, everyone did agree that
 it was more important to _have a set of standard guidelines_ than it was to have unanimous agreement on what those guidelines are.)
 
-Please see our [PC^2 Coding Style Guidelines document](./CodingStyle.md) for insight into what is expected of code contributions to PC^2.
+Please see our [PC^2 Development Standards](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards) wiki page for insight into what is expected of code contributions to PC^2 -- in particular, check out the sections on [Java Code](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#java-code), [JavaDoc](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#javadoc), and [Junits](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#junits).
 
 ## <a name="feedback"></a> Providing Feedback
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -33,7 +33,7 @@ There are various types of Client modules:
   * Each contest Judge (human or automated) runs a **Judge** module.
   * Each contest Team runs either a **Team** module or interfaces with the system via a browser using a **Web Client Team** module.
   * Scoreboards are displayed by a **Scoreboard** module.
-  * An **Event Feed** module can be used to generate a [CLICS Event Feed](https://clics.ecs.baylor.edu/index.php?title=Main_Page).
+  * An **Event Feed** module can be used to generate a [CLICS Event Feed](https://ccs-specs.icpc.io/2022-07/contest_api#event-feed).
 
 Clients communicate _only_ with the Server module for their site -- never with any other client nor with any server but the one
 designated as their "site server" (which is declared via a configuration file named **pc2v9.ini**).

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -124,7 +124,7 @@ start by reading about the [PC2 Development Environment](https://github.com/pc2c
 
 When you have completed the above steps and come up with a bug fix or enhancement, the final step is to submit a [Pull Request](https://help.github.com/en/articles/about-pull-requests).  Pull Requests (PR's) allow you to submit a request to the PC^2 maintainers to merge your code into the PC^2 master branch and thus make it part of an upcoming public distribution of PC^2.
 
-Prior to submitting a PR, be sure that you have complied with all the preceding steps, including following the [PC^2 Coding Style Guidelines](./CodingStyle.md) and the creation of automated tests (e.g. JUnits) which demonstrate that your code works as intended (failure to adhere to these steps will almost certainly result in rejection of your PR, regardless of how "cool" the new feature might be).
+Prior to submitting a PR, be sure that you have complied with all the preceding steps, including following the [PC^2 Development Standards guidelines](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards) regarding code and documentation standards as well as the creation of automated tests (e.g. JUnits) which demonstrate that your code works as intended (failure to adhere to these steps will almost certainly result in rejection of your PR, regardless of how "cool" the new feature might be).
 
 To submit a PR, follow the steps in the GitHub [Creating a Pull Request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) guide. Specifically, these steps are:
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -70,7 +70,7 @@ For this reason, we have adopted a set of coding guidelines which we expect all 
 everyone on the original PC^2 core development team agreed on all the elements of our guidelines.  However, everyone did agree that
 it was more important to _have a set of standard guidelines_ than it was to have unanimous agreement on what those guidelines are.)
 
-Please see our [PC^2 Development Standards](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards) wiki page for insight into what is expected of code contributions to PC^2 -- in particular, check out the sections on [Java Code](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#java-code), [JavaDoc](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#javadoc), and [Junits](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#junits).
+Please see our [PC^2 Development Standards](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards) wiki page for insight into what is expected of code contributions to PC^2 -- in particular, check out the sections on [Java Code](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#java-code), [JavaDoc](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#javadoc), and [JUnits](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards#junits).
 
 ## <a name="feedback"></a> Providing Feedback
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -99,9 +99,9 @@ If you are interested in doing more than providing feedback -- you want to contr
 ### <a name="firstcodecontribution"></a>  Your First Code Contribution
 
 Unsure how to begin contributing to PC^2? You can start by looking through the PC^2 [Issues List](https://github.com/pc2ccs/pc2v9/issues) for
-issues labeled `beginner` and `help-wanted`.  
+issues labeled `good first issue`, `beginner` and `help-wanted`.  
 
-* `Beginner` issues should only require a few lines of code, and a test or two.
+* `Good First Issue` and `Beginner` issues should only require a few lines of code, and a test or two.
 * `Help-wanted` issues are items which are likely to be a bit more involved than `beginner` issues.
 
 You can also learn a lot about how to contribute to PC2 by spending some time looking through the [PC2V9 Wiki](https://github.com/pc2ccs/pc2v9/wiki).


### PR DESCRIPTION
### Description of what the PR does

Replaces the bad links to a non-existent document (`CodingStyle.md`) in the `Contributing.md` top-level description file with links to appropriate sections of existing documentation.

At some point in the past, many of the PC2 Wiki pages from the old CSUS ECS wiki were converted to GitHub wiki pages.  At the time that was done, it was anticipated that a new "CodingStyle" document (wiki page) would also be created.  However, that never happened.  I have spent hours combing the old ECS wiki/dev_wiki pages and found no such document; the closest I found was [this page](https://pc2.ecs.csus.edu/devwiki/index.php/Development_Standards) which mentions a few things about JUnits and Java Code.  _All_ of the things mentioned on that page have already been included in various sections of the much larger [Development Standards page](https://github.com/pc2ccs/pc2v9/wiki/Development-Standards), so this PR replaces the bad links to the (non-existent) page with links to the appropriate section of that document.

The PR also includes a CI step of adding to the `Contributing.md` file a couple of references to the GitHub "Good First Issue" label, which didn't exist at the time the `Contributing.md` document was first created.

### Issue which the PR addresses

Fixes #816 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 11, Eclipse Version: 2023-03 (4.27.0) Build id: 20230309-1520

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

- Open the PC2 "Contributing" document at https://github.com/clevengr/pc2v9/blob/i816_Coding_Style_Guidelines_Does_not_Exist._Hyperlink_Broken/CONTRIBUTING.MD.
- Scroll down to the `Coding Style` section (or just click on the `Coding Style` link in the first section of the document).
- In the last sentence under `Coding Style`, click on each of the (now four) links and verify that each one of them links to a valid page.
- CI: scroll down to the `Your First Code Contribution` section and verify that the inclusion of the label `good first issue` is present and that the section reads properly.