### PR TITLE
Renaming JSerializFilePicker to JSerializedFilePicker

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/JSerializedFilePicker.java
+++ b/src/edu/csus/ecs/pc2/ui/JSerializedFilePicker.java
@@ -24,7 +24,7 @@ import edu.csus.ecs.pc2.core.model.SerializedFile;
  */
 
 // $HeadURL$
-public class JSerializFilePicker extends JPanel {
+public class JSerializedFilePicker extends JPanel {
 
     /**
      * 
@@ -45,7 +45,7 @@ public class JSerializFilePicker extends JPanel {
      * This method initializes
      * 
      */
-    public JSerializFilePicker() {
+    public JSerializedFilePicker() {
         super();
         initialize();
     }


### PR DESCRIPTION
## pull request

This issue addresses: [#887](https://github.com/pc2ccs/pc2v9/issues/887)

The goal was to rename the class: ``JSerializFilePicker`` to ``JSerializedFilePicker``

Tell me if this PR requires more information!
