### PR TITLE
Change wording for interactive validator choice for Custom Output Validators

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -5630,7 +5630,7 @@ public class EditProblemPane extends JPanePlugin {
 
     private JRadioButton getUseInteractiveRadioButton() {
         if (rdbtnUseInteractive == null) {
-            rdbtnUseInteractive = new JRadioButton("Uses CLICS Interactive Problem Interface");
+            rdbtnUseInteractive = new JRadioButton("Use CLICS Interactive Problem Interface");
             rdbtnUseInteractive.setSelected(false);
             rdbtnUseInteractive.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
Change "Uses CLICS Interactive Problem Interface" to "Use CLICS Interactive Problem Interface.

### Description of what the PR does
Changes radio button choice wording for interactive validator.

### Issue which the PR addresses
Fixes #848 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
All

### Precise steps for _testing_ the PR
Open an adminstrator client.
Select the problems tab
Select a problem and edit it.
Select the Output Validator tab
Notice the consistent wording for the radio button choices for Customer (User-supplied) Validator.

![image](https://github.com/pc2ccs/pc2v9/assets/5657363/71990dc1-4063-458a-9ef0-f612b5646f01)
