### PR TITLE
i859: update button titles and tool tips

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/QuickJudgePane.java
+++ b/src/edu/csus/ecs/pc2/ui/QuickJudgePane.java
@@ -578,7 +578,8 @@ public class QuickJudgePane extends JPanePlugin implements UIPlugin {
     private JButton getJudgementSubmittedButton() {
         if (judgementSubmittedButton == null) {
             judgementSubmittedButton = new JButton();
-            judgementSubmittedButton.setText("Submit");
+            judgementSubmittedButton.setToolTipText("Update judgements on selected runs");
+            judgementSubmittedButton.setText("Update judgement");
             judgementSubmittedButton.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     judgeSelectedRuns();
@@ -763,6 +764,7 @@ public class QuickJudgePane extends JPanePlugin implements UIPlugin {
     private JButton getRejudgeButton() {
         if (rejudgeButton == null) {
             rejudgeButton = new JButton("Rejudge");
+            rejudgeButton.setToolTipText("Rejudge selected runs");
             rejudgeButton.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
 


### PR DESCRIPTION
### Description of what the PR does

On Judging Utilities tab update component names and tool tips

### Issue which the PR addresses

#859 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Microsoft Windows [Version 10.0.22621.2428]

java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

start server
start admin
Run Contest tab
Judging Utilities tab

Changes
Rename Submit button "Update judgement"
Add tooltip "Rejudge selected runs" to Rejudge button
Add tooltip "Update judgements on selected runs" to Update judgement

