### PR TITLE
i_872 class scoreboard utilites should be renamed using proper spelling

### DIFF
--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilities.java
@@ -35,7 +35,7 @@ import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.security.Permission.Type;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.standings.TeamStanding;
 import edu.csus.ecs.pc2.core.standings.json.ScoreboardJsonModel;
 import edu.csus.ecs.pc2.core.standings.json.StandingScore;
@@ -124,7 +124,7 @@ public class CLICSAwardUtilities {
         Map<Group, ClientId> groupWinners = new HashMap<Group, ClientId>();
         
         try {
-            ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(contest);
+            ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
 
             List<TeamStanding> teamStands = contestStandings.getTeamStandings();
             for (TeamStanding teamStanding : teamStands) {
@@ -211,7 +211,7 @@ public class CLICSAwardUtilities {
 
     public static void addMedals(IInternalContest contest, List<CLICSAward> list) throws JsonParseException, JsonMappingException, JAXBException, IllegalContestState, IOException {
 
-        ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(contest);
+        ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
         ScoreboardJsonModel model = new ScoreboardJsonModel(contestStandings);
 
 //        List<TeamScoreRow> rows = model.getRows();
@@ -313,7 +313,7 @@ public class CLICSAwardUtilities {
      */
     public static void addWinner(IInternalContest contest, List<CLICSAward> list) throws JsonParseException, JsonMappingException, JAXBException, IllegalContestState, IOException {
 
-        ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(contest);
+        ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
         ScoreboardJsonModel model = new ScoreboardJsonModel(contestStandings);
 
         String winnerId = null;

--- a/src/edu/csus/ecs/pc2/core/report/ScoreboardJSONReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/ScoreboardJSONReport.java
@@ -14,7 +14,7 @@ import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 
 /**
  * Print CLICS API Scoreboard JSON
@@ -97,7 +97,7 @@ public class ScoreboardJSONReport implements IReport {
 
     public String[] createReport(Filter inFilter) {
         try {
-            ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(contest);
+            ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
             CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contestStandings);
             String json = clicsScoreboard.toString();
             String[] sa = { json };

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -45,7 +45,7 @@ import edu.csus.ecs.pc2.core.model.Run.RunStates;
 import edu.csus.ecs.pc2.core.security.Permission;
 import edu.csus.ecs.pc2.core.security.PermissionList;
 import edu.csus.ecs.pc2.core.security.Permission.Type;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.util.IMemento;
 import edu.csus.ecs.pc2.core.util.XMLMemento;
 import edu.csus.ecs.pc2.util.ScoreboardVariableReplacer;
@@ -1024,7 +1024,7 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
             if (account.getClientId().getClientType() == ClientType.Type.TEAM && account.isAllowed(Permission.Type.DISPLAY_ON_SCOREBOARD)) {
                 
                 if (divisionNumber != null) {
-                    String div = ScoreboardUtilites.getDivision(theContest, account.getClientId());
+                    String div = ScoreboardUtilities.getDivision(theContest, account.getClientId());
                     if (!divisionNumber.toString().trim().equals(div.trim())) {
                         /**
                          * If this account is NOT in the same division as divisionNumber then do not add StandingsRecord, skip to next account.

--- a/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
@@ -32,7 +32,7 @@ import edu.csus.ecs.pc2.core.model.RunUtilities;
 import edu.csus.ecs.pc2.core.model.Site;
 import edu.csus.ecs.pc2.core.security.Permission;
 import edu.csus.ecs.pc2.core.security.PermissionList;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.util.IMemento;
 import edu.csus.ecs.pc2.core.util.XMLMemento;
 import edu.csus.ecs.pc2.util.ScoreboardVariableReplacer;
@@ -172,7 +172,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         for(Account av : allAccountVector) {
             if(av.isAllowed(Permission.Type.DISPLAY_ON_SCOREBOARD)) {
                 if (divisionNumber != null) {
-                    String div = ScoreboardUtilites.getDivision(contest, av.getClientId());
+                    String div = ScoreboardUtilities.getDivision(contest, av.getClientId());
                     if (! divisionNumber.toString().trim().equals(div.trim())){
                         /**
                          * If this account is NOT in the same division as the divisionNumber, then do not account to list of accounts on scoreboard, skip to next account.

--- a/src/edu/csus/ecs/pc2/core/standings/ScoreboardUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ScoreboardUtilities.java
@@ -40,7 +40,7 @@ import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
 import edu.csus.ecs.pc2.core.standings.json.ScoreboardJsonModel;
 
-public class ScoreboardUtilites {
+public class ScoreboardUtilities {
 
     /**
      * Create x from XML StringContestStandings
@@ -88,7 +88,7 @@ public class ScoreboardUtilites {
     }
     
     public static ContestStandings createContestStandings(IInternalContest contest) throws JAXBException, IllegalContestState, JsonParseException, JsonMappingException, IOException {
-        String xmlString = ScoreboardUtilites.createScoreboardXML(contest);
+        String xmlString = ScoreboardUtilities.createScoreboardXML(contest);
         return createContestStandings(xmlString);
     }
     

--- a/src/edu/csus/ecs/pc2/exports/ccs/ContestAPIStandingsJSON.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ContestAPIStandingsJSON.java
@@ -21,7 +21,7 @@ import edu.csus.ecs.pc2.core.scoring.NewScoringAlgorithm;
 import edu.csus.ecs.pc2.core.scoring.ProblemSummaryInfo;
 import edu.csus.ecs.pc2.core.scoring.StandingsRecord;
 import edu.csus.ecs.pc2.core.scoring.SummaryRow;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.util.JSONTool;
 
 /**
@@ -88,7 +88,7 @@ public class ContestAPIStandingsJSON {
                 honorScoreboardFreeze = false;
             }
             
-            Run[] runs = ScoreboardUtilites.getRunsForUserDivision(contest.getClientId(), contest);
+            Run[] runs = ScoreboardUtilities.getRunsForUserDivision(contest.getClientId(), contest);
             StandingsRecord[] standingsRecords = scoringAlgorithm.getStandingsRecords(contest, null, properties, honorScoreboardFreeze, runs);
 
             for (StandingsRecord sr : standingsRecords) {

--- a/src/edu/csus/ecs/pc2/services/core/ScoreboardJson.java
+++ b/src/edu/csus/ecs/pc2/services/core/ScoreboardJson.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.core;
 
 import java.io.IOException;

--- a/src/edu/csus/ecs/pc2/services/core/ScoreboardJson.java
+++ b/src/edu/csus/ecs/pc2/services/core/ScoreboardJson.java
@@ -15,7 +15,7 @@ import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.standings.json.ScoreboardJsonUtility;
 
 /**
@@ -54,7 +54,7 @@ public class ScoreboardJson {
 
         DefaultScoringAlgorithm scoringAlgorithm = new DefaultScoringAlgorithm();
 
-        Properties properties = ScoreboardUtilites.getScoringProperties(contest);
+        Properties properties = ScoreboardUtilities.getScoringProperties(contest);
 
         if (log == null) {
             log = StaticLog.getLog();
@@ -76,7 +76,7 @@ public class ScoreboardJson {
      * @throws IOException
      */
     public String createJSON(String xml) throws JAXBException, IOException {
-        ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(xml);
+        ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(xml);
         String json = ScoreboardJsonUtility.createScoreboardJSON(contestStandings);
         return json;
     }

--- a/test/edu/csus/ecs/pc2/core/StringUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/StringUtilitiesTest.java
@@ -16,7 +16,7 @@ import edu.csus.ecs.pc2.core.model.InternalContest;
 import edu.csus.ecs.pc2.core.model.Judgement;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.model.SampleContest;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 import edu.csus.ecs.pc2.imports.ccs.ContestSnakeYAMLLoader;
 import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
@@ -305,7 +305,7 @@ public class StringUtilitiesTest extends AbstractTestCase {
         Group[] groups = contest.getGroups();
         
         for (Group group : groups) {
-            String divName = ScoreboardUtilites.getDivision(group.getDisplayName());
+            String divName = ScoreboardUtilities.getDivision(group.getDisplayName());
             assertNotNull("No division found for "+group.getDisplayName(), divName);
         }
         
@@ -321,23 +321,23 @@ public class StringUtilitiesTest extends AbstractTestCase {
         Run[] runlist = contest.getRuns();
         for (Run run : runlist) {
             assertNotNull("Expecting account for "+run.getSubmitter(), contest.getAccount(run.getSubmitter()));
-            String div = ScoreboardUtilites.getDivision(contest, run.getSubmitter());
+            String div = ScoreboardUtilities.getDivision(contest, run.getSubmitter());
             assertNotNull("Missing division for "+run.getSubmitter(), div);
         }
         
         ClientId client1 = accounts[5].getClientId();
         Group group = contest.getGroup(contest.getAccount(client1).getGroupId());
 
-        Run[] runs = ScoreboardUtilites.getRunsForUserDivision(client1, contest);
+        Run[] runs = ScoreboardUtilities.getRunsForUserDivision(client1, contest);
         assertEquals("Expecting runs matching group " + group, 7, runs.length);
 
         client1 = accounts[12].getClientId();
-        runs = ScoreboardUtilites.getRunsForUserDivision(client1, contest);
+        runs = ScoreboardUtilities.getRunsForUserDivision(client1, contest);
         assertEquals("Expecting runs matching group " + group, 5, runs.length);
 
         accounts[12].setGroupId(null); // test for null group
         contest.updateAccounts(accounts);
-        runs = ScoreboardUtilites.getRunsForUserDivision(client1, contest);
+        runs = ScoreboardUtilities.getRunsForUserDivision(client1, contest);
         assertEquals("Expecting runs matching group " + group, 0, runs.length);
         
     }
@@ -400,7 +400,7 @@ public class StringUtilitiesTest extends AbstractTestCase {
             String input = fields[0];
             String expected = fields[1];
 
-            String actual = ScoreboardUtilites.getDivision(input);
+            String actual = ScoreboardUtilities.getDivision(input);
             assertEquals("Expecting division for " + input, expected, actual);
         }
 

--- a/test/edu/csus/ecs/pc2/core/StringUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/StringUtilitiesTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 

--- a/test/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilitiesTest.java
@@ -22,7 +22,7 @@ import edu.csus.ecs.pc2.core.model.FinalizeData;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.ClientType.Type;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.standings.TeamStanding;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.InternalContest;
@@ -78,7 +78,7 @@ public class CLICSAwardUtilitiesTest extends AbstractTestCase {
     public void dumpStandings(String message, IInternalContest contest) throws JsonParseException, JsonMappingException, JAXBException, IllegalContestState, IOException {
         
         System.out.println("dumpStandings: "+message);
-        ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(contest);
+        ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
 
         List<TeamStanding> teamStands = contestStandings.getTeamStandings();
         for (TeamStanding teamStanding : teamStands) {

--- a/test/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboardTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboardTest.java
@@ -21,7 +21,7 @@ import edu.csus.ecs.pc2.core.model.SampleContest;
 import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
 import edu.csus.ecs.pc2.core.scoring.NewScoringAlgorithm;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.standings.json.TeamScoreRow;
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 
@@ -166,7 +166,7 @@ public class CLICSScoreboardTest extends AbstractTestCase{
         assertFileExists(inputJSONFile, "Input scoreboard.json");
 //        editFile(inputJSONFile);
 
-        String jsonString = ScoreboardUtilites.loadFileContents(new File(inputJSONFile));
+        String jsonString = ScoreboardUtilities.loadFileContents(new File(inputJSONFile));
         
         assertNotNull(jsonString);
         // TODO TODO JUNIT FIX - why JsonMappingException

--- a/test/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithmTest.java
+++ b/test/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithmTest.java
@@ -34,7 +34,7 @@ import edu.csus.ecs.pc2.core.model.RunFiles;
 import edu.csus.ecs.pc2.core.model.SampleContest;
 import edu.csus.ecs.pc2.core.security.FileSecurityException;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.standings.TeamStanding;
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 import edu.csus.ecs.pc2.imports.ccs.ContestSnakeYAMLLoader;
@@ -334,14 +334,14 @@ public class NewScoringAlgorithmTest extends AbstractTestCase {
         Group[] groups = contest.getGroups();
         
         for (Group group : groups) {
-            String divName = ScoreboardUtilites.getDivision(group.getDisplayName());
+            String divName = ScoreboardUtilities.getDivision(group.getDisplayName());
             assertNotNull("No division found for "+group.getDisplayName(), divName);
         }
         
         Account[] accounts = getTeamAccounts(contest);
         Arrays.sort(accounts, new AccountComparator());
         for (Account account : accounts) {
-            String name = ScoreboardUtilites.getDivision(contest, account.getClientId());
+            String name = ScoreboardUtilities.getDivision(contest, account.getClientId());
             assertNotNull("No division found for "+account, name);
         }
 
@@ -354,7 +354,7 @@ public class NewScoringAlgorithmTest extends AbstractTestCase {
         Run[] runlist = contest.getRuns();
         for (Run run : runlist) {
             assertNotNull("Expecting account for "+run.getSubmitter(), contest.getAccount(run.getSubmitter()));
-            String div = ScoreboardUtilites.getDivision(contest, run.getSubmitter());
+            String div = ScoreboardUtilities.getDivision(contest, run.getSubmitter());
             assertNotNull("Missing division for "+run.getSubmitter(), div);
         }
         
@@ -363,11 +363,11 @@ public class NewScoringAlgorithmTest extends AbstractTestCase {
         ClientId client1 = accounts[5].getClientId();
         Group group = contest.getGroup(contest.getAccount(client1).getGroupId());
 
-        Run[] runs = ScoreboardUtilites.getRunsForUserDivision(client1, contest);
+        Run[] runs = ScoreboardUtilities.getRunsForUserDivision(client1, contest);
         assertEquals("Expecting runs matching group " + group, 7, runs.length);
 
         client1 = accounts[12].getClientId();
-        runs = ScoreboardUtilites.getRunsForUserDivision(client1, contest);
+        runs = ScoreboardUtilities.getRunsForUserDivision(client1, contest);
         assertEquals("Expecting runs matching group " + group, 5, runs.length);
 
         NewScoringAlgorithm scoringAlgorithm = new NewScoringAlgorithm();
@@ -377,7 +377,7 @@ public class NewScoringAlgorithmTest extends AbstractTestCase {
         Group group2 = contest.getGroup(acc.getGroupId());
         assertNotNull(group2);
         
-        String divString = ScoreboardUtilites.getDivision(contest, client1);
+        String divString = ScoreboardUtilities.getDivision(contest, client1);
         Integer division = new Integer(divString);
         ClientId id  = contest.getClientId();
         assertNotNull("No client Id for contest",id);
@@ -391,15 +391,15 @@ public class NewScoringAlgorithmTest extends AbstractTestCase {
         assertEquals("Expecting standing records for client "+lastClient, 22, standingsRecords.length);
 
         division = 1;
-        Run[] divRuns = ScoreboardUtilites.getRunsForDivision(contest, division.toString());
+        Run[] divRuns = ScoreboardUtilities.getRunsForDivision(contest, division.toString());
         assertEquals("Expecting run count for division "+division, 5, divRuns.length);
         
         division = 2;
-        divRuns = ScoreboardUtilites.getRunsForDivision(contest, division.toString());
+        divRuns = ScoreboardUtilities.getRunsForDivision(contest, division.toString());
         assertEquals("Expecting run count for division "+division, 7, divRuns.length);
         
         division = 3;
-        divRuns = ScoreboardUtilites.getRunsForDivision(contest, division.toString());
+        divRuns = ScoreboardUtilities.getRunsForDivision(contest, division.toString());
         assertEquals("Expecting run count for division "+division, 9, divRuns.length);
         
         
@@ -445,14 +445,14 @@ public class NewScoringAlgorithmTest extends AbstractTestCase {
         Group[] groups = contest.getGroups();
 
         for (Group group : groups) {
-            String divName = ScoreboardUtilites.getDivision(group.getDisplayName());
+            String divName = ScoreboardUtilities.getDivision(group.getDisplayName());
             assertNotNull("No division found for " + group.getDisplayName(), divName);
         }
 
         Account[] accounts = getTeamAccounts(contest);
         Arrays.sort(accounts, new AccountComparator());
         for (Account account : accounts) {
-            String name = ScoreboardUtilites.getDivision(contest, account.getClientId());
+            String name = ScoreboardUtilities.getDivision(contest, account.getClientId());
             assertNotNull("No division found for " + account, name);
         }
 

--- a/test/edu/csus/ecs/pc2/services/core/ScoreboardJsonTest.java
+++ b/test/edu/csus/ecs/pc2/services/core/ScoreboardJsonTest.java
@@ -17,7 +17,7 @@ import edu.csus.ecs.pc2.core.model.JSONObjectMapper;
 import edu.csus.ecs.pc2.core.model.SampleContest;
 import edu.csus.ecs.pc2.core.standings.ContestStandings;
 import edu.csus.ecs.pc2.core.standings.GroupList;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilites;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.core.standings.ScoringGroup;
 import edu.csus.ecs.pc2.core.standings.StandingsHeader;
 import edu.csus.ecs.pc2.core.standings.TeamStanding;
@@ -130,7 +130,7 @@ public class ScoreboardJsonTest extends AbstractTestCase {
          */
         String xmlFilename = "testdata/ScoreboardJsonTest/testNADC21Prac2EF/nadcPractice-event-feed.xml";
 
-        ContestStandings contestStandings = ScoreboardUtilites.createContestStandings(new File(xmlFilename));
+        ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(new File(xmlFilename));
 
         assertNotNull(contestStandings);
 


### PR DESCRIPTION
### Description of what the PR does
Renames all instances of the class ScoreboardUtilites to ScoreboardUtilities.
Also, copyright notices dates were changed so that it ends at 2023.

### Issue which the PR addresses
Fixes #872 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12 R, JDK 8u381 (1.8)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
N/A Refactoring. To test, build and execute all the unit tests with success.