### PR TITLE
i898: update sumithello sample contest to generate 2 scoreboard accts.

### DIFF
--- a/samps/contests/sumithello/config/contest.yaml
+++ b/samps/contests/sumithello/config/contest.yaml
@@ -60,7 +60,7 @@ accounts:
 
   - account: SCOREBOARD
     site: 1
-    count: 1
+    count: 2
     
 auto-judging:
   - account: JUDGE


### PR DESCRIPTION

### Description of what the PR does

Updates the `contest.yaml` file in the `sumithello` sample contest so that it generates two scoreboard accounts rather than just one.  See the description in Issue #898 for an explanation of why this is useful.

### Issue which the PR addresses

Fixes #898 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 10, Eclipse Version: 2020-12 (4.18.0), Java 1.8.0_271.

### Precise steps for _testing_ the PR 

- Download and unzip the generated distribution artifact for the PR.
- Start a PC2 server using the `--load sumithello` argument.
- Start a PC2 Admin; verify that the `Accounts` tab shows TWO scoreboard accounts:  Scoreboard1 and Scoreboard2.
- Start a WTI-API server.
  - Note:  currently, a PR build does not include the WTI package.  However, _it's not necessary to use the latest WTI; any recent version will do._
- Verify that the WTI server starts up correctly.  This includes:
  - Verify that the WTI console log shows the message 
```
sendLoginRequest start - sending from SCOREBOARD2 @ site 0
sendLoginRequest end - packet sent.
 receiveObject(S) start got Packet[LOGIN_SUCCESS] #5 SERVER0 @ site 1 -> SCOREBOARD2 @ site 1
```
  - Verify that the WTI console shows  a message like
```
[main] INFO org.eclipse.jetty.server.Server - Started @xxxx
```

If the WTI was able to successfully login to Scoreboard2 and start starts without errors, the PR worked.
