### PR TITLE
i_911 Make some aesthetic changes to the index html standings pages

### DIFF
--- a/data/xsl/index.xsl
+++ b/data/xsl/index.xsl
@@ -41,7 +41,7 @@
 	    </center>
 	</font>
 	    <center>
-            <TABLE cellspacing="0">
+            <TABLE>
                 <tr><th><strong><u>Rank</u></strong></th>
 <th><strong><u>Name</u></strong></th>
 <th><strong><u>Solved</u></strong></th>

--- a/data/xsl/standings.css
+++ b/data/xsl/standings.css
@@ -2,8 +2,9 @@
 table {
 	border: 1px solid #ccc; 
 	border-bottom: 0;
+	border-collapse: separate;
+	border-spacing: 5px;
 	width: 52.7em;
-	margin-bottom: 2em;
 }
 body {
    font-family: verdana, arial, tahoma, sans-serif;
@@ -12,12 +13,15 @@ table th {
 	text-align: center;
 	background: #247eca;
 	color: white;
-	padding: 0em; 
+	padding: 1px; 
 	border: outset 2px #eee8aa;
+	border-radius: 8px;
 }
 table td {
 	border-bottom: 1px solid #DDD; 
 	padding: .0em .0em .0em .5em;
+	border-radius: 8px;
+	text-align: center;
 }
 table tr td.rank {
 	background: transparent; 
@@ -81,7 +85,7 @@ div.tail {
        color: #888;
 //width: 65.875em;
 width: 80%;
- border: 1px solid #ccc;
+// border: 1px solid #ccc;
 margin-left: auto;
 margin-right: auto;
 }
@@ -97,15 +101,15 @@ table tr.even {
         background-color: #EEEEFF; color: black;
 }
 table tr td.yes {
-        background-color: #00ff00; color: black;
+        background-color: #50e050; color: black;
         text-align: center;
 }
 table tr td.pending {
-        background-color: #ffff00; color: black;
+        background-color: #e0e050; color: black;
         text-align: center;
 }
 table tr td.no {
-        background-color: #ff0000; color: black;
+        background-color: #e05050; color: black;
         text-align: center;
 }
 table tr td.center {


### PR DESCRIPTION
### Description of what the PR does
This PR makes the "**index.html**" standings web pages (public and secret) more aesthetically pleasing by toning down the bright colors and putting rounded corners on the cells in the table.

### Issue which the PR addresses
Fixes #911 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Ubuntu 22.04.3
openjdk version "11.0.6" 2020-01-14
OpenJDK Runtime Environment (build 11.0.6+10-post-Ubuntu-1ubuntu118.04.1)
OpenJDK 64-Bit Server VM (build 11.0.6+10-post-Ubuntu-1ubuntu118.04.1, mixed mode, sharing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load a contest that has submitted and judged runs (I used the PacNW 2022 Regional)
2) Start a scoreboard client and log in to force generation of the HTML pages
3) Look at the generated **index.html** (screen shot below).
<img width="1483" alt="image" src="https://github.com/pc2ccs/pc2v9/assets/5657363/a6a2db32-4b02-41f7-b249-d5fd82cd8b64">
