### PR TITLE
i_862: Clarification Button Fixed

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ClarificationsTablePane.java
+++ b/src/edu/csus/ecs/pc2/ui/ClarificationsTablePane.java
@@ -1136,12 +1136,18 @@ public class ClarificationsTablePane extends JPanePlugin {
                 return;
             }
             if (lastAnswered != null) {
-                int showConfirmDialog = JOptionPane.showConfirmDialog(getParentFrame(), "You are asking to answer a new clarification, but you already have a clarification checked out for answering.\n" + //
+                String [] options = {"Yes, I really want to change clars", "No, I'll stick with the previous clar"};
+                String message = 
+                        "You are asking to answer a new clarification, but you already have a clarification checked out for answering." + //
                         "\n" + //
-                        "If you want to give up the previous clarification and switch to answering the new one, click \"Yes\";\n" + //
-                        "\n" + //
-                        "otherwise, click \"No\" and go back to answering the previous clarification.\n" + //
-                        "", "Switch to different Clarification?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null);
+                        "If you want to give up the previous clarification and switch to answering the new one, click \"Yes\";" + //
+                         "\n" + //
+                        "otherwise, click \"No\" and go back to answering the previous clarification."  ;
+
+                int showConfirmDialog = JOptionPane.showOptionDialog(getParentFrame(), message, "Switch to different Clarification?",
+                        JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[1]) ;
+
+                
                 if (showConfirmDialog == JOptionPane.YES_OPTION) {
                     getController().cancelClarification(getContest().getClarification(lastAnswered));
                     // now continue the rest of this method


### PR DESCRIPTION
### Description of what the PR does
Changes the button labels so that the buttons are more descriptive for the case where a judge tries to clarify a question asked while having already selected another question. 

### Issue which the PR addresses
Fixes #862 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
 To test, build and execute all the unit tests with success. Also run the project. Start the server and login as an admin and as a team. Start the contest and make the team ask 2 questions. As the admin, click on answer the question and click on answer the question for the other question.
<img width="547" alt="Screenshot 2023-12-06 195333" src="https://github.com/pc2ccs/pc2v9/assets/60805192/4e314ea3-a7e1-4343-a05c-477859a3bea2">
  
