### PR TITLE
I850 - Validate that memory limit is non-negative in sandbox configuration for a problem

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -1883,6 +1883,17 @@ public class EditProblemPane extends JPanePlugin {
         }
         
         
+        // verify that the memory limit is a non-negative number 
+        try {
+            int memLimit = Integer.parseInt(getProblemSandboxPane().getPC2SandboxOptionMemLimitTextbox().getText().trim());
+            if (memLimit < 0) {
+                showMessage("Memory limit value must be greater than or equal to zero.");
+                return false;
+            }
+        } catch (NumberFormatException e) {
+            showMessage("Memory limit must be a non-negative number");
+            return false;
+        }
 
         // verify that if the PC2 Validator is selected, an option has been chosen
         if (getUsePC2ValidatorRadioButton().isSelected()) {


### PR DESCRIPTION
### Description of what the PR does
Add a test in `EditProblemPane.validateProblemFields() `to make sure that the memory limit specified on the **Sandbox** tab is valid.
Note that this test is ALWAYS performed, even if a sandbox is not selected for the problem.  It is possible that the user selected a sandbox, entered a negative value, then de-selected a sandbox.  We STILL want to issue an error here so we don't have any future issues with the memory limit.  Note that this scenario would require the user to perform the above sequence, so they went out of their way to put a negative value there, which we simply will not permit.

### Issue which the PR addresses
Fixes #850 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
All.
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Start an administrator client
2. Edit a problem.
3. Select the **Sandbox** tab.
4. Select the "_Use PC^2 Sandbox (not available on Windows)_" radio button.
5. Enter a negative value in the _Memory Limit (MB):_ edit text box.
6. Press the **Update** button.
7. Observe the error dialog that is presented.
<img width="642" alt="image" src="https://github.com/pc2ccs/pc2v9/assets/5657363/6ad05b91-0c3c-4668-ae6e-3655d87ac632">


