### PR TITLE
I168 improve WTI-UI notifications

### DIFF
--- a/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.ts
@@ -43,7 +43,7 @@ export class NewClarificationComponent implements OnInit, OnDestroy {
         this.newClarificationForm.reset();
         this.close();
         this._contestService.clarificationsUpdated.next();
-        this._uiHelper.alert('Clarification has been submitted successfully!');
+        this._uiHelper.alertOk('Clarification has been submitted successfully!');
       }, (error: any) => {
         console.error('error submitting new clarification');
         console.error(error);

--- a/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
@@ -30,7 +30,7 @@ export class UiHelperService {
 
   alert(message: string): void {
     this._matSnackBar.open(message, 'Close', {
-      duration: 120000,   //automatically dismiss after 2 minutes
+      duration: undefined,   //no automatic dismissal; user must close
 	  horizontalPosition: 'center',
 	  verticalPosition: 'top'
     });

--- a/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
@@ -31,8 +31,7 @@ export class UiHelperService {
   alert(message: string): void {
     this._matSnackBar.open(message, 'Close', {
       duration: undefined,   //no automatic dismissal; user must close
-	  horizontalPosition: 'center',
-	  verticalPosition: 'top'
+	  panelClass: 'green-snackbar'
     });
   }
 

--- a/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
@@ -30,7 +30,9 @@ export class UiHelperService {
 
   alert(message: string): void {
     this._matSnackBar.open(message, 'Close', {
-      duration: 4000
+      duration: 120000,   //automatically dismiss after 2 minutes
+	  horizontalPosition: 'center',
+	  verticalPosition: 'top'
     });
   }
 

--- a/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
+++ b/projects/WTI-UI/src/app/modules/core/services/ui-helper.service.ts
@@ -28,10 +28,17 @@ export class UiHelperService {
     }
   }
 
-  alert(message: string): void {
+  alertOk(message: string): void {
     this._matSnackBar.open(message, 'Close', {
       duration: undefined,   //no automatic dismissal; user must close
 	  panelClass: 'green-snackbar'
+    });
+  }
+
+  alertError(message: string): void {
+    this._matSnackBar.open(message, 'Close', {
+      duration: undefined,   //no automatic dismissal; user must close
+	  panelClass: 'red-snackbar'
     });
   }
 

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -123,7 +123,7 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	    this._uiHelper.alertError('File names may not contain spaces');
 	    console.error('One or more submitted file contains a space in its filename');
   } else if (this.filenameContainsDuplicates(this.mainFile, this.additionalFiles)) {
-      this._uiHelper.alert('You may not submit multiple files with the same name');
+      this._uiHelper.alertError('You may not submit multiple files with the same name');
 	    console.error('One or more submitted file have the same filename');
 	} else {
 		//submit the run

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -120,7 +120,7 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	//make sure no file names contain blanks (the PC2 server chokes on such filenames)
 	if (this.filenameContainsBlanks(this.mainFile, this.additionalFiles, this.testFiles)){
 		//pop up an error dialog
-	    this._uiHelper.alert('File names may not contain spaces');
+	    this._uiHelper.alertError('File names may not contain spaces');
 	    console.error('One or more submitted file contains a space in its filename');
   } else if (this.filenameContainsDuplicates(this.mainFile, this.additionalFiles)) {
       this._uiHelper.alert('You may not submit multiple files with the same name');
@@ -132,10 +132,10 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	      .subscribe(_ => {
 	        this.clearNewSubmission();
 	        this.close();
-	        this._uiHelper.alert('Run has been submitted successfully!');
+	        this._uiHelper.alertOk('Run has been submitted successfully!');
 	        this._teamService.runsUpdated.next();
 	      }, (error: any) => {
-	        this._uiHelper.alert('Error submitting problem! Check console for details');
+	        this._uiHelper.alertError('Error submitting problem! Check console for details');
 	        console.error(error);
 	      });
 	}
@@ -147,7 +147,7 @@ export class NewRunComponent implements OnInit, OnDestroy {
     try {
       fileSubmission.byteData = btoa(fileContents);
     } catch (error) {
-      this._uiHelper.alert('Binary files are not allowed!');
+      this._uiHelper.alertError('Binary files are not allowed!');
       fileSubmission.byteData = fileContents;
       // window.location.href = 'http://amishrakefight.org/gfy/';
     }

--- a/projects/WTI-UI/src/app/modules/shared/components/app-footer/app-footer.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/app-footer/app-footer.component.html
@@ -1,3 +1,3 @@
 <footer>
-    <div class='center'>Copyright © 2020 PC^2&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a (click)='showAbout()'>About</a></div>
+    <div class='center'>Copyright © 2020-2024 PC<sup>2</sup>&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a (click)='showAbout()'>About</a></div>
 </footer>

--- a/projects/WTI-UI/src/styles/styles.scss
+++ b/projects/WTI-UI/src/styles/styles.scss
@@ -75,10 +75,29 @@ button.textLink {
 }
 
 .mat-mdc-snack-bar-container {
+	
     &.green-snackbar {
       --mdc-snackbar-container-color: lightgreen;
-      --mat-mdc-snack-bar-button-color: red;
       --mdc-snackbar-supporting-text-color: black;
+//      --mat-mdc-snack-bar-button-color: red;   //doesn't seem to work as expected
+
+      button {
+	    background:white; 
+        font-size: 1.2rem;
+        font-weight: bold;
+      }
+    }
+
+    &.red-snackbar {
+      --mdc-snackbar-container-color: red;
+      --mdc-snackbar-supporting-text-color: white;
+//      --mat-mdc-snack-bar-button-color: black;  //doesn't seem to work as expected
+
+      button {
+	    background:white; 
+        font-size: 1.2rem;
+        font-weight: bold;
+      }
     }
 }
 

--- a/projects/WTI-UI/src/styles/styles.scss
+++ b/projects/WTI-UI/src/styles/styles.scss
@@ -74,6 +74,14 @@ button.textLink {
     align-items: center !important;
 }
 
+.mat-mdc-snack-bar-container {
+    &.green-snackbar {
+      --mdc-snackbar-container-color: lightgreen;
+      --mat-mdc-snack-bar-button-color: red;
+      --mdc-snackbar-supporting-text-color: black;
+    }
+}
+
 a { cursor: pointer; }
 
 th {

--- a/projects/WTI-UI/src/styles/styles.scss
+++ b/projects/WTI-UI/src/styles/styles.scss
@@ -69,6 +69,7 @@ button.textLink {
 
 .center { text-align: center; }
 
+/*Center items in the global overlay (causes MatSnackBar alerts to be centered) */
 .cdk-global-overlay-wrapper {
     align-items: center !important;
 }

--- a/projects/WTI-UI/src/styles/styles.scss
+++ b/projects/WTI-UI/src/styles/styles.scss
@@ -69,6 +69,10 @@ button.textLink {
 
 .center { text-align: center; }
 
+.cdk-global-overlay-wrapper {
+    align-items: center !important;
+}
+
 a { cursor: pointer; }
 
 th {


### PR DESCRIPTION
### Description of what the PR does

Updates various elements of the WTI-UI Angular code to improve the WTI-UI notification interface.  Specifically:
- Separates the `ui-helper.service.ts` method `alert()` into two separate methods, one named `alertOk()` for displaying "normal/successful-operation" alerts and another named `alertError()` for displaying "error condition" alerts;
- Updates all calls in WTI-UI code to the old `alert()` method to instead call one of the new alert methods (`alertOk()` or `alertError()`) depending on the reason for the alert notification;
- Updates the calls to `MatSnackBar.open()` in both `alertOk()` and `alertError()` so that the corresponding  notifications remain on the screen indefinitely (that is, until the user dismisses them by clicking their `Close` button);
- Updates the global SCSS (Sass Cascading Style Sheets) file `styles.scss` so that
  - All alert notifications are displayed centered on the screen;
  - Normal alert notifications (those generated by calls to `alertOk()`) are displayed on a GREEN background;
  - Error alert notifications (those generated by calls to `alertError()` are displayed on a RED background.
- The PR also updates the copyright date in the WTI-UI footer, and fixes the formatting of the "PC2" superscript "2".


### Issue which the PR addresses

Fixes #168

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 10, Eclipse Version: 2020-12 (4.18.0); Java version "11.0.16.1" 2022-08-18 LTS

### Precise steps for _testing_ the PR 

- Download the PR code to your local system.
- Run the "package.xml" script to build a local version of the PR
  (this is necessary because GitHub build artifacts currently do not contain the WTI code;
   see Issue 896 - https://github.com/pc2ccs/pc2v9/issues/896)
- Copy the .zip or .gzip file from the new distribution into an empty folder.
- Unzip the distribution.
- Open a command prompt in the unzipped distribution folder.
- Start the PC2 Server, loading a sample contest -- e.g. with the command 
     `.\bin\pc2server --login s1 --contestpassword contest --load sumithello`
- Start a PC2 Admin.
- Start the contest if it is not already running (it won't be with the default "sumithello" contest).
- Go into the projects folder in the distribution and unzip the WebTeamInterface-1.1-.zip file containing the WTI code.
- Open a command prompt in the unzipped WTI folder.
- Start the WTI server, e.g. with the command `.\bin\pc2wti`
- Open a browser to `http://localhost:8080`.
- Login to the WTI using an existing team account (the "sumithello" contest predefines team1 through team22).
- Click on "Submit Problem", then select a problem, a language, and a legitimate source code file (with no spaces in the file name).
- Click "Submit".

You should see a green notification box, centered in the screen, like this:

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/ba408c24-dfc4-4707-ad1a-61cea15c97f2)


- Try moving to other tabs; notice that the notification remains on-screen and centered.  It also won't go away no matter how long you wait (although taking some action which generates ANOTHER notification WILL dismiss the current notification.) 

- Go back to the "Runs" tab.
- Click the "Close" button on the green notification.
- Click "Submit Problem" again.
- Select a problem and a language.
- Select a source file THAT CONTAINS SPACES IN THE FILE NAME.

You should see a RED notification box, centered in the screen, like this:

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/f8e2265d-d532-41c4-8832-85ddcde1a702) 

- Click CLOSE.
- Go to the PC2 Admin and verify that this second submission was NOT sent to the PC2 server.

- Click "Submit Problem" again.
- Select a problem and a language.
- Select a "Main File" that is a BINARY file -- i.e. not a text file.  For example, try selecting a .png, .jpg, or .gif file.

You should see a RED notification box, centered in the screen, like this:

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/e1fb1719-d4f4-4fc9-94b5-abd1daada732)


- Click "Close" on the notification box, and then click "Submit" (as if you really are trying to submit the binary file).

You should see a RED notification box, centered in the screen, like this:

![image](https://github.com/pc2ccs/pc2v9/assets/9256691/5c6481ce-0783-4b7d-b5e0-188258386db0)

You can open the browser Dev Console and see that the PC2 Server responded with a "Bad Request" (due to the submission of the binary file).

### Additional Information

It took a long time to get this PR working; I figured it might be useful to document something about that here.  In particular, the problem was getting the "notification" messages -- which are actually instances of Angular `Material SnackBar` class -- to be centered and to use different colors.  Almost all of the online resources describing how to do this failed to work.  It turned out that the reason for this is because those examples wich assume the SnackBar is being instantiated in an Angular `Component`.  However, in the WTI-UI code the SnackBar which displays alerts is actually instantiated in a _service class_ (specifically, `UIHelperService`).  Because of this, the SnackBar elements _are not associated with any particular component_ (such as "New Run"); they are instead associated with a `<div>` near the top level of the DOM.  In other words, they "float" above the entire document.

This meant that any changes which were coded in the CSS (which is stored in `styles.scss`) that attempted to format the SnackBar using standard CSS "classes" were being ignored.  Eventually I figured out how to write CSS code that modified the SnackBar `<div>` at the top level.  That's why you'll see strange things in the updated `styles.scss` file like
```css
.mat-mdc-snack-bar-container {
    &.green-snackbar {
      --mdc-snackbar-container-color: lightgreen;
      --mdc-snackbar-supporting-text-color: black;
      button {
	background:white; 
        font-size: 1.2rem;
        font-weight: bold;
      }
    }
```
This code is modifying the top-level "snack-bar-container", by defining CSS classes for that container.

