### PR TITLE
I870: Added Enable/Disable Problem Display

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/SubmitClarificationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitClarificationPane.java
@@ -189,7 +189,7 @@ public class SubmitClarificationPane extends JPanePlugin {
     }
 
     /**
-     * Enable or disable submission buttons.
+     * Enable or disable submission buttons, Question pane and Problem drop-down list.
      * 
      * @param turnButtonsOn
      *            if true, buttons enabled.
@@ -197,6 +197,8 @@ public class SubmitClarificationPane extends JPanePlugin {
     private void setButtonsActive(final boolean turnButtonsOn) {
         SwingUtilities.invokeLater(new Runnable() {
             public void run() {
+                getProblemComboBox().setEnabled(turnButtonsOn);
+                getQuestionTextArea().setEnabled(turnButtonsOn);
                 getSubmitClarificationButton().setEnabled(turnButtonsOn);
             }
         });

--- a/src/edu/csus/ecs/pc2/ui/SubmitClarificationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitClarificationPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -171,7 +171,7 @@ public class SubmitRunPane extends JPanePlugin {
     }
 
     /**
-     * Enable or disable submission buttons.
+     * Enable or disable submission buttons and Problem-list drop-down.
      * 
      * @param turnButtonsOn
      *            if true, buttons enabled.
@@ -181,6 +181,7 @@ public class SubmitRunPane extends JPanePlugin {
             public void run() {
                 if (isTeam()) {
                     // Only turn buttons on and off if a Team
+                    getProblemComboBox().setEnabled(turnButtonsOn);
                     getSubmitRunButton().setEnabled(turnButtonsOn);
                     getPickFileButton().setEnabled(turnButtonsOn);
                     getTestButton().setEnabled(turnButtonsOn);

--- a/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitRunPane.java
@@ -171,7 +171,7 @@ public class SubmitRunPane extends JPanePlugin {
     }
 
     /**
-     * Enable or disable submission buttons and Problem-list drop-down.
+     * Enable or disable submission buttons and all drop-down lists.
      * 
      * @param turnButtonsOn
      *            if true, buttons enabled.
@@ -182,6 +182,7 @@ public class SubmitRunPane extends JPanePlugin {
                 if (isTeam()) {
                     // Only turn buttons on and off if a Team
                     getProblemComboBox().setEnabled(turnButtonsOn);
+                    getLanguageComboBox().setEnabled(turnButtonsOn);
                     getSubmitRunButton().setEnabled(turnButtonsOn);
                     getPickFileButton().setEnabled(turnButtonsOn);
                     getTestButton().setEnabled(turnButtonsOn);


### PR DESCRIPTION
### Description of what the PR does
The file submission buttons are enabled/disabled with the contest clock using the function `setButtonsActive` in `SubmitRunPane`. Added `getProblemComboBox().setEnabled` to enable/disable the Problem drop-down list in the same function and it will be synced with the file submission buttons getting enabled /disabled.

### Issue which the PR addresses
Fixes #870 

### Environment in which the PR was developed (OS, IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Run the Ant script `build.xml` in the `pc2v9` project.
- Start a PC2 server, loading a sample contest such as "SumitHello".
- Start a PC2 Admin (Do not start a contest yet).
- Start a PC2 Team.
- You should see in the top left in Red "STOPPED" denoting the contest is stopped. Now the problem pane will be grayed out and you'll not be able to interact and view the problem names there.
- Start the contest.
- The problem pane will now be active, and you can view the problem names now.
![image](https://github.com/pc2ccs/pc2v9/assets/24360328/fd950c18-fbb9-4eeb-bdb8-cd50c6fed06b)