### PR TITLE
i831 dotimedcompile.sh was missing from package distribution

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!--  Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau. -->
+<!--  Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau. -->
 <project name="package-pc2v9" default="archives" basedir=".">
     
 	<!--
@@ -88,6 +88,7 @@
                 <include name="**/distribute_score"/>
             </zipfileset>
             <zipfileset dir="${intscripts.dir}" filemode="755" prefix="${release}/scripts">
+                <include name="**/dotimedcompile.sh"/>
                 <include name="**/pc2sandbox.sh"/>
                 <include name="**/pc2syscheck.sh"/>
                 <include name="**/pc2syscheck.cmd"/>


### PR DESCRIPTION
### Description of what the PR does
Add `scripts/dotimedcompile.sh` to package.xml

### Issue which the PR addresses
Fixed #831 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ubuntu 22.04.3

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Run the ANT `package.xml `and generate a distribution
2) Perform a directory listing of the zip and/or tar.gz files produced in the `dist `folder.
3) The `pc2-9.9build\scripts\dotimedcompile.sh` file should be there
<img width="358" alt="image" src="https://github.com/pc2ccs/pc2v9/assets/5657363/8eda0301-71f6-466b-8d50-51ca5f2eff86">
