### PR TITLE
I131: Update Cancelling invalid changes not to discard

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -425,11 +425,11 @@ public class EditProblemPane extends JPanePlugin {
      * message "Problem Modified - Save Changes?") and responding "Yes" to the message.
      * 
      */
-    protected void addProblem() {
+    protected boolean addProblem() {
 
         if (problemNameTextField.getText().trim().length() < 1) {
             showMessage("Enter a problem name (\"General\" tab)");
-            return;
+            return false;
         }
 
         if (!validateProblemFields()) {
@@ -437,7 +437,7 @@ public class EditProblemPane extends JPanePlugin {
             if (debug22EditProblem) {
                 System.err.println("DEBUG: validateProblemFields() returned false");
             }
-            return;
+            return false;
         }
 
         //warn if the problem has input data files but no Input Validator, unless the user has previously disabled this warning
@@ -464,7 +464,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorWarningOnAddProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
-                return;
+                return false;
             }
         }
 
@@ -485,7 +485,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorProgramNameOnAddProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
-                return;
+                return false;
             }
         }
 
@@ -532,11 +532,11 @@ public class EditProblemPane extends JPanePlugin {
             }
         } catch (InvalidFieldValue e) {
             showMessage(e.getMessage());
-            return;
+            return false;
         } catch (Exception e) {
             showMessage("Exeception while adding Problem; see log.");
             getLog().throwing("EditProblemPane", "addProblem()", e);
-            return;
+            return false;
         }
 
         if (!newProblem.getElementId().equals(newProblemDataFiles.getProblemId())) {
@@ -570,6 +570,7 @@ public class EditProblemPane extends JPanePlugin {
         if (getParentFrame() != null) {
             getParentFrame().setVisible(false);
         }
+        return true;
     }
 
     private int getIntegerValue(String s) {
@@ -2139,7 +2140,9 @@ public class EditProblemPane extends JPanePlugin {
 
             if (result == JOptionPane.YES_OPTION) {
                 if (getAddButton().isEnabled()) {
-                    addProblem();
+                    if (!addProblem()) {
+                        return;
+                    }
                 } else {
                     if (!updateProblem()) {
                         return;

--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -1654,13 +1654,13 @@ public class EditProblemPane extends JPanePlugin {
      * 
      */
 
-    protected void updateProblem() {
+    protected boolean updateProblem() {
 
         // showStackTrace();
 
         if (!validateProblemFields()) {
             // problem defined by the GUI fields is invalid, just return ( error message was issued by validateProblemFields() )
-            return;
+            return false;
         }
 
         //warn if the problem has input data files but no Input Validator, unless the user has previously disabled this warning
@@ -1687,7 +1687,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorWarningOnUpdateProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
-                return;
+                return false;
             }
         }
 
@@ -1709,7 +1709,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorProgramNameOnUpdateProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
-                return;
+                return false;
             }
         }
         // all the GUI fields are valid; create a new Problem from them
@@ -1786,11 +1786,11 @@ public class EditProblemPane extends JPanePlugin {
         } catch (InvalidFieldValue e) {
             JOptionPane.showMessageDialog(this, e.getMessage());
             // showMessage(e.getMessage());
-            return;
+            return false;
         } catch (Exception e) {
             showMessage("Exeception while updating Problem; see log.");
             getLog().throwing("EditProblemPane", "updateProblem()", e);
-            return;
+            return false;
         }
 
         // add a Problem Letter to the problem if it doesn't have one (note: problem letter is not displayed in the GUI)
@@ -1816,6 +1816,7 @@ public class EditProblemPane extends JPanePlugin {
         if (getParentFrame() != null) {
             getParentFrame().setVisible(false);
         }
+        return true;
     }
 
     /**
@@ -2140,7 +2141,9 @@ public class EditProblemPane extends JPanePlugin {
                 if (getAddButton().isEnabled()) {
                     addProblem();
                 } else {
-                    updateProblem();
+                    if (!updateProblem()) {
+                        return;
+                    }
                 }
                 if (getParentFrame() != null) {
                     getParentFrame().setVisible(false);

--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -434,7 +434,7 @@ public class EditProblemPane extends JPanePlugin {
         }
 
         if (!validateProblemFields()) {
-            // new problem is invalid, just return; message issued by validateProblemFields
+            // new problem is invalid, return false as problem was not added; message issued by validateProblemFields
             if (debug22EditProblem) {
                 System.err.println("DEBUG: validateProblemFields() returned false");
             }
@@ -465,6 +465,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorWarningOnAddProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
+                // return false as problem was not added
                 return false;
             }
         }
@@ -486,6 +487,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorProgramNameOnAddProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
+                // return false as problem was not added
                 return false;
             }
         }
@@ -533,10 +535,12 @@ public class EditProblemPane extends JPanePlugin {
             }
         } catch (InvalidFieldValue e) {
             showMessage(e.getMessage());
+            // return false as problem was not added
             return false;
         } catch (Exception e) {
             showMessage("Exeception while adding Problem; see log.");
             getLog().throwing("EditProblemPane", "addProblem()", e);
+            // return false as problem was not added
             return false;
         }
 
@@ -1662,7 +1666,7 @@ public class EditProblemPane extends JPanePlugin {
         // showStackTrace();
 
         if (!validateProblemFields()) {
-            // problem defined by the GUI fields is invalid, just return ( error message was issued by validateProblemFields() )
+            // problem defined by the GUI fields is invalid, return false as problem was not updated ( error message was issued by validateProblemFields() )
             return false;
         }
 
@@ -1690,6 +1694,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorWarningOnUpdateProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
+                // return false as problem was not updated
                 return false;
             }
         }
@@ -1712,6 +1717,7 @@ public class EditProblemPane extends JPanePlugin {
                 showMissingInputValidatorProgramNameOnUpdateProblem = false;
             }
             if (!(response == JOptionPane.YES_OPTION)) {
+                // return false as problem was not updated
                 return false;
             }
         }
@@ -1789,10 +1795,12 @@ public class EditProblemPane extends JPanePlugin {
         } catch (InvalidFieldValue e) {
             JOptionPane.showMessageDialog(this, e.getMessage());
             // showMessage(e.getMessage());
+            // return false as problem was not updated
             return false;
         } catch (Exception e) {
             showMessage("Exeception while updating Problem; see log.");
             getLog().throwing("EditProblemPane", "updateProblem()", e);
+            // return false as problem was not updated
             return false;
         }
 

--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -424,6 +424,7 @@ public class EditProblemPane extends JPanePlugin {
      * The method also gets invoked by making GUI changes to a new problem definition, then pressing "Cancel" (which displays a 
      * message "Problem Modified - Save Changes?") and responding "Yes" to the message.
      * 
+     * @return true if all GUI values are valid and problem is added successfully; false otherwise
      */
     protected boolean addProblem() {
 
@@ -1653,6 +1654,7 @@ public class EditProblemPane extends JPanePlugin {
      * then pressing "Cancel" (which displays a message "Problem Modified - Save Changes?") and responding "Yes"
      * to the message.
      * 
+     * @return true if all GUI values are valid and problem is updated successfully; false otherwise
      */
 
     protected boolean updateProblem() {


### PR DESCRIPTION
### Description of what the PR does
`handleCancelButton()` calls `updateProblem()` but it has no way to know whether it actually updated problems or exited due to some invalid changes. It simply runs the command to close the window after that. So, the return type of `updateProblem()` was changed to `boolean` and it returns `true` only if it successfully updates problem and `false` otherwise. Now `handleCancelButton()` will close the window only if `updateProblem()` returns `true`. Similar changes were made for `addProblem()`.

### Issue which the PR addresses
Fixes #131 

### Environment in which the PR was developed (OS, IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Run the Ant script build.xml in the pc2v9 project.
- Start a PC2 server, loading a sample contest such as "SumitHello".
- Start a PC2 Admin.
- Select a problem and click **Edit**.
- Make multiple changes with at least one invalid change.
- Click on **Cancel**.
- This displays a dialog "Problem modified, save changes?". Click on **Yes**.
- A prompt showing invalid configuration shows up. Click on **OK**
- Now the Edit problem pane does not close or discard any changes.
- Try the same for **Add** problem.
- Now if all changes are valid and user accepts changes then the pane will close.