### PR TITLE
I885: Fixed typo (Utilites->Utilities) in file names and class usages

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -755,7 +755,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
         log.info("  Test case " + testNumber + " passed = " + Utilities.yesNoString(submissionIsCorrect) + " " + reason);
 
-        JudgementRecord record = JudgementUtilites.createJudgementRecord(contest, run, executionData, executionData.getValidationResults());
+        JudgementRecord record = JudgementUtilities.createJudgementRecord(contest, run, executionData, executionData.getValidationResults());
 
         // Judgement judgement = getContest().getJudgement(record.getJudgementId());
         // log.info(" Test case " + testNumber + " passed = " + Utilities.yesNoString(passed) + " judgement = " + judgement);
@@ -2302,7 +2302,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
         if (executionData.isRunTimeLimitExceeded()) {
 
-            Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, Judgement.ACRONYM_TIME_LIMIT_EXCEEDED);
+            Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, Judgement.ACRONYM_TIME_LIMIT_EXCEEDED);
             String judgementString = "No - Time Limit Exceeded"; // default
             if (judgement != null) {
                 judgementString = judgement.getDisplayName();
@@ -2312,7 +2312,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             executionData.setValidationSuccess(true);
             proceedToValidation = false;
         } else if(executionData.isMemoryLimitExceeded()) {
-            Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, Judgement.ACRONYM_MEMORY_LIMIT_EXCEEDED);
+            Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, Judgement.ACRONYM_MEMORY_LIMIT_EXCEEDED);
             String judgementString = "No - Memory Limit Exceeded"; // default
             if (judgement != null) {
                 judgementString = judgement.getDisplayName();
@@ -2323,7 +2323,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             proceedToValidation = false;
             
         } else if(bSandboxSystemError) {
-            Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, Judgement.ACRONYM_OTHER_CONTACT_STAFF);
+            Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, Judgement.ACRONYM_OTHER_CONTACT_STAFF);
             String judgementString = "No - contact staff"; // default
             if (judgement != null) {
                 judgementString = judgement.getDisplayName();
@@ -2339,7 +2339,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
         // TLE/MLE/OCS
         if (executionData.getExecuteExitValue() != 0  &&  !killedByTimer && proceedToValidation) {
             
-            Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, "RTE");
+            Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, "RTE");
             String judgementString = "No - Run-time Error"; // default
             if (judgement != null) {
                 judgementString = judgement.getDisplayName();

--- a/src/edu/csus/ecs/pc2/core/execute/JudgementUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/JudgementUtilities.java
@@ -29,12 +29,12 @@ import edu.csus.ecs.pc2.core.model.RunTestCase;
  */
 
 // $HeadURL$
-public final class JudgementUtilites {
+public final class JudgementUtilities {
 
     /**
      * 
      */
-    private JudgementUtilites() {
+    private JudgementUtilities() {
         super();
     }
 
@@ -74,7 +74,7 @@ public final class JudgementUtilites {
         } else if (!executionData.isCompileSuccess()) {
             // Compile failed, darn!
 
-            Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, "CE");
+            Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, "CE");
             String judgementString = "No - Compilation Error"; // default
             ElementId elementId = null;
             if (judgement != null) {

--- a/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.services.web;
 
 import java.io.ByteArrayOutputStream;

--- a/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/services/web/EventFeedStreamer.java
@@ -15,7 +15,7 @@ import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.list.AccountComparator;
 import edu.csus.ecs.pc2.core.log.Log;
-import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilities;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.AccountEvent;
 import edu.csus.ecs.pc2.core.model.Clarification;
@@ -404,7 +404,7 @@ public class EventFeedStreamer extends JSONUtilities implements Runnable, UIPlug
                         String json = getJSONEvent(JUDGEMENT_KEY, getNextEventId(), EventFeedOperation.UPDATE, jsonTool.convertJudgementToJSON(run).toString());
                         sendJSON(json + NL);
                         // Now send out the runcases (test cases).  Get most recent ones for this run.
-                        RunTestCase [] testCases = JudgementUtilites.getLastTestCaseArray(contest, run);
+                        RunTestCase [] testCases = JudgementUtilities.getLastTestCaseArray(contest, run);
                         for (int j = 0; j < testCases.length; j++) {
                             json = getJSONEvent(RUN_KEY, getNextEventId(), EventFeedOperation.CREATE, jsonTool.convertToJSON(testCases, j).toString());
                             sendJSON(json + NL);

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -14,7 +14,7 @@ import javax.swing.SwingUtilities;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.execute.Executable;
 import edu.csus.ecs.pc2.core.execute.ExecutionData;
-import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilities;
 import edu.csus.ecs.pc2.core.list.RunComparatorByElapsedRunIdSite;
 import edu.csus.ecs.pc2.core.list.UnavailableRunsList;
 import edu.csus.ecs.pc2.core.log.Log;
@@ -503,11 +503,11 @@ public class AutoJudgingMonitor implements UIPlugin {
         executable.execute();
         
         // Dump execution results files to log
-        String executeDirctoryName = JudgementUtilites.getExecuteDirectoryName(getContest().getClientId());
+        String executeDirctoryName = JudgementUtilities.getExecuteDirectoryName(getContest().getClientId());
         Problem problem = getContest().getProblem(fetchedRun.getProblemId());
         ClientId clientId = getContest().getClientId();
-        List<Judgement> judgements = JudgementUtilites.getLastTestCaseJudgementList(contest, fetchedRun);
-        JudgementUtilites.dumpJudgementResultsToLog(log, clientId, fetchedRun, executeDirctoryName, problem, judgements, executable.getExecutionData(), "", new Properties());
+        List<Judgement> judgements = JudgementUtilities.getLastTestCaseJudgementList(contest, fetchedRun);
+        JudgementUtilities.dumpJudgementResultsToLog(log, clientId, fetchedRun, executeDirctoryName, problem, judgements, executable.getExecutionData(), "", new Properties());
 
         ExecutionData executionData = executable.getExecutionData();
         
@@ -529,7 +529,7 @@ public class AutoJudgingMonitor implements UIPlugin {
 
                 notifyMessager.updateStatusLabel("Run failed to compile");
 
-                Judgement judgement = JudgementUtilites.findJudgementByAcronym(contest, "CE");
+                Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, "CE");
                 String judgementString = "No - Compilation Error"; // default
                 ElementId elementId = null;
                 if (judgement != null) {

--- a/src/edu/csus/ecs/pc2/ui/EditRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditRunPane.java
@@ -25,7 +25,7 @@ import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.Executable;
 import edu.csus.ecs.pc2.core.execute.ExecuteTimerFrame;
 import edu.csus.ecs.pc2.core.execute.ExecutionData;
-import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilities;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ElementId;
@@ -812,11 +812,11 @@ public class EditRunPane extends JPanePlugin {
         IFileViewer fileViewer = executable.execute();
         
         // Dump execution results files to log
-        String executeDirctoryName = JudgementUtilites.getExecuteDirectoryName(getContest().getClientId());
+        String executeDirctoryName = JudgementUtilities.getExecuteDirectoryName(getContest().getClientId());
         Problem problem = getContest().getProblem(run.getProblemId());
         ClientId clientId = getContest().getClientId();
-        List<Judgement> judgements = JudgementUtilites.getLastTestCaseJudgementList(getContest(), run);
-        JudgementUtilites.dumpJudgementResultsToLog(log, clientId, run, executeDirctoryName, problem, judgements, executable.getExecutionData(), "", new Properties());
+        List<Judgement> judgements = JudgementUtilities.getLastTestCaseJudgementList(getContest(), run);
+        JudgementUtilities.dumpJudgementResultsToLog(log, clientId, run, executeDirctoryName, problem, judgements, executable.getExecutionData(), "", new Properties());
         
         fileViewer.setVisible(true);
     }

--- a/src/edu/csus/ecs/pc2/ui/EditRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditRunPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -36,7 +36,7 @@ import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.Executable;
 import edu.csus.ecs.pc2.core.execute.ExecuteTimerFrame;
 import edu.csus.ecs.pc2.core.execute.ExecutionData;
-import edu.csus.ecs.pc2.core.execute.JudgementUtilites;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilities;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.AccountEvent;
 import edu.csus.ecs.pc2.core.model.ClientId;
@@ -597,7 +597,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             judgementId = run.getJudgementRecord().getJudgementId();
         }
 
-        for (Judgement judgement : JudgementUtilites.getSingleListofJudgements(getContest())) {
+        for (Judgement judgement : JudgementUtilities.getSingleListofJudgements(getContest())) {
             if (judgement.isActive()) {
                 getJudgementComboBox().addItem(judgement);
                 if (judgement.getElementId().equals(judgementId)) {
@@ -874,11 +874,11 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         executable.execute();
         
         // Dump execution results files to log
-        String executeDirctoryName = JudgementUtilites.getExecuteDirectoryName(getContest().getClientId());
+        String executeDirctoryName = JudgementUtilities.getExecuteDirectoryName(getContest().getClientId());
         Problem juProblem = getContest().getProblem(run.getProblemId());
         ClientId clientId = getContest().getClientId();
-        List<Judgement> judgements = JudgementUtilites.getLastTestCaseJudgementList(getContest(), run);
-        JudgementUtilites.dumpJudgementResultsToLog(log, clientId, run, executeDirctoryName, juProblem, judgements, executable.getExecutionData(), "", new Properties());
+        List<Judgement> judgements = JudgementUtilities.getLastTestCaseJudgementList(getContest(), run);
+        JudgementUtilities.dumpJudgementResultsToLog(log, clientId, run, executeDirctoryName, juProblem, judgements, executable.getExecutionData(), "", new Properties());
 
         ExecutionData executionData = executable.getExecutionData();
         if (executionData != null && executionData.getExecutionException() != null) {
@@ -959,7 +959,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
      
             showValidatorControls(true);
             
-            Judgement judgement = JudgementUtilites.findJudgementByAcronym(getContest(), "CE");
+            Judgement judgement = JudgementUtilities.findJudgementByAcronym(getContest(), "CE");
             String judgementString = "No - Compilation Error"; // default
             ElementId elementId = null;
             if (judgement != null) {

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.util.List;

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
@@ -22,7 +22,7 @@ import edu.csus.ecs.pc2.core.util.AbstractTestCase;
  * 
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
-public class JudgementUtilitesTest extends AbstractTestCase {
+public class JudgementUtilitiesTest extends AbstractTestCase {
     
     private SampleContest sample = new SampleContest();
 //    
@@ -49,7 +49,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
          * Test Compilation error
          */
         executionData.setCompileSuccess(false);
-        JudgementRecord judgementRecord = JudgementUtilites.createJudgementRecord(contest, run, executionData, "Works for me");
+        JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "Works for me");
         
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals(Judgement.ACRONYM_COMPILATION_ERROR, judgmeent.getAcronym());
@@ -77,7 +77,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         
         executionData.setExecutionException(new Exception("unit test M1"));
         
-        JudgementRecord judgementRecord = JudgementUtilites.createJudgementRecord(contest, run, executionData, "Works for me");
+        JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "Works for me");
         
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         
@@ -112,7 +112,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         String expected = judgement.getDisplayName();
         executionData.setValidationResults(expected);
         
-        JudgementRecord judgementRecord = JudgementUtilites.createJudgementRecord(contest, run, executionData, executionData.getValidationResults());
+        JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, executionData.getValidationResults());
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals("WA2", judgmeent.getAcronym());
         
@@ -145,7 +145,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         String expected = judgement.getDisplayName();
         executionData.setValidationResults(expected);
         
-        JudgementRecord judgementRecord = JudgementUtilites.createJudgementRecord(contest, run, executionData, "It's alright");
+        JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "It's alright");
         
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals(getDefaultJudgementAcronym(contest), judgmeent.getAcronym());
@@ -176,7 +176,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         executionData.setExecuteSucess(false);;
         executionData.setValidationSuccess(false);
         
-        JudgementRecord judgementRecord = JudgementUtilites.createJudgementRecord(contest, run, executionData, "Works for me");
+        JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "Works for me");
         
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals(getDefaultJudgementAcronym(contest), judgmeent.getAcronym());
@@ -209,7 +209,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         Judgement judgement22 = contest.getJudgements()[0];
         executionData.setValidationResults("accepted");
         
-        JudgementRecord judgementRecord = JudgementUtilites.createJudgementRecord(contest, run, executionData, "accepted");
+        JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "accepted");
         
         Judgement newJudgment = contest.getJudgement(judgementRecord.getJudgementId());
         
@@ -261,7 +261,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         // Add all yes, except a No at noTestCaseNumber
         addTestCases(run, problem, noTestCaseNumber, noJudgement, sample.getYesJudgement(contest));
 
-        List<Judgement> jList = JudgementUtilites.getLastTestCaseJudgementList(contest, run);
+        List<Judgement> jList = JudgementUtilities.getLastTestCaseJudgementList(contest, run);
         assertNotNull (jList);
         
         int tcn = problem.getNumberTestCases();
@@ -339,7 +339,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
 
         assertEquals("judgement count", 9, judgements.length);
 
-        List<Judgement> jList = JudgementUtilites.getSingleListofJudgements(contest);
+        List<Judgement> jList = JudgementUtilities.getSingleListofJudgements(contest);
         assertEquals("judgement count", 9, jList.size());
 
         assertEquals("judgement site number", 3, jList.get(0).getSiteNumber());
@@ -371,7 +371,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         judgements = contest.getJudgements();
         assertEquals("judgement count", 18, judgements.length);
 
-        List<Judgement> jList = JudgementUtilites.getSingleListofJudgements(contest);
+        List<Judgement> jList = JudgementUtilities.getSingleListofJudgements(contest);
         assertEquals("judgement count", 9, jList.size());
 
         assertEquals("judgement site number", 1, jList.get(0).getSiteNumber());
@@ -419,13 +419,13 @@ public class JudgementUtilitesTest extends AbstractTestCase {
         assertNotNull("AC Judgement", acJudgement);
         Judgement waJudgement = getJudgement(contest, Judgement.ACRONYM_WRONG_ANSWER);
         assertNotNull("WA Judgement", waJudgement);
-        RunTestCase[] recs = JudgementUtilites.getLastTestCaseArray(contest, run);
+        RunTestCase[] recs = JudgementUtilities.getLastTestCaseArray(contest, run);
         assertEquals("Expected zero test cases ", 0, recs.length);
         // Add firstset of test cases - all AC
         for (int testCaseNum = 1; testCaseNum <= problem.getNumberTestCases(); testCaseNum++) {
             addRunTestCase(contest, run, testCaseNum, acJudgement, judges[0].getClientId());
         }
-        recs = JudgementUtilites.getLastTestCaseArray(contest, run);
+        recs = JudgementUtilities.getLastTestCaseArray(contest, run);
         
         assertEquals("Expected test cases ", 10, recs.length);
         // Add second set of test cases - all WA
@@ -433,7 +433,7 @@ public class JudgementUtilitesTest extends AbstractTestCase {
             addRunTestCase(contest, run, testCaseNum, waJudgement, judges[0].getClientId());
         }
         assertEquals("Expected total test cases ", 20, run.getRunTestCases().length);
-        recs = JudgementUtilites.getLastTestCaseArray(contest, run);
+        recs = JudgementUtilities.getLastTestCaseArray(contest, run);
         
         assertEquals("Expected test cases ", 10, recs.length);
         

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
@@ -394,7 +394,7 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
     }
 
     /**
-     * Test JudgementUtilites.getLastTestCaseArray.
+     * Test JudgementUtilities.getLastTestCaseArray.
      *
      * Added two test cases (first all judged AC, second all judged WA).
      * Test that getLastTestCaseArray returns the last ("WA") RunTestCases


### PR DESCRIPTION
### Description of what the PR does

Fixed typos in class name `JudgementUtilites` and `JudgementUtilitesTest` and their usages in other classes.

### Issue which the PR addresses
Fixes #885 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
MacOS Ventura
Jetbrains IntelliJ
Java 1.8 (Amazon Corretto)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Run unit tests in _JudgementUtilitiesTest.java_ and make sure all tests still pass