### PR TITLE
I897: Added Additional Files in the Confirm Submission window of Team GUI

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -493,14 +493,40 @@ public class SubmitRunPane extends JPanePlugin {
         if (submitTheRun) {
             try {
                 String confirmQuestion = "<HTML><FONT SIZE=+1>Do you wish to submit run for<BR><BR>" + "Problem:  <FONT COLOR=BLUE>" + Utilities.forHTML(problem.toString()) + "</FONT><BR><BR>"
-                        + "Language:  <FONT COLOR=BLUE>" + Utilities.forHTML(language.toString()) + "</FONT><BR><BR>" + "File: <FONT COLOR=BLUE>" + Utilities.forHTML(filename)
-                        + "</FONT><BR><BR></FONT>";
+                        + "Language:  <FONT COLOR=BLUE>" + Utilities.forHTML(language.toString()) + "</FONT><BR><BR>";
+
+                if (additionalFilesMCLB.getRowCount() > 0) {
+                    confirmQuestion += "<TABLE><TBODY><TR><TD><FONT SIZE=+1>Main File:</FONT></TD><TD><FONT COLOR=BLUE SIZE=+1>" + Utilities.forHTML(filename)
+                        + "</FONT></TD></TR>";
+                    String otherfilename = (String) additionalFilesMCLB.getRow(0)[0];
+                    confirmQuestion += "<TR><TD><FONT SIZE=+1>Additional File(s):</FONT></TD><TD><FONT COLOR=BLUE SIZE=+1>" + Utilities.forHTML(otherfilename) + "</FONT></TD></TR>";
+                    for (int i = 1; i < additionalFilesMCLB.getRowCount(); i++) {
+                        otherfilename = (String) additionalFilesMCLB.getRow(i)[0]; 
+                        confirmQuestion += "<TR><TD> </TD><TD><FONT COLOR=BLUE SIZE=+1>" + Utilities.forHTML(otherfilename) + "</FONT></TD></TR>";
+                    }
+                    confirmQuestion += "</TBODY></TABLE>";
+                }
+                else {
+                    confirmQuestion += "<TABLE><TBODY><TR><TD><FONT SIZE=+1>Main File:</FONT></TD><TD><FONT COLOR=BLUE SIZE=+1>" + Utilities.forHTML(filename)
+                        + "</FONT></TD></TR></TBODY></TABLE>";
+                }
+                confirmQuestion += "<BR><BR></FONT></HTML>";
 
                 int result = FrameUtilities.yesNoCancelDialog(getParentFrame(), confirmQuestion, "Confirm Submission");
 
                 if (result == JOptionPane.YES_OPTION) {
-
-                    log.info("submitRun for " + problem + " " + language + " file: " + filename);
+                    
+                    String logInfo = "submitRun for " + problem + " " + language + " main file: " + filename;
+                    if (additionalFilesMCLB.getRowCount() > 0) {
+                        logInfo += " additional file(s): [";
+                        for (int i = 0; i < additionalFilesMCLB.getRowCount(); i++) {
+                            String otherfilename = (String) additionalFilesMCLB.getRow(i)[0]; 
+                            logInfo += otherfilename;
+                            if (i == additionalFilesMCLB.getRowCount() - 1) logInfo += "]";
+                            else logInfo += ", ";
+                        }
+                    }
+                    log.info(logInfo);
                     getController().submitJudgeRun(problem, language, filename, otherFiles);
                 }
 

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -522,8 +522,12 @@ public class SubmitRunPane extends JPanePlugin {
                         for (int i = 0; i < additionalFilesMCLB.getRowCount(); i++) {
                             String otherfilename = (String) additionalFilesMCLB.getRow(i)[0]; 
                             logInfo += otherfilename;
-                            if (i == additionalFilesMCLB.getRowCount() - 1) logInfo += "]";
-                            else logInfo += ", ";
+                            if (i == additionalFilesMCLB.getRowCount() - 1) {
+                                logInfo += "]";
+                            }
+                            else {
+                                logInfo += ", ";
+                            }
                         }
                     }
                     log.info(logInfo);


### PR DESCRIPTION
### Description of what the PR does
Updated class `SubmitRunPane` and put a check in function `testOrSubmitRun` to add the Additional Files (if included) in the confirm submission window.

### Issue which the PR addresses
Fixes #897 

### Environment in which the PR was developed (OS, IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Run the Ant script `build.xml` in the `pc2v9` project.
- Start a PC2 server, loading a sample contest such as "SumitHello".
- Start a PC2 Admin.
- Start the contest.
- Start a PC2 Team.
- Try to submit a problem where you add some files with the same name as each other or the Main File name in Additional Files.
- The confirm submission window will now include all the Additional File(s) included.
![Capture](https://github.com/pc2ccs/pc2v9/assets/24360328/d9a3a554-1dea-4917-bc74-6d424b0ce8bf)
