### PR TITLE
i835: add EWTeam deprecation notices to ewrun and ewrun.bat scripts.

### DIFF
--- a/projects/EWTeam/scripts/ewrun
+++ b/projects/EWTeam/scripts/ewrun
@@ -4,6 +4,12 @@
 # Author : pc2@ecs.csus.edu
 #
 
+echo ""
+echo "Warning: EWTeam is deprecated and will be removed in an upcoming version of PC^2."
+echo "It has been superseded by the "Web Team Interface (WTI)" project;"
+echo "  see Appendix N in the PC^2 Contest Administrator's Guide for details on using WTI as a web-based interface for teams."
+echo ""
+
 . `dirname $0`/ewenv
 
 # MacOS or not

--- a/projects/EWTeam/scripts/ewrun.bat
+++ b/projects/EWTeam/scripts/ewrun.bat
@@ -5,9 +5,9 @@ rem Purpose: Start the ew Team server/java bridge
 rem Author : pc2@ecs.csus.edu
 
 echo.
-echo Warning: EWTeam is deprecated and will be removed in an upcoming version of PC^2.  
+echo Warning: EWTeam is deprecated and will be removed in an upcoming version of PC^^2.  
 echo It has been superseded by the "Web Team Interface (WTI)" project; 
-echo   see Appendix N in the PC^2 Contest Administrator's Guide for details on using WTI as a web-based interface for teams.
+echo   see Appendix N in the PC^^2 Contest Administrator's Guide for details on using WTI as a web-based interface for teams.
 echo.
 
 rem Windows 2000 and beyond syntax

--- a/projects/EWTeam/scripts/ewrun.bat
+++ b/projects/EWTeam/scripts/ewrun.bat
@@ -4,6 +4,12 @@ REM Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, 
 rem Purpose: Start the ew Team server/java bridge 
 rem Author : pc2@ecs.csus.edu
 
+echo.
+echo Warning: EWTeam is deprecated and will be removed in an upcoming version of PC^2.  
+echo It has been superseded by the "Web Team Interface (WTI)" project; 
+echo   see Appendix N in the PC^2 Contest Administrator's Guide for details on using WTI as a web-based interface for teams.
+echo.
+
 rem Windows 2000 and beyond syntax
 set EWBIN=%~dp0
 if exist %EWBIN%\ewenv.bat goto :continue


### PR DESCRIPTION
### Description of what the PR does

Adds "deprecation warning" messages to `ewrun` and `ewrun.bat`, the scripts which are used to start the EWTeam (actually, the "JavaBridge" which is the server for EWTeam browser requests).

### Issue which the PR addresses
Fixes #835 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 11.

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Execute the `ewrun` and `ewrun.bat` scripts at Linux and Windows command lines, respectively; verify that a "Warning" message about EWTeam deprecation is displayed prior to the script continuing.
