### PR TITLE
I631 Updated WTI and Team GUI backend to prevent duplicate filename submissions in additional files

### DIFF
--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -203,22 +203,34 @@ export class NewRunComponent implements OnInit, OnDestroy {
   //returns true if there are duplicate filenames among any of the specified FileSubmissions; false if all unique.
   private filenameContainsDuplicates(mainfile: FileSubmission, additionalFiles: FileSubmission []): boolean {
     let mainfilename = mainfile.fileName;
-    let l = mainfilename.indexOf("/");
-    if (l == -1) l = mainfilename.indexOf("\\");
-    if (l > -1) mainfilename = mainfilename.substring(l + 1);
+    let l = mainfilename.lastIndexOf("/");
+    if (l == -1) {
+      l = mainfilename.lastIndexOf("\\");
+    }
+    if (l > -1) {
+      mainfilename = mainfilename.substring(l + 1);
+    }
     for (let i = 0; i < additionalFiles.length; i++) {
       let otherfilename = additionalFiles[i].fileName;
-      l = otherfilename.indexOf("/");
-      if (l == -1) l = otherfilename.indexOf("\\");
-      if (l > -1) otherfilename = otherfilename.substring(l + 1);
+      l = otherfilename.lastIndexOf("/");
+      if (l == -1) {
+        l = otherfilename.lastIndexOf("\\");
+      }
+      if (l > -1) {
+        otherfilename = otherfilename.substring(l + 1);
+      }
       if (mainfilename === otherfilename) {
         return true;
       }
       for (let j = i + 1; j < additionalFiles.length; j++) {
         let otherfilename2 = additionalFiles[j].fileName;
-        l = otherfilename2.indexOf("/");
-        if (l == -1) l = otherfilename2.indexOf("\\");
-        if (l > -1) otherfilename2 = otherfilename2.substring(l + 1);
+        l = otherfilename2.lastIndexOf("/");
+        if (l == -1) {
+          l = otherfilename2.lastIndexOf("\\");
+        }
+        if (l > -1) {
+          otherfilename2 = otherfilename2.substring(l + 1);
+        }
         if (otherfilename2 === otherfilename) {
           return true;
         }

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -122,6 +122,9 @@ export class NewRunComponent implements OnInit, OnDestroy {
 		//pop up an error dialog
 	    this._uiHelper.alert('File names may not contain spaces');
 	    console.error('One or more submitted file contains a space in its filename');
+  } else if (this.filenameContainsDuplicates(this.mainFile, this.additionalFiles)) {
+      this._uiHelper.alert('You may not submit multiple files with the same name');
+	    console.error('One or more submitted file have the same filename');
 	} else {
 		//submit the run
 	    this._teamService.submitRun(model)
@@ -196,6 +199,34 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	//none of the specified FileSubmission files contains a space in its name
 	return false;
 	}
+
+  //returns true if there are duplicate filenames among any of the specified FileSubmissions; false if all unique.
+  private filenameContainsDuplicates(mainfile: FileSubmission, additionalFiles: FileSubmission []): boolean {
+    let mainfilename = mainfile.fileName;
+    let l = mainfilename.indexOf("/");
+    if (l == -1) l = mainfilename.indexOf("\\");
+    if (l > -1) mainfilename = mainfilename.substring(l + 1);
+    for (let i = 0; i < additionalFiles.length; i++) {
+      let otherfilename = additionalFiles[i].fileName;
+      l = otherfilename.indexOf("/");
+      if (l == -1) l = otherfilename.indexOf("\\");
+      if (l > -1) otherfilename = otherfilename.substring(l + 1);
+      if (mainfilename === otherfilename) {
+        return true;
+      }
+      for (let j = i + 1; j < additionalFiles.length; j++) {
+        let otherfilename2 = additionalFiles[j].fileName;
+        l = otherfilename2.indexOf("/");
+        if (l == -1) l = otherfilename2.indexOf("\\");
+        if (l > -1) otherfilename2 = otherfilename2.substring(l + 1);
+        if (otherfilename2 === otherfilename) {
+          return true;
+        }
+      }
+    }
+    //none of the specified FileSubmission files contains duplicate names
+    return false;
+  }
 	
 	//returns a string intended to identify the platform on which the browser is running
 	private getOSName() : string {

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -483,15 +483,13 @@ public class SubmitRunPane extends JPanePlugin {
         
         if (additionalFilesMCLB.getRowCount() > 0) {
 
-            int l = filename.lastIndexOf('/');
-            if (l == -1) l = filename.lastIndexOf('\\');
             String mainfilename = filename;
+            int l = filename.lastIndexOf(File.separatorChar);
             if (l > -1) mainfilename = filename.substring(l + 1);
 
             for (int i = 0; i < additionalFilesMCLB.getRowCount(); i++) {
                 String otherfilename = (String) additionalFilesMCLB.getRow(i)[0];
-                l = otherfilename.lastIndexOf('/');
-                if (l == -1) l = otherfilename.lastIndexOf('\\');
+                l = otherfilename.lastIndexOf(File.separatorChar);
                 if (l > -1) otherfilename = otherfilename.substring(l + 1);
                 if (otherfilename.equals(mainfilename)) {
                     showMessage("You may not submit multiple files with the same name");
@@ -501,8 +499,7 @@ public class SubmitRunPane extends JPanePlugin {
                 
                 for (int j = i + 1; j < additionalFilesMCLB.getRowCount(); j++) {
                     String otherfilename2 = (String) additionalFilesMCLB.getRow(j)[0];
-                    l = otherfilename2.lastIndexOf('/');
-                    if (l == -1) l = otherfilename2.lastIndexOf('\\');
+                    l = otherfilename2.lastIndexOf(File.separatorChar);
                     if (l > -1) otherfilename2 = otherfilename2.substring(l + 1);
                     if (otherfilename.equals(otherfilename2)) {
                         showMessage("You may not submit multiple files with the same name");

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -439,7 +439,7 @@ public class SubmitRunPane extends JPanePlugin {
     /**
      * Submit run or test run.
      * 
-     * Validates that the user has selected problem, language and a valid filename.
+     * Validates that the user has selected problem, language, a valid filename and there are no files with duplicate name.
      * 
      * @param submitTheRun
      *            if true, submits the run.
@@ -494,7 +494,8 @@ public class SubmitRunPane extends JPanePlugin {
                 if (l == -1) l = otherfilename.lastIndexOf('\\');
                 if (l > -1) otherfilename = otherfilename.substring(l + 1);
                 if (otherfilename.equals(mainfilename)) {
-                    showMessage("Found multiple files with same filename");
+                    showMessage("You may not submit multiple files with the same name");
+                    log.warning("Found multiple files with same filename");
                     return;
                 }
                 
@@ -504,7 +505,8 @@ public class SubmitRunPane extends JPanePlugin {
                     if (l == -1) l = otherfilename2.lastIndexOf('\\');
                     if (l > -1) otherfilename2 = otherfilename2.substring(l + 1);
                     if (otherfilename.equals(otherfilename2)) {
-                        showMessage("Found multiple files with same filename");
+                        showMessage("You may not submit multiple files with the same name");
+                        log.warning("Found multiple files with same filename");
                         return;
                     }
                 }

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -485,12 +485,16 @@ public class SubmitRunPane extends JPanePlugin {
 
             String mainfilename = filename;
             int l = filename.lastIndexOf(File.separatorChar);
-            if (l > -1) mainfilename = filename.substring(l + 1);
+            if (l > -1) {
+                mainfilename = filename.substring(l + 1);
+            }
 
             for (int i = 0; i < additionalFilesMCLB.getRowCount(); i++) {
                 String otherfilename = (String) additionalFilesMCLB.getRow(i)[0];
                 l = otherfilename.lastIndexOf(File.separatorChar);
-                if (l > -1) otherfilename = otherfilename.substring(l + 1);
+                if (l > -1) {
+                    otherfilename = otherfilename.substring(l + 1);
+                }
                 if (otherfilename.equals(mainfilename)) {
                     showMessage("You may not submit multiple files with the same name");
                     log.warning("Found multiple files with same filename");
@@ -500,7 +504,9 @@ public class SubmitRunPane extends JPanePlugin {
                 for (int j = i + 1; j < additionalFilesMCLB.getRowCount(); j++) {
                     String otherfilename2 = (String) additionalFilesMCLB.getRow(j)[0];
                     l = otherfilename2.lastIndexOf(File.separatorChar);
-                    if (l > -1) otherfilename2 = otherfilename2.substring(l + 1);
+                    if (l > -1) {
+                        otherfilename2 = otherfilename2.substring(l + 1);
+                    }
                     if (otherfilename.equals(otherfilename2)) {
                         showMessage("You may not submit multiple files with the same name");
                         log.warning("Found multiple files with same filename");

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -481,7 +481,35 @@ public class SubmitRunPane extends JPanePlugin {
             return;
         }
         
-        if (additionalFilesMCLB.getRowCount() > 0){
+        if (additionalFilesMCLB.getRowCount() > 0) {
+
+            int l = filename.lastIndexOf('/');
+            if (l == -1) l = filename.lastIndexOf('\\');
+            String mainfilename = filename;
+            if (l > -1) mainfilename = filename.substring(l + 1);
+
+            for (int i = 0; i < additionalFilesMCLB.getRowCount(); i++) {
+                String otherfilename = (String) additionalFilesMCLB.getRow(i)[0];
+                l = otherfilename.lastIndexOf('/');
+                if (l == -1) l = otherfilename.lastIndexOf('\\');
+                if (l > -1) otherfilename = otherfilename.substring(l + 1);
+                if (otherfilename.equals(mainfilename)) {
+                    showMessage("Found multiple files with same filename");
+                    return;
+                }
+                
+                for (int j = i + 1; j < additionalFilesMCLB.getRowCount(); j++) {
+                    String otherfilename2 = (String) additionalFilesMCLB.getRow(j)[0];
+                    l = otherfilename2.lastIndexOf('/');
+                    if (l == -1) l = otherfilename2.lastIndexOf('\\');
+                    if (l > -1) otherfilename2 = otherfilename2.substring(l + 1);
+                    if (otherfilename.equals(otherfilename2)) {
+                        showMessage("Found multiple files with same filename");
+                        return;
+                    }
+                }
+            }
+
             try {
                 otherFiles = getAdditionalSerializedFiles();
             } catch (Exception e) {


### PR DESCRIPTION
### Description of what the PR does
- Updated class `SubmitRunPane` and put a check in function `testOrSubmitRun` to prevent submission of Files with duplicate names in Team GUI.
- Added a check inside `new-run.component.ts` of WTI-UI to prevent submission of Files with duplicate names in WTI.

### Issue which the PR addresses
Fixes #631 

### Environment in which the PR was developed (OS, IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR
#### To test the WTI-UI.
- Run the Ant script `package.xml` in the `pc2v9` project (this generates a complete new PC2 distribution; this is necessary to generate an updated `pc2.jar` file for use in the WTI distribution). Make sure there is `nodejs` version 16 installed before, if not follow the instructions [here](https://github.com/pc2ccs/pc2v9/pull/834).
- Copy the new `WebTeamInterface-1.1.zip` (or `.tar.gz`) file from the projects folder in the distribution to an empty folder.
Unzip the WTI file.
- Start a PC2 server, loading a sample contest such as "SumitHello".
- Start a PC2 Admin.
    - Ensure there is a "scoreboard2" account (if not, generate one).
    - Ensure there is at least one team account.
- Start the contest.
- Go into the unzipped WTI folder and execute the command `./bin/pc2wti.bat` (or `./bin/pc2wti` in Linux) to start the WTI server (API).
- Open a browser to http://localhost:8080/. You should see the standard WTI "Balloon Login" screen.
- Login as a team.
- Try to submit a problem where you add some files with the same name as each other or the Main File name in Additional Files.
- It would not submit and display the message `You may not submit multiple files with the same name`.
![Capture](https://github.com/pc2ccs/pc2v9/assets/24360328/d1bffc23-4b60-4305-baa5-dcabfc0b7db7)

#### To test the Team GUI
- Run the Ant script `build.xml` in the `pc2v9` project.
- Start a PC2 server, loading a sample contest such as "SumitHello".
- Start a PC2 Admin.
- Start the contest.
- Start a PC2 Team.
- Try to submit a problem where you add some files with the same name as each other or the Main File name in Additional Files.
- It would not submit and display the message `You may not submit multiple files with the same name`.
![Capture1](https://github.com/pc2ccs/pc2v9/assets/24360328/1107eba8-f6ae-475e-be54-9e71233f1b34)

### Additional Context
It is also possible to add the checks in `ServerConnection` class and throw an Exception but in that case the WTI-UI will display a generic error message and teams will not know why their submission was invalid. It can still be added as additional fail-safe to the system.