### PR TITLE
I209: Display team stderr to judges

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -229,6 +229,11 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
     private ArrayList<String> teamsOutputFilenames = new ArrayList<String>();
 
     /**
+     * List of Team's output filenames, created by execute method.
+     */
+    private ArrayList<String> teamsStderrFilenames = new ArrayList<String>();
+
+    /**
      * List of Validator output filenames, created by execute method.
      */
     private ArrayList<String> validatorOutputFilenames = new ArrayList<String>();
@@ -359,6 +364,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
     public IFileViewer execute(boolean clearDirFirst) {
 
         teamsOutputFilenames = new ArrayList<String>();
+        teamsStderrFilenames = new ArrayList<String>();
 
         if (usingGUI) {
             fileViewer = new MultipleFileViewer(log);
@@ -1393,8 +1399,22 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
         return optStr;
     }
 
+    /**
+     * Returns a filename specific to data set number to store team's stdout
+     * 
+     * @param dataSetNumber
+     */
     private String getTeamOutputFilename(int dataSetNumber) {
         return prefixExecuteDirname("teamoutput." + dataSetNumber + ".txt");
+    }
+
+    /**
+     * Returns a filename specific to data set number to store team's stderr
+     * 
+     * @param dataSetNumber
+     */
+    private String getTeamStderrFilename(int dataSetNumber) {
+        return prefixExecuteDirname("teamstderr." + dataSetNumber + ".txt");
     }
 
     /**
@@ -2245,12 +2265,17 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
             // teams output file - single file name
             SerializedFile userOutputFile = executionData.getExecuteProgramOutput();
+            SerializedFile userStderrFile = executionData.getExecuteStderr();
             createFile(userOutputFile, prefixExecuteDirname(userOutputFile.getName()));
+            createFile(userStderrFile, prefixExecuteDirname(userStderrFile.getName()));
 
             String teamsOutputFilename = getTeamOutputFilename(dataSetNumber);
+            String teamsStderrFilename = getTeamStderrFilename(dataSetNumber);
 
             createFile(userOutputFile, teamsOutputFilename); // Create a per test case Team's output file
+            createFile(userStderrFile, teamsStderrFilename); // Create a per test case Team's stderr file
             teamsOutputFilenames.add(teamsOutputFilename); // add to list
+            teamsStderrFilenames.add(teamsStderrFilename); // add to list
             if (executionData.getExecuteExitValue() != 0) {
                 long returnValue = ((long) executionData.getExecuteExitValue() << 0x20) >>> 0x20;
 
@@ -3452,6 +3477,15 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
      */
     public List<String> getTeamsOutputFilenames() {
         return teamsOutputFilenames;
+    }
+
+    /**
+     * Get filenames for each team's stderr for each test case.
+     * 
+     * @return the list of team stderr file names.
+     */
+    public List<String> getTeamsStderrFilenames() {
+        return teamsStderrFilenames;
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -168,6 +168,11 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     private List<String> savedTeamOutputFileNames = null;
 
     /**
+     * Saved team stderr names.
+     */
+    private List<String> savedTeamStderrFileNames = null;
+
+    /**
      * saved validator output names
      */
     private List<String> savedValidatorOutputFileNames = null;
@@ -907,9 +912,11 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         }
 
         savedTeamOutputFileNames = executable.getTeamsOutputFilenames();
+        savedTeamStderrFileNames = executable.getTeamsStderrFilenames();
         savedValidatorOutputFileNames = executable.getValidatorOutputFilenames();
         savedValidatorErrFileNames = executable.getValidatorErrFilenames();
         sendTeamOutputFileNames();
+        sendTeamStderrFileNames();
         sendValidatorOutputFileNames();
         sendValidatorStderrFileNames();
         // only if do not show output is not checked
@@ -1021,6 +1028,46 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             }
 
             getTestResultsFrame().setTeamOutputFileNames(teamOutputNames);
+        }
+    }
+
+    /**
+     * Send execution stderr filenames to Test Results Viewer.
+     * 
+     * Copies the names from the List of exectution stderr file names (which was saved by the execute() method)
+     * into an array, then passes the array to the Test Results frame.
+     */
+    private void sendTeamStderrFileNames() {
+
+        if (getTestResultsFrame() != null) {
+
+            String[] teamStderrNames = null;
+
+            // add entries from actual team test stderr
+            if (savedTeamStderrFileNames != null) {
+                int size = getProblemDataFiles().getJudgesDataFiles().length;
+                if (size < savedTeamStderrFileNames.size()) {
+                    size = savedTeamStderrFileNames.size();
+                }
+                if (size < 1) {
+                    size = 1;
+                }
+                teamStderrNames = new String[size];
+
+                // null out list
+                for (int i = 0; i < size; i++) {
+                    teamStderrNames[i] = null;
+                }
+
+                for (int i = 0; i < savedTeamStderrFileNames.size(); i++) {
+                    teamStderrNames[i] = savedTeamStderrFileNames.get(i);
+                    if (new File(teamStderrNames[i]).length() == 0) {
+                        teamStderrNames[i] = null; 
+                    }
+                }
+            }
+
+            getTestResultsFrame().setTeamStderrFileNames(teamStderrNames);
         }
     }
 
@@ -1454,6 +1501,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     protected void viewOutputsAndData() {
 
         sendTeamOutputFileNames();
+        sendTeamStderrFileNames();
         sendValidatorOutputFileNames();
         sendValidatorStderrFileNames();
         if (getTestResultsFrame().isVisible()) {

--- a/src/edu/csus/ecs/pc2/ui/TestCaseResultsTableModel.java
+++ b/src/edu/csus/ecs/pc2/ui/TestCaseResultsTableModel.java
@@ -89,6 +89,9 @@ public class TestCaseResultsTableModel extends DefaultTableModel {
                 // link for viewing team output (which must exist - even if empty - since the test case was executed)
                 JLabel teamOutputViewLabel = new JLabel("View");
 
+                // link for viewing team stderr (which must exist - even if empty - since the test case was executed)
+                JLabel teamStderrViewLabel = new JLabel("View");
+
                 // links for comparing team output with corresponding judge's output (but only if the problem has judge's data)
                 JLabel teamOutputCompareLabel = new JLabel("");                
                 JLabel judgesOutputViewLabel = new JLabel("");
@@ -139,7 +142,7 @@ public class TestCaseResultsTableModel extends DefaultTableModel {
 
                 // build the row object and add it to the model
                 Object[] rowData = new Object[] { selected, testCaseNum, resultLabel, time,
-                        teamOutputViewLabel, teamOutputCompareLabel, judgesOutputViewLabel,
+                        teamOutputViewLabel, teamOutputCompareLabel, teamStderrViewLabel, judgesOutputViewLabel,
                         judgesDataViewLabel, validatorOutputViewLabel, validatorStderrViewLabel };
 
                 super.addRow(rowData);
@@ -247,6 +250,9 @@ public class TestCaseResultsTableModel extends DefaultTableModel {
         
         //link for comparing team output with corresponding judge's output
         JLabel teamOutputCompareJLabel = new JLabel(data.getTeamsOutputCompareLabel());
+
+        //link for viewing team stderr
+        JLabel teamStderrViewJLabel = new JLabel(data.getTeamStderrViewLabel());
         
         //link for viewing judge's output
         JLabel judgesOutputViewJLabel = new JLabel(data.getJudgesOutputViewLabel());
@@ -261,7 +267,7 @@ public class TestCaseResultsTableModel extends DefaultTableModel {
 
         //build the row object and add it to the model
         Object [] rowData = new Object [] {selected, testCaseNum, resultLabel, data.getTime(), 
-                teamOutputViewJLabel, teamOutputCompareJLabel, judgesOutputViewJLabel, 
+                teamOutputViewJLabel, teamOutputCompareJLabel, teamStderrViewJLabel, judgesOutputViewJLabel, 
                 judgesDataViewJLabel, validatorOutputViewJLabel, validatorStderrViewJLabel };
 
         super.addRow(rowData);

--- a/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
@@ -90,6 +90,10 @@ public class TestResultsFrame extends javax.swing.JFrame implements UIPlugin {
         getMultiTestSetOutputViewerPane().setTeamOutputFileNames(filenames);
     }
 
+    public void setTeamStderrFileNames(String [] filenames){
+        getMultiTestSetOutputViewerPane().setTeamStderrFileNames(filenames);
+    }
+
     public void setValidatorStderrFileNames(String[] filenames) {
         getMultiTestSetOutputViewerPane().setValidatorStderrFileNames(filenames);
     }

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -2012,7 +2012,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
      */
     protected void viewFile(int row, int col) {
         //make sure the column points to one of the "file links" in the table
-        if (col != COLUMN.TEAM_OUTPUT_VIEW.ordinal() && col != COLUMN.JUDGE_OUTPUT.ordinal() && col != COLUMN.JUDGE_DATA.ordinal() && col != COLUMN.VALIDATOR_OUTPUT.ordinal()
+        if (col != COLUMN.TEAM_OUTPUT_VIEW.ordinal() && col != COLUMN.TEAM_ERR.ordinal() && col != COLUMN.JUDGE_OUTPUT.ordinal() && col != COLUMN.JUDGE_DATA.ordinal() && col != COLUMN.VALIDATOR_OUTPUT.ordinal()
                 && col != COLUMN.VALIDATOR_ERR.ordinal()) {
             if (log != null) {
                 log.log(Log.WARNING, "TestResultsPane.viewFile(): invalid column number for file viewing request: " + col);
@@ -2049,6 +2049,8 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         String title = "<unknown>";
         if (col == COLUMN.TEAM_OUTPUT_VIEW.ordinal()) {
             title = "Team Output"; 
+        } else if (col == COLUMN.TEAM_ERR.ordinal()) {
+            title = "Team STDERR";
         } else if (col == COLUMN.JUDGE_OUTPUT.ordinal()) {
             title = "Judge's Output";
         } else if (col == COLUMN.JUDGE_DATA.ordinal()) {
@@ -2200,6 +2202,16 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
                     returnFile = null;
                 } else {
                     returnFile = currentTeamOutputFileNames[row];
+                }
+            }
+        } else if (col == COLUMN.TEAM_ERR.ordinal()) {
+            //get team output file corresponding to test case "row"
+            if (currentTeamStderrFileNames != null || currentTeamStderrFileNames.length >= row) {
+                // get the team output file name, which should be provided by the client as a full path
+                if (currentTeamStderrFileNames[row] == null) {
+                    returnFile = null;
+                } else {
+                    returnFile = currentTeamStderrFileNames[row];
                 }
             }
         } else if (col == COLUMN.JUDGE_OUTPUT.ordinal()) {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -105,13 +105,13 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
      * list of columns
      */
     protected enum COLUMN {
-        SELECT_CHKBOX, DATASET_NUM, RESULT, TIME, TEAM_OUTPUT_VIEW, TEAM_OUTPUT_COMPARE, 
+        SELECT_CHKBOX, DATASET_NUM, RESULT, TIME, TEAM_OUTPUT_VIEW, TEAM_OUTPUT_COMPARE, TEAM_ERR,
             JUDGE_OUTPUT, JUDGE_DATA, VALIDATOR_OUTPUT, VALIDATOR_ERR
     };
 
     // define the column headers for the table of results
     private String[] columnNames = { "Select", "Data Set #", "Result", "Time (ms)", 
-                                        "Team Output", "Compare Outputs", 
+                                        "Team Output", "Compare Outputs", "Team StdErr",
                                         "Judge's Output", "Judge's Data", "Validator StdOut",
                                         "Validator StdErr" };
 
@@ -1690,6 +1690,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         // set a LinkRenderer on those cells containing links
         localResultsTable.getColumn(columnNames[COLUMN.TEAM_OUTPUT_VIEW.ordinal()]).setCellRenderer(new LinkCellRenderer());
         localResultsTable.getColumn(columnNames[COLUMN.TEAM_OUTPUT_COMPARE.ordinal()]).setCellRenderer(new LinkCellRenderer());
+        localResultsTable.getColumn(columnNames[COLUMN.TEAM_ERR.ordinal()]).setCellRenderer(new LinkCellRenderer());
         localResultsTable.getColumn(columnNames[COLUMN.JUDGE_OUTPUT.ordinal()]).setCellRenderer(new LinkCellRenderer());
         localResultsTable.getColumn(columnNames[COLUMN.JUDGE_DATA.ordinal()]).setCellRenderer(new LinkCellRenderer());
         localResultsTable.getColumn(columnNames[COLUMN.VALIDATOR_OUTPUT.ordinal()]).setCellRenderer(new LinkCellRenderer());
@@ -1879,11 +1880,12 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 //                "--  ",                                     //execution time (of which there is none since the test case wasn't executed)
 //                "",                                         //link to team output (none since it wasn't executed)
 //                "",                                         //link to team compare-with-judge label (disabled since there's no team output)
+//                "",                                         //link to team stderr (none since it wasn't executed)
 //                viewJudgeAnswerFile,                        //link to judge's output (answer file) if any
 //                viewJudgeDataFile,                          //link to judge's data if any
 //                "",                                         //link to validator stdout (none)
 //                ""                                          //link to validator stderr (none)
-                TestResultsRowData rowData = new TestResultsRowData("Not Executed", "--  ","", "",viewJudgeAnswerFile,viewJudgeDataFile, "", "");
+                TestResultsRowData rowData = new TestResultsRowData("Not Executed", "--  ", "", "", "",viewJudgeAnswerFile,viewJudgeDataFile, "", "");
                 tableModel.addRow(
                         new Boolean(false),                         //selection checkbox
                         new String(Integer.toString(testCaseNum)),  //test case number
@@ -1915,15 +1917,16 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             }
             
             // Add exactly one row as a place holder to tell the user judging is taking place
-            //     "Awaiting Result",                          //result string
+            //     "Judging",                                   //result string
             //      "--  ",                                     //execution time (of which there is none since the test case wasn't executed)
             //      "",                                         //link to team output (none since it wasn't executed)
             //      "",                                         //link to team compare-with-judge label (disabled since there's no team output)
+            //      "",                                         //link to team stderr (none since it wasn't executed)
             //      "",                                         //link to judge's output (answer file) if any
             //      "",                                         //link to judge's data if any
             //      "",                                         //link to validator stdout (none)
             //      ""                                          //link to validator stderr (none)
-            TestResultsRowData rowData = new TestResultsRowData("Judging", "--  ","", "","", "", "", "");
+            TestResultsRowData rowData = new TestResultsRowData("Judging", "--  ", "", "", "", "", "", "", "");
             // add new row
             tableModel.addRow(
                     new Boolean(false),                         //selection checkbox

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -2196,7 +2196,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         
         if (col == COLUMN.TEAM_OUTPUT_VIEW.ordinal() || col == COLUMN.TEAM_OUTPUT_COMPARE.ordinal()) {
             //get team output file corresponding to test case "row"
-            if (currentTeamOutputFileNames != null || currentTeamOutputFileNames.length >= row) {
+            if (currentTeamOutputFileNames != null && currentTeamOutputFileNames.length >= row) {
                 // get the team output file name, which should be provided by the client as a full path
                 if (currentTeamOutputFileNames[row] == null) {
                     returnFile = null;
@@ -2206,7 +2206,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             }
         } else if (col == COLUMN.TEAM_ERR.ordinal()) {
             //get team output file corresponding to test case "row"
-            if (currentTeamStderrFileNames != null || currentTeamStderrFileNames.length >= row) {
+            if (currentTeamStderrFileNames != null && currentTeamStderrFileNames.length >= row) {
                 // get the team output file name, which should be provided by the client as a full path
                 if (currentTeamStderrFileNames[row] == null) {
                     returnFile = null;

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -145,6 +145,8 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
     
     private String [] currentTeamOutputFileNames ;
 
+    private String [] currentTeamStderrFileNames;
+
     private JLabel lblLanguage;
 
     private JLabel lblNumFailedTestCases;
@@ -2324,6 +2326,10 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
      */
     public void setTeamOutputFileNames(String [] filenames){
         this.currentTeamOutputFileNames = filenames ;
+    }
+
+    public void setTeamStderrFileNames(String [] filenames){
+        this.currentTeamStderrFileNames = filenames;
     }
 
     public void setValidatorOutputFileNames(String[] filenames) {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsRowData.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsRowData.java
@@ -12,7 +12,8 @@ public class TestResultsRowData {
     private String resultString; 
     private String time; 
     private String teamOutputViewLabel;
-    private String teamOutputCompareLabel; 
+    private String teamOutputCompareLabel;
+    private String teamStderrViewLabel; 
     private String judgesOutputViewLabel; 
     private String judgesDataViewLabel;
     private String validatorOutputViewLabel; 
@@ -22,18 +23,20 @@ public class TestResultsRowData {
      * @param time
      * @param teamOutputViewLabel
      * @param teamOutputCompareLabel
+     * @param teamStderrViewLabel
      * @param judgesOutputViewLabel
      * @param judgesDataViewLabel
      * @param validatorOutputViewLabel
      * @param validatorStderrViewLabel
      */
-    public TestResultsRowData(String resultString, String time, String teamOutputViewLabel, String teamOutputCompareLabel, String judgesOutputViewLabel, String judgesDataViewLabel,
+    public TestResultsRowData(String resultString, String time, String teamOutputViewLabel, String teamOutputCompareLabel, String teamStderrViewLabel, String judgesOutputViewLabel, String judgesDataViewLabel,
             String validatorOutputViewLabel, String validatorStderrViewLabel) {
         super();
         this.resultString = resultString;
         this.time = time;
         this.teamOutputViewLabel = teamOutputViewLabel;
         this.teamOutputCompareLabel = teamOutputCompareLabel;
+        this.teamStderrViewLabel = teamStderrViewLabel;
         this.judgesOutputViewLabel = judgesOutputViewLabel;
         this.judgesDataViewLabel = judgesDataViewLabel;
         this.validatorOutputViewLabel = validatorOutputViewLabel;
@@ -75,6 +78,12 @@ public class TestResultsRowData {
      */
     public String getTeamsOutputCompareLabel() {
         return teamOutputCompareLabel;
+    }
+    /**
+     * @return the teamOutputViewLabel
+     */
+    public String getTeamStderrViewLabel() {
+        return teamStderrViewLabel;
     }
     /**
      * @return the judgesDataViewLabel


### PR DESCRIPTION
### Description of what the PR does
- Updated `Executable` class to now save Team stderr for each test case in a file and return the list of files
- Updated `SelectJudgmentPaneNew` to receive list of team stderr files from executable and forward it to `TestResultsPane`
- Updated `TestResultsFrame` to forward list of team stderr files to `TestResultsPane`
- Updated `TestResultsPane` to add a new column for team stderr and show the stderr upon button click
- Updated `TestCaseResultsTableModel` to handle new column for team stderr
- Updated `TestResultsRowData` to handle new column for team stder

### Issue which the PR addresses
Fixes #209 

### Environment in which the PR was developed (OS, IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8), C++ 13.2.0

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Run the Ant script build.xml in the pc2v9 project.
- Start a PC2 server, loading a sample contest such as "SumitHello".
- Start a PC2 Admin.
- In `Problems` pane make sure one of the problems have judging type set to Manual, if not edit and set to Manual.
- In `Auto Judge` pane make sure one of the judges have Problems `(none selected)`, if not edit and set.
- Start the contest.
- Start a PC2 team.
- Make a submission for a problem which had manual judging type set.
- It is usually hard to get to receive execution time STDERR. I set C++ and simulated using `cerr`. Need to be tested for other languages.
- Starte a PC2 judge. Make sure to use the one which no problems set for auto-judge.
- Select the submission from `New Runs` pane and request run.
- In `Select Judgement for Run {:id}` window click on Execute Run.
- In `Test Results for Run {:id}` you should see a new column name `Team StdErr`. Click on View to view the StdErr.
![image](https://github.com/pc2ccs/pc2v9/assets/24360328/b9d0b231-051d-429f-8c07-724cab0b9a39)

### Additional Context
- CI: In All Runs pane if we try to Rejudge, then View Outputs and Data and then try to view any Team Output/Stderr, etc. it throws NullPointerException error. This is because in TestResultsPane lines 2199 and 2209 it checks for the condition `currentTeamOutputFileNames != null || currentTeamOutputFileNames.length >= row` and because the condition has OR it checks for the length even if the variable is null.
Resolution: Changed the condition to AND i.e. `&&`.
- CI: The above issue occurs because the list variable is null which should not happen technically. This is because all the output/stderr, etc. files are created in a temporary folder `executesiteNjudgeM` and the contents are deleted each time `SelectJudgementFrame` is called. Currently a testcase output and stderr is being stored in a SerializedFile in ExecutionData object of Executable class and it gets overwritten for each test case (can be resolved by making it a list of SerilizedFiles). However the Executable/ExecutionData object is not saved anywhere in PC2 database. The TestResultsPane table is being  populated using objects of Run, RunFiles, RunTestCase (it stores only the verdict) but they do not store the actual output/stderr.
Resolution: Need to be researched more. It is a potential roadblock to solving issues #35, #39, etc.