### PR TITLE
i888 Use correct java compiler for JUnit tests

### DIFF
--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -164,6 +164,8 @@ public class ExecutableTest extends AbstractTestCase {
     private Language createLanguage(String autoFillLanguageTitle) {
 
         String[] values = LanguageAutoFill.getAutoFillValues(autoFillLanguageTitle);
+        // Make sure to use correct javac for the JVM in use.
+        SampleContest.fixJavaJDKPath(values);
         Language language = new Language(values[4]);
         // displayNameTextField.setText(values[0]);
         // compileCommandLineTextField.setText(values[1]);

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -1915,6 +1915,8 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         Problem problem = problems[0];
         sampleContest.setClicsValidation(originalContest, null, problem);
         ElementId problemId = problem.getElementId();
+        
+        Language [] origLanguages = originalContest.getLanguages();
 
         // ExportYAML2 exportYAML = new ExportYAML2();
         ExportYAML exportYAML = new ExportYAML();
@@ -1949,7 +1951,8 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
         // runner-args: '{:basename}
 
         assertEquals("Expected language name ", "Java", languages[0].getDisplayName());
-        assertEquals("Expected language compilerCmd ", "javac {:mainfile}", languages[0].getCompileCommandLine());
+        // Since SampleContest can massage the name of the java compiler, use the original instead of canned
+        assertEquals("Expected language compilerCmd ", origLanguages[0].getCompileCommandLine(), languages[0].getCompileCommandLine());
         assertEquals("Expected language exemask ", "{:basename}.class", languages[0].getExecutableIdentifierMask());
         assertEquals("Expected language execCmd ", "java {:package}{:basename}", languages[0].getProgramExecuteCommandLine());
 

--- a/test/edu/csus/ecs/pc2/validator/customValidator/CustomCppClicsInterfaceValidatorTest.java
+++ b/test/edu/csus/ecs/pc2/validator/customValidator/CustomCppClicsInterfaceValidatorTest.java
@@ -147,6 +147,8 @@ public class CustomCppClicsInterfaceValidatorTest extends AbstractTestCase {
     private Language createLanguage(String autoFillLanguageTitle) {
 
         String[] values = LanguageAutoFill.getAutoFillValues(autoFillLanguageTitle);
+        // Make sure to use correct javac for the JVM in use.
+        SampleContest.fixJavaJDKPath(values);
         Language language = new Language(values[4]);
         // displayNameTextField.setText(values[0]);
         // compileCommandLineTextField.setText(values[1]);

--- a/test/edu/csus/ecs/pc2/validator/customValidator/CustomJavaClicsInterfaceValidatorTest.java
+++ b/test/edu/csus/ecs/pc2/validator/customValidator/CustomJavaClicsInterfaceValidatorTest.java
@@ -370,6 +370,9 @@ public class CustomJavaClicsInterfaceValidatorTest extends AbstractTestCase {
     private Language createLanguage(String autoFillLanguageTitle) {
 
         String[] values = LanguageAutoFill.getAutoFillValues(autoFillLanguageTitle);
+        // Make sure to use correct javac for the JVM in use.
+        SampleContest.fixJavaJDKPath(values);
+
         Language language = new Language(values[4]);
         // displayNameTextField.setText(values[0]);
         // compileCommandLineTextField.setText(values[1]);

--- a/test/edu/csus/ecs/pc2/validator/customValidator/CustomJavaPC2InterfaceValidatorTest.java
+++ b/test/edu/csus/ecs/pc2/validator/customValidator/CustomJavaPC2InterfaceValidatorTest.java
@@ -372,6 +372,8 @@ public class CustomJavaPC2InterfaceValidatorTest extends AbstractTestCase {
     private Language createLanguage(String autoFillLanguageTitle) {
 
         String[] values = LanguageAutoFill.getAutoFillValues(autoFillLanguageTitle);
+        // Make sure to use correct javac for the JVM in use.
+        SampleContest.fixJavaJDKPath(values);
         Language language = new Language(values[4]);
         // displayNameTextField.setText(values[0]);
         // compileCommandLineTextField.setText(values[1]);


### PR DESCRIPTION
### Description of what the PR does
Since _Eclipse 4.17 (2020-09)_, **Java 11** (or newer) is the default JDK that ships with Eclipse.  Previously, it was **Java 8** (1.8). This PR attempts to track down the correct JDK to use for compiling the _JUnit_ test programs.  The JDK must match the currently running JVM in order to qualify.  A search of  the `JAVA_HOME/bin` and folders on the `PATH `environment variable are checked for the presence of the corresponding JDK (`javac[.exe]`). The code only checks for the presence of the Java version string in the folder name.  It could be expanded to actually attempt to run "`javac -version`" in each folder, but that shouldn't be necessary, and is highly inefficient.

The reason for this PR is that the JUnits requiring compiles were using Eclipse's JDK (Version >11), but attempting to execute the produced class files using JRE 1.8.  This lead to the errors described in #888.

### Issue which the PR addresses
Fixed #888 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Eclipse 2021-12, with JVM org.eclipse.justj.openjdk.hotspot.jre.full.win32.x86_64_17.0.1.v20211116-1657
JDK 1.8.0_351

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Run all JUnits.  They should pass now.   Previously, the ones in #888 (ExecuteTest, among others) did not pass.
