### PR TITLE
i_395 scoring properties settings now on main page

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -1,10 +1,9 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.ComponentOrientation;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Graphics2D;
@@ -47,7 +46,6 @@ import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
-
 import edu.csus.ecs.pc2.core.CommandVariableReplacer;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.model.ContestInformation;
@@ -153,8 +151,6 @@ public class ContestInformationPane extends JPanePlugin {
 
     private JTextField textfieldMaxOutputSizeInK = null;
 
-    private JButton scoringPropertiesButton = null;
-
     private Properties savedScoringProperties = null; // @jve:decl-index=0:
 
     private Properties changedScoringProperties = null;
@@ -184,6 +180,8 @@ public class ContestInformationPane extends JPanePlugin {
     private JPanel judgesDefaultAnswerPane;
 
     private JPanel judgingOptionsPane;
+    
+    private ScoringPropertiesPane scoringPropertiesPane;
 
     private JPanel teamSettingsPane;
 
@@ -501,9 +499,9 @@ public class ContestInformationPane extends JPanePlugin {
             judgeSettingsPane = new JPanel();
             
             judgeSettingsPane.setAlignmentX(LEFT_ALIGNMENT);
-            judgeSettingsPane.setMaximumSize(new Dimension(750, 250));
-            judgeSettingsPane.setMinimumSize(new Dimension(750, 250));
-            judgeSettingsPane.setPreferredSize(new Dimension(750,250));
+            judgeSettingsPane.setMaximumSize(new Dimension(800, 400));
+            judgeSettingsPane.setMinimumSize(new Dimension(800, 400));
+            judgeSettingsPane.setPreferredSize(new Dimension(800,350));
 
             if (showPaneOutlines) {
                 
@@ -527,8 +525,9 @@ public class ContestInformationPane extends JPanePlugin {
             
             judgeSettingsPane.add(getJudgingOptionsPane(),LEFT_ALIGNMENT);
             
+            judgeSettingsPane.add(getScoringPropertiesPane(),LEFT_ALIGNMENT);
+            
             judgeSettingsPane.add(Box.createHorizontalStrut(20));
-            judgeSettingsPane.add(getScoringPropertiesButton(),LEFT_ALIGNMENT);
 
         }
         return judgeSettingsPane;
@@ -703,7 +702,19 @@ public class ContestInformationPane extends JPanePlugin {
         }
         return teamInformationDisplaySettingsPane;
     }
+    private JPanel getScoringPropertiesPane() {
+        if (scoringPropertiesPane == null) {
+            scoringPropertiesPane = new ScoringPropertiesPane(getUpdateButton(),getCancelButton());
 
+            scoringPropertiesPane.setBorder(javax.swing.BorderFactory.createTitledBorder(null, "Scoring Properties", 
+                    javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
+                    javax.swing.border.TitledBorder.DEFAULT_POSITION, null, null));
+            
+        }
+        return scoringPropertiesPane;
+    }
+
+    
     private JPanel getJudgingOptionsPane() {
         if (judgingOptionsPane == null) {
             
@@ -994,7 +1005,7 @@ public class ContestInformationPane extends JPanePlugin {
             newContestInformation.setAutoStartContest(savedContestInformation.isAutoStartContest());
         }
 
-        newContestInformation.setScoringProperties(changedScoringProperties);
+        newContestInformation.setScoringProperties(scoringPropertiesPane.getProperties());
         
         newContestInformation.setFreezeTime(contestFreezeLengthTextField.getText());
 
@@ -1074,6 +1085,7 @@ public class ContestInformationPane extends JPanePlugin {
 
                 getUnfreezeScoreboardButton().setSelected(contestInformation.isUnfrozen());
                 setContestInformation(contestInformation);
+                ((ScoringPropertiesPane) getScoringPropertiesPane()).setProperties(changedScoringProperties);
                 setEnableButtons(false);
             }
 
@@ -1443,60 +1455,6 @@ public class ContestInformationPane extends JPanePlugin {
         return allowMultipleTeamLoginsCheckbox ;
     }
 
-    /**
-     * This method initializes scoringPropertiesButton
-     * 
-     * @return javax.swing.JButton
-     */
-    private JButton getScoringPropertiesButton() {
-        if (scoringPropertiesButton == null) {
-            
-            scoringPropertiesButton = new JButton();
-            scoringPropertiesButton.setHorizontalAlignment(SwingConstants.LEFT);
-            scoringPropertiesButton.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT);
-
-            scoringPropertiesButton.setAlignmentX(LEFT_ALIGNMENT);
-            scoringPropertiesButton.setToolTipText("Edit Scoring Properties");
-            scoringPropertiesButton.setMnemonic(KeyEvent.VK_S);
-            scoringPropertiesButton.setText("Edit Scoring Properties");
-            scoringPropertiesButton.addActionListener(new java.awt.event.ActionListener() {
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                    showContestPropertiesEditor();
-                }
-            });
-        }
-        return scoringPropertiesButton;
-    }
-
-    protected void showContestPropertiesEditor() {
-
-        PropertiesEditFrame propertiesEditFrame = new PropertiesEditFrame();
-        propertiesEditFrame.setTitle("Edit Scoring Properties");
-        propertiesEditFrame.setProperties(changedScoringProperties, new UpdateScoreProperties());
-        propertiesEditFrame.setVisible(true);
-    }
-
-    /**
-     * Update the edited properties.
-     * 
-     * @author pc2@ecs.csus.edu
-     * @version $Id$
-     */
-
-    // $HeadURL$
-    protected class UpdateScoreProperties implements IPropertyUpdater {
-
-        public void updateProperties(Properties properties) {
-            changedScoringProperties = properties;
-            enableUpdateButton();
-        }
-    }
-
-    /**
-     * This method initializes ccsTestModeCheckbox
-     * 
-     * @return javax.swing.JCheckBox
-     */
     private JCheckBox getCcsTestModeCheckbox() {
         if (ccsTestModeCheckbox == null) {
             

--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -499,9 +499,9 @@ public class ContestInformationPane extends JPanePlugin {
             judgeSettingsPane = new JPanel();
             
             judgeSettingsPane.setAlignmentX(LEFT_ALIGNMENT);
-            judgeSettingsPane.setMaximumSize(new Dimension(800, 400));
-            judgeSettingsPane.setMinimumSize(new Dimension(800, 400));
-            judgeSettingsPane.setPreferredSize(new Dimension(800,350));
+            judgeSettingsPane.setMaximumSize(new Dimension(800, 425));
+            judgeSettingsPane.setMinimumSize(new Dimension(800, 425));
+            judgeSettingsPane.setPreferredSize(new Dimension(800,375));
 
             if (showPaneOutlines) {
                 
@@ -1328,7 +1328,7 @@ public class ContestInformationPane extends JPanePlugin {
      */
     private JTextField getJudgesDefaultAnswerTextField() {
         if (judgesDefaultAnswerTextField == null) {
-            judgesDefaultAnswerTextField = new JTextField(40);
+            judgesDefaultAnswerTextField = new JTextField(50);
             judgesDefaultAnswerTextField.setText("");
 //            judgesDefaultAnswerTextField.setSize(new Dimension(280, 29));
 //            judgesDefaultAnswerTextField.setLocation(new Point(208, 214));

--- a/src/edu/csus/ecs/pc2/ui/MCLB.java
+++ b/src/edu/csus/ecs/pc2/ui/MCLB.java
@@ -70,7 +70,31 @@ public class MCLB extends MultiColumnListbox {
     public void autoSizeAllColumns() {
         autoSizeAllColumns(this);
     }
+    /**
+     * Sets column size
+     * @param columnNum index of a column from left to right (0-indexed)
+     * @param length in pixels
+     */
+    public void setColumnSize(int columnNum,int length) {
+        final MCLB theBox = this;
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                theBox.getColumnInfo(columnNum).setWidth(length);
+            }
+        });
+    }
+    
+    public void setResizable (boolean resizable) {
+        final MCLB theBox = this;
 
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                for (int i = 0; i < theBox.getColumnCount(); i++) {
+                    theBox.getColumnInfo(i).setResizable(resizable);
+                }
+            }
+        });
+    }
     /**
      * Set sorter for column in listbox.
      * 

--- a/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
@@ -35,6 +35,8 @@ public class ScoringPropertiesPane extends JPanel {
     
     private JButton cancelButton;
     
+    private int lengthOfColumns;
+    
     public ScoringPropertiesPane(JButton updateButtona,JButton cancelButtona) {
         super();
         updateButton = updateButtona;
@@ -45,14 +47,16 @@ public class ScoringPropertiesPane extends JPanel {
     
     private void initialize() {
         this.setLayout(new BorderLayout());
-        this.setPreferredSize(new Dimension(275, 185));
+        this.setPreferredSize(new Dimension(350, 200));
         this.add(getPropertyListBox(), BorderLayout.CENTER);
+        this.lengthOfColumns = 167;
+        
 
     }
     
     protected void updateProperties(Properties properties) {
         propertyUpdater.updateProperties(properties);
-        propertyListBox.removeAllRows(); //WHYY??
+        propertyListBox.removeAllRows();
 
     }
     
@@ -69,8 +73,10 @@ public class ScoringPropertiesPane extends JPanel {
             HeapSorter sorter = new HeapSorter();
             propertyListBox.setColumnSorter(1, sorter, 1);
 
-            propertyListBox.autoSizeAllColumns();
-
+            propertyListBox.setColumnSize(0,this.lengthOfColumns);
+            propertyListBox.setColumnSize(1,this.lengthOfColumns);
+            propertyListBox.setResizable(false);
+            
             propertyListBox.addKeyListener(new java.awt.event.KeyAdapter() {
                 public void keyPressed(java.awt.event.KeyEvent e) {
                     enableButtons();
@@ -115,7 +121,8 @@ public class ScoringPropertiesPane extends JPanel {
             propertyListBox.addRow(objects);
         }
         
-        propertyListBox.autoSizeAllColumns();
+        propertyListBox.setColumnSize(0,this.lengthOfColumns);
+        propertyListBox.setColumnSize(1,this.lengthOfColumns);
 
         enableButtons();
     }
@@ -140,10 +147,8 @@ public class ScoringPropertiesPane extends JPanel {
     private JTextField createJTextField(String text, boolean passwordField) {
         JTextField textField = new JTextField();
         textField.setText(text);
-
         textField.addKeyListener(new java.awt.event.KeyAdapter() {
             public void keyReleased(java.awt.event.KeyEvent e) {
-                propertyListBox.autoSizeAllColumns();
                 enableButtons();
             }
         });

--- a/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
@@ -1,0 +1,171 @@
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.security.InvalidParameterException;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+import com.ibm.webrunner.j2mclb.util.HeapSorter;
+/**
+ * ScoringPropertiesPane is a inner pane for ContestInformationPane
+ * Allows editing Scoring Properties for admin.
+ * @author pc2@ecs.csus.edu
+ *
+ */
+public class ScoringPropertiesPane extends JPanel {
+    private static final long serialVersionUID = -8131372758010937976L;
+    
+    private MCLB propertyListBox = null;
+
+    private Properties originalProperties = new Properties(); // @jve:decl-index=0:
+    
+    private IPropertyUpdater propertyUpdater = null;
+    
+    private JButton updateButton;
+    
+    private JButton cancelButton;
+    
+    public ScoringPropertiesPane(JButton updateButtona,JButton cancelButtona) {
+        super();
+        updateButton = updateButtona;
+        cancelButton = cancelButtona;
+        
+        initialize();
+    }
+    
+    private void initialize() {
+        this.setLayout(new BorderLayout());
+        this.setPreferredSize(new Dimension(275, 185));
+        this.add(getPropertyListBox(), BorderLayout.CENTER);
+
+    }
+    
+    protected void updateProperties(Properties properties) {
+        propertyUpdater.updateProperties(properties);
+        propertyListBox.removeAllRows(); //WHYY??
+
+    }
+    
+    private MCLB getPropertyListBox() {
+        if (propertyListBox == null) {
+            propertyListBox = new MCLB();
+
+            propertyListBox.setMultipleSelections(true);
+
+            Object[] cols = { "Property", "Value" };
+
+            propertyListBox.addColumns(cols);
+
+            HeapSorter sorter = new HeapSorter();
+            propertyListBox.setColumnSorter(1, sorter, 1);
+
+            propertyListBox.autoSizeAllColumns();
+
+            propertyListBox.addKeyListener(new java.awt.event.KeyAdapter() {
+                public void keyPressed(java.awt.event.KeyEvent e) {
+                    enableButtons();
+                }
+            });
+        }
+        return propertyListBox;
+    }
+    
+    public boolean propertiesChanged() {
+        return !originalProperties.equals(getProperties());
+    }
+     
+    public void setProperties(final Properties properties) {
+        
+        if (properties == null){
+            throw new InvalidParameterException("Properties are null");
+        }
+
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                originalProperties = properties;
+                refreshProperties();
+            }
+        });
+    }
+    
+    protected void refreshProperties() {
+
+        propertyListBox.removeAllRows();
+
+        Set<Object> set = originalProperties.keySet();
+
+        String[] keys = (String[]) set.toArray(new String[set.size()]);
+
+        Arrays.sort(keys);
+        for (String key : keys) {
+
+            Object[] objects = new Object[2];
+            objects[0] = key;
+            objects[1] = createJTextField((String) originalProperties.get(key), false);
+            propertyListBox.addRow(objects);
+        }
+        
+        propertyListBox.autoSizeAllColumns();
+
+        enableButtons();
+    }
+    
+    /**
+     * Reads properties from user input.
+     * @return
+     */
+    public Properties getProperties() {
+
+        Properties fieldProps = new Properties();
+
+        for (int i = 0; i < propertyListBox.getRowCount(); i++) {
+            Object[] objects = propertyListBox.getRow(i);
+            JTextField field = (JTextField) objects[1];
+            fieldProps.put(objects[0], field.getText());
+        }
+
+        return fieldProps;
+    }
+    
+    private JTextField createJTextField(String text, boolean passwordField) {
+        JTextField textField = new JTextField();
+        textField.setText(text);
+
+        textField.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent e) {
+                propertyListBox.autoSizeAllColumns();
+                enableButtons();
+            }
+        });
+        return textField;
+    }
+    
+    public IPropertyUpdater getPropertyUpdater() {
+        return propertyUpdater;
+    }
+    
+    public void setPropertyUpdater(IPropertyUpdater propertyUpdater) {
+        this.propertyUpdater = propertyUpdater;
+    } 
+    
+    protected void enableButtons() {
+        boolean changed = propertiesChanged();
+
+        if (changed) {
+            updateButton.setEnabled(true);
+            cancelButton.setEnabled(true);
+        }
+        else {
+            updateButton.setEnabled(false);
+            cancelButton.setEnabled(false);
+        }
+    }
+}

--- a/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
@@ -21,8 +21,10 @@ import com.ibm.webrunner.j2mclb.util.HeapSorter;
  *
  */
 public class ScoringPropertiesPane extends JPanel {
-    private static final long serialVersionUID = -8131372758010937976L;
     
+
+    private static final long serialVersionUID = 147946474651407431L;
+
     private MCLB propertyListBox = null;
 
     private Properties originalProperties = new Properties(); // @jve:decl-index=0:

--- a/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
@@ -49,7 +49,7 @@ public class ScoringPropertiesPane extends JPanel {
         this.setLayout(new BorderLayout());
         this.setPreferredSize(new Dimension(350, 200));
         this.add(getPropertyListBox(), BorderLayout.CENTER);
-        this.lengthOfColumns = 167;
+        lengthOfColumns = 167;
         
 
     }
@@ -73,8 +73,8 @@ public class ScoringPropertiesPane extends JPanel {
             HeapSorter sorter = new HeapSorter();
             propertyListBox.setColumnSorter(1, sorter, 1);
 
-            propertyListBox.setColumnSize(0,this.lengthOfColumns);
-            propertyListBox.setColumnSize(1,this.lengthOfColumns);
+            propertyListBox.setColumnSize(0,lengthOfColumns);
+            propertyListBox.setColumnSize(1,lengthOfColumns);
             propertyListBox.setResizable(false);
             
             propertyListBox.addKeyListener(new java.awt.event.KeyAdapter() {
@@ -121,8 +121,8 @@ public class ScoringPropertiesPane extends JPanel {
             propertyListBox.addRow(objects);
         }
         
-        propertyListBox.setColumnSize(0,this.lengthOfColumns);
-        propertyListBox.setColumnSize(1,this.lengthOfColumns);
+        propertyListBox.setColumnSize(0,lengthOfColumns);
+        propertyListBox.setColumnSize(1,lengthOfColumns);
 
         enableButtons();
     }


### PR DESCRIPTION
### Description of what the PR does
Judging Settings Pane in Settings for Admin has been updated so that Scoring Properties are displayed without a new frame and saves without additional button.

### Issue which the PR addresses
Fixes #395 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
On admin, select settings, see that there is a Scoring Properties Pane, try to update the value. 

<img width="632" alt="Screenshot 2024-01-08 032649" src="https://github.com/pc2ccs/pc2v9/assets/60805192/00f6ab8e-031e-4df3-903a-574e66c6acef">
<img width="603" alt="Screenshot 2024-01-08 032951" src="https://github.com/pc2ccs/pc2v9/assets/60805192/d40aaebf-e158-47bd-b456-b4f3c9cfc34f">
