### PR TITLE
I867: Renamed all instances of ExportFilesUtiltiites to ExportFilesUtilities

### DIFF
--- a/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
@@ -19,7 +19,7 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
 import edu.csus.ecs.pc2.services.core.ScoreboardJson;
 
-public class ExportFilesUtiltiites {
+public class ExportFilesUtilities {
 
     /**
      * Write contest results files to directory.

--- a/src/edu/csus/ecs/pc2/core/report/ResultsExportReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/ResultsExportReport.java
@@ -152,7 +152,7 @@ public class ResultsExportReport implements IReport {
         String scoreboardJsonFilename = getPc2ResultsDir() + File.separator + Constants.SCOREBOARD_JSON_FILENAME;
         String awardsFileName = getPc2ResultsDir() + File.separator + Constants.AWARDS_JSON_FILENAME;
         
-        ExportFilesUtiltiites.writeResultsFiles(contest, getPc2ResultsDir());
+        ExportFilesUtilities.writeResultsFiles(contest, getPc2ResultsDir());
 
         String finalizedStatus = "No.  (Warning - contest is not finalized)";
         

--- a/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
+++ b/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
@@ -35,7 +35,7 @@ import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.ClientSettings;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.core.report.ExportFilesUtiltiites;
+import edu.csus.ecs.pc2.core.report.ExportFilesUtilities;
 import edu.csus.ecs.pc2.core.report.ResultsCompareReport;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
 
@@ -360,7 +360,7 @@ public class ResultsComparePane extends JPanePlugin {
         }
         
         try {
-             String[] filesCreated = ExportFilesUtiltiites.writeResultsFiles(getContest(), pc2ResultsDirectory);
+             String[] filesCreated = ExportFilesUtilities.writeResultsFiles(getContest(), pc2ResultsDirectory);
              
              List<String> messageLines = new ArrayList<String>();
              messageLines.add(    "Created results files");


### PR DESCRIPTION
### Description of what the PR does
Renames all instances of the class ExportFilesUtiltiites to ExportFilesUtilities

### Issue which the PR addresses
Fixes #867

### Environment in which the PR was developed (OS, IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
No change in code behavior, just refactored. To test build and execute all the unit tests with success.