### PR TITLE
I863 add team identification to wti UI

### DIFF
--- a/projects/WTI-UI/src/app/app.module.ts
+++ b/projects/WTI-UI/src/app/app.module.ts
@@ -14,7 +14,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule} from '@angular/material/icon';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatToolbarModule} from '@angular/material/toolbar';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
 //import { DeviceDetectorModule } from 'ngx-device-detector';
 
 @NgModule({
@@ -39,7 +40,7 @@ import { MatToolbarModule} from '@angular/material/toolbar';
     MatToolbarModule
 //	DeviceDetectorModule.forRoot()
   ],
-  providers: [],
+  providers: [AppTitleService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -28,7 +28,7 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
 	
-	this._appTitleService.setTitleWithTeamId("Submit Clar");
+	this._appTitleService.setTitleWithTeamId("Clarifications");
 	
     this.buildForm();
     this.loadClars();

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -7,6 +7,7 @@ import { Clarification } from '../../../core/models/clarification';
 import { MatDialog } from '@angular/material/dialog';
 import { NewClarificationComponent } from '../new-clarification/new-clarification.component';
 import { AuthService } from '../../../core/auth/auth.service';
+import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
 
 @Component({
   templateUrl: './clarifications-page.component.html',
@@ -22,9 +23,13 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
   constructor(private _formBuilder: FormBuilder,
               private _contestService: IContestService,
               private _modalService: MatDialog,
-              private _authService: AuthService) { }
+              private _authService: AuthService,
+			  private _appTitleService: AppTitleService) { }
 
   ngOnInit(): void {
+	
+	this._appTitleService.setTitleWithTeamId("Submit Clar");
+	
     this.buildForm();
     this.loadClars();
 

--- a/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
@@ -22,10 +22,10 @@ export class AppTitleService {
 	    let acctId = this._authService.username; 
 		let teamId = "";
 		//make sure we got a reasonable string back from AuthService
-    	if (!acctId==null && (typeof acctId === "string" && acctId.length>4)) {
+    	if (!(acctId==null) && (typeof acctId === "string" && acctId.length>4)) {
 			//pull the team number out of the PC2 account (e.g. pull "22" out of account "team22")
      		teamId = acctId.substr(4);
 		}
-    	this.setTitle("PC2 Team" + teamId + " " + newTitle);
+    	this.setTitle("PC2 Team " + teamId + " " + newTitle);
 	}
 }

--- a/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
@@ -26,6 +26,6 @@ export class AppTitleService {
 			//pull the team number out of the PC2 account (e.g. pull "22" out of account "team22")
      		teamId = acctId.substr(4);
 		}
-    	this.setTitle("PC2 Team " + teamId + " " + newTitle);
+    	this.setTitle("PC2 Team " + teamId + " - " + newTitle);
 	}
 }

--- a/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
@@ -20,7 +20,12 @@ export class AppTitleService {
 	//set a new title in the browser tab, including the logged-in teamId in the title
 	setTitleWithTeamId(newTitle: string) {
 	    let acctId = this._authService.username; 
-    	let teamId = acctId.substr(4);
+		let teamId = "";
+		//make sure we got a reasonable string back from AuthService
+    	if (!acctId==null && (typeof acctId === "string" && acctId.length>4)) {
+			//pull the team number out of the PC2 account (e.g. pull "22" out of account "team22")
+     		teamId = acctId.substr(4);
+		}
     	this.setTitle("PC2 Team" + teamId + " " + newTitle);
 	}
 }

--- a/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/app-title.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { AuthService } from 'src/app/modules/core/auth/auth.service';
+
+@Injectable()
+export class AppTitleService {
+
+    constructor(private _titleService: Title, private _authService: AuthService) { }
+
+	//return the current browser tab title
+    getTitle() {
+        this._titleService.getTitle();
+    }
+
+	//set a new title in the browser tab
+    setTitle(newTitle: string) {
+        this._titleService.setTitle(newTitle);
+    }
+
+	//set a new title in the browser tab, including the logged-in teamId in the title
+	setTitleWithTeamId(newTitle: string) {
+	    let acctId = this._authService.username; 
+    	let teamId = acctId.substr(4);
+    	this.setTitle("PC2 Team" + teamId + " " + newTitle);
+	}
+}

--- a/projects/WTI-UI/src/app/modules/login/components/login-page/login-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/login/components/login-page/login-page.component.ts
@@ -8,6 +8,7 @@ import { TeamsLoginResponse } from 'src/app/modules/core/models/teams-login-resp
 import { IWebsocketService } from 'src/app/modules/core/abstract-services/i-websocket.service';
 import { Router } from '@angular/router';
 import { IContestService } from 'src/app/modules/core/abstract-services/i-contest.service';
+import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
 
 @Component({
   templateUrl: './login-page.component.html',
@@ -23,9 +24,13 @@ export class LoginPageComponent implements OnInit, OnDestroy {
               private _authService: AuthService,
               private _websocketService: IWebsocketService,
               private _router: Router,
-              private _contestService: IContestService) { }
+              private _contestService: IContestService,
+			  private _appTitleService: AppTitleService) { }
 
   ngOnInit(): void {
+	
+	this._appTitleService.setTitleWithTeamId("Login");
+		
     if (this._authService.token) { this._router.navigateByUrl(this._authService.defaultRoute); }
     this.buildForm();
   }

--- a/projects/WTI-UI/src/app/modules/options/components/options-page/options-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/options/components/options-page/options-page.component.ts
@@ -3,6 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ChangePasswordComponent } from '../change-password/change-password.component';
 import { UiHelperService } from 'src/app/modules/core/services/ui-helper.service';
 import { environment } from 'src/environments/environment';
+import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
 
 @Component({
   templateUrl: './options-page.component.html',
@@ -15,9 +16,12 @@ export class OptionsPageComponent implements OnInit {
   set runsNotificationsEnabled(newval: boolean) { this._uiHelperService.enableRunsNotifications = newval; }
 
   constructor(private _dialogSvc: MatDialog,
-              private _uiHelperService: UiHelperService) { }
+              private _uiHelperService: UiHelperService,
+			  private _appTitleService: AppTitleService) { }
 
-  ngOnInit(): void {  }
+  ngOnInit(): void {
+	this._appTitleService.setTitleWithTeamId("Options");
+  }
 
   showWebsocketDebug(): boolean {
     return !!environment.useMock;

--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
@@ -27,7 +27,7 @@ export class RunsPageComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
 	
-	this._appTitleService.setTitleWithTeamId("Submit Run");
+	this._appTitleService.setTitleWithTeamId("Runs");
 	
     this.buildForm();
     this.loadRuns();

--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
@@ -7,6 +7,8 @@ import { Run } from 'src/app/modules/core/models/run';
 import { MatDialog } from '@angular/material/dialog';
 import { NewRunComponent } from '../new-run/new-run.component';
 import { TestRunDetailComponent } from '../test-run-detail/test-run-detail.component';
+import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
+
 
 @Component({
   templateUrl: './runs-page.component.html',
@@ -20,9 +22,13 @@ export class RunsPageComponent implements OnInit, OnDestroy {
 
   constructor(private _formBuilder: FormBuilder,
               private _teamService: ITeamsService,
-              private _matDialog: MatDialog) { }
+              private _matDialog: MatDialog,
+			  private _appTitleService: AppTitleService) { }
 
   ngOnInit(): void {
+	
+	this._appTitleService.setTitleWithTeamId("Submit Run");
+	
     this.buildForm();
     this.loadRuns();
 

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy, DoCheck } from '@angular/core';
 import { IContestService } from 'src/app/modules/core/abstract-services/i-contest.service';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
 
 @Component({
 	templateUrl: './scoreboard-page.component.html',
@@ -13,11 +14,15 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	teamStandings: any = [];
 
 	constructor(
-		private _contestService: IContestService
+		private _contestService: IContestService,
+		private _appTitleService: AppTitleService
 	) { }
 
 	ngOnInit(): void {
 		//console.log("Scoreboard OnInit executed.");
+		
+		this._appTitleService.setTitleWithTeamId("Scoreboard");
+		
 		this.loadStandings();
 
 		// when standings are updated, trigger a reload

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
@@ -4,6 +4,9 @@
         <img src='/assets/VerticalBar.png' alt='VerticalBar'>
         <img src='/assets/icpc-banner.png' alt='ICPC Programming Contest Logo'>
     </div>
+    <div class='teamid-container'>
+    	<P> TEAM XX </P>
+    </div>
     <nav *ngIf='showLinks'>
         <a routerLink='/runs' routerLinkActive='active'>Runs</a>
         <a routerLink='/clarifications' routerLinkActive='active'>Clarifications</a>

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
@@ -5,7 +5,7 @@
         <img src='/assets/icpc-banner.png' alt='ICPC Programming Contest Logo'>
     </div>
     <div class='teamid-container' *ngIf='showTeamId'>
-    	<P> TEAM XX </P>
+    	<P> TEAM: {{ userName }} </P>
     </div>
     <nav *ngIf='showLinks'>
         <a routerLink='/runs' routerLinkActive='active'>Runs</a>

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
@@ -5,7 +5,7 @@
         <img src='/assets/icpc-banner.png' alt='ICPC Programming Contest Logo'>
     </div>
     <div class='teamid-container' *ngIf='showTeamId'>
-    	<P> TEAM: {{ userName }} </P>
+    	<P>TEAM {{teamId}}</P>
     </div>
     <nav *ngIf='showLinks'>
         <a routerLink='/runs' routerLinkActive='active'>Runs</a>

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.html
@@ -4,7 +4,7 @@
         <img src='/assets/VerticalBar.png' alt='VerticalBar'>
         <img src='/assets/icpc-banner.png' alt='ICPC Programming Contest Logo'>
     </div>
-    <div class='teamid-container'>
+    <div class='teamid-container' *ngIf='showTeamId'>
     	<P> TEAM XX </P>
     </div>
     <nav *ngIf='showLinks'>

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.scss
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.scss
@@ -10,6 +10,7 @@ header {
 
   .logo-container img { height: 4rem; }
 
+  /* Set the container holding logged-in Team ID to large, white font */
   .teamid-container {
     color: white;
     font-size: 1.5rem;

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.scss
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.scss
@@ -10,6 +10,11 @@ header {
 
   .logo-container img { height: 4rem; }
 
+  .teamid-container {
+    color: white;
+    font-size: 1.5rem;
+  }
+  
   nav a {
     display: inline-block;
     padding: 0.75rem;

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
@@ -7,7 +7,9 @@ import { AuthService } from 'src/app/modules/core/auth/auth.service';
     styleUrls: ['./app-header.component.scss']
 })
 export class AppHeaderComponent {
+
   get showLinks(): boolean { return this._authService.isLoggedIn; }
+  get showTeamId(): boolean { return this._authService.isLoggedIn; }
 
   constructor(private _authService: AuthService) { }
 }

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
@@ -11,7 +11,7 @@ export class AppHeaderComponent {
   //Return a boolean indicating whether or not to show nav-bar links in the header
   get showLinks(): boolean { return this._authService.isLoggedIn; }
   
-  //Return a boolean indicatin whether or not to show a teamId in the header
+  //Return a boolean indicating whether or not to show a teamId in the header
   get showTeamId(): boolean { return this._authService.isLoggedIn; }
   
   /* Return a string containing the "team id" -- that is, the PC2 team account number with

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
@@ -10,6 +10,7 @@ export class AppHeaderComponent {
 
   get showLinks(): boolean { return this._authService.isLoggedIn; }
   get showTeamId(): boolean { return this._authService.isLoggedIn; }
+  get userName(): string { return this._authService.username; }
 
   constructor(private _authService: AuthService) { }
 }

--- a/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-header/app-header.component.ts
@@ -8,9 +8,19 @@ import { AuthService } from 'src/app/modules/core/auth/auth.service';
 })
 export class AppHeaderComponent {
 
+  //Return a boolean indicating whether or not to show nav-bar links in the header
   get showLinks(): boolean { return this._authService.isLoggedIn; }
+  
+  //Return a boolean indicatin whether or not to show a teamId in the header
   get showTeamId(): boolean { return this._authService.isLoggedIn; }
-  get userName(): string { return this._authService.username; }
+  
+  /* Return a string containing the "team id" -- that is, the PC2 team account number with
+     the leading "team" removed */
+  get teamId(): string { 
+    let acctId = this._authService.username; 
+    let teamId = acctId.substr(4);
+    return teamId;
+  }
 
   constructor(private _authService: AuthService) { }
 }


### PR DESCRIPTION
### Description of what the PR does

Adds the Id of the logged-in team to the WTI-UI header bar.

UPDATE: the PR now also adds the logged-in team to the browser tab (the "page title"), along with an indication in the tab title of which page is active (e.g. "Login", "Runs", "Scoreboard", etc.).

### Issue which the PR addresses

Fixes #863, fixes #690.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 11, Eclipse Version: 2023-03 (4.27.0), Node version 16.20,  Angular V16

### Precise steps for _testing_ the PR 

- Download the distribution artifact for the PR.
- Unzip the pc2v9 build.
- Start a PC2 server using `--load` to load a sample contest (`--load sumithello` will work).
- Start a PC2 Admin, verify that there exists a "scoreboard2" account.
  - If there is no "scoreboard2" account, use the `Accounts>Generate` pane to create one.  (Note:  the `sumithello` sample contest does _not_ have a "scoreboard2" account -- but neither do any of the other "sample" contests... which seems like a deficiency...)
- Go into the `projects` folder in the distribution; unzip the `WebTeamInterface-1.1` zip file.
  - Update: the current GitHub build steps for the PC2v9 project fail to include the WTI subproject in builds which have not yet been merged (see Issue #896 ).  Until this is fixed, to test this PR it will be necessary to copy the branch from my fork and build a distribution on your local system.
- Start a WTI-API server (type `./bin/pc2wti` in the unzipped project folder).
- Open a new browser window.
- **Clear the browser cache**.  (This is necessary if you have run a WTI client recently; it may still have the cached (old) version of the WTI-UI javascript.)
- Open a browser connection to your WTI-API server.  (For example, type `http://localhost:8080` in the address bar.)
- You should see a generic "WTI Login screen" (with balloons in the background).
- Enter the login credentials for some team account that exists in your PC2 Server configuration (for the `sumithello` sample contest, accounts `team1` through `team22` will pre-exist and have "joe" passwords).

You should see a standard WTI main screen (with the `Runs` view selected).  However, unlike with previous WTI versions, _you should now see an indication in the header of the currently logged-in team_.  For example:

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/fd0a0202-4c06-40ca-96c9-e7f1808de5d9)

or

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/7669b8f1-8562-4771-88f1-eb1d64feb41d)

or

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/81dd211f-e9b5-410d-bf05-83d6ab3f8c2d)

or

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/02ab5f95-627f-46c6-8dc7-889328f2cb39)

(and no, I did NOT generate the above screenshots using MSPaint -- they were legitimate team logins :) )

All other functions in the WTI team interface should work as before (the PR makes no changes to anything but the files managing the header).




