### PR TITLE
I39: Add Execute All in judge button to bypass stop on first failure

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.BufferedInputStream;

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -94,6 +94,11 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
     private boolean killedByTimer ;
 
     /**
+     * If true override stopOnFirstFailedTestCase and run all testcases
+     */
+    private boolean overrideStopOnFirstFailedTestCase = false;
+
+    /**
      * Directory where main file is found
      */
     private String mainFileDirectory;
@@ -355,6 +360,10 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
         return (result);
     }
 
+    public void setOverrideStopOnFirstFailedTestCase(boolean b) {
+        overrideStopOnFirstFailedTestCase = b;
+    }
+
     @Override
     public IFileViewer execute() {
         return execute(true);
@@ -519,7 +528,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
                     // execute the judged run against each test data set until either all test cases are run
                     // or (if the problem indicates stop on first failed test case) a test case fails
-                    while ((dataSetNumber < dataFiles.length) && ( !(stopOnFirstFailedTestCase && atLeastOneTestFailed))) {
+                    while ((dataSetNumber < dataFiles.length) && (overrideStopOnFirstFailedTestCase || !(stopOnFirstFailedTestCase && atLeastOneTestFailed))) {
 
                         // execute against one specific data set
                         passed = executeAndValidateDataSet(dataSetNumber);

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -628,7 +628,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         getAcceptValidatorJudgementButton().setEnabled(b);
         // getViewOutputsButton().setEnabled(b);
         getAcceptChosenSelectionButton().setEnabled(b && getJudgementComboBox().getSelectedIndex() != -1);
-        getTestResultsFrame().setExecuteAllButton(b);
+        getTestResultsFrame().enableExecuteAllButton(b);
     }
 
     /**
@@ -1529,7 +1529,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         if (testResultsFrame == null) {
             testResultsFrame = new TestResultsFrame();
             // Add action listener whether Test results pane button is clicked
-            testResultsFrame.addActionListenerToExecuteAll(new ActionListener() {
+            testResultsFrame.addActionListenerToExecuteAllButton(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     new Thread(new Runnable() {

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -628,6 +628,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         getAcceptValidatorJudgementButton().setEnabled(b);
         // getViewOutputsButton().setEnabled(b);
         getAcceptChosenSelectionButton().setEnabled(b && getJudgementComboBox().getSelectedIndex() != -1);
+        getTestResultsFrame().setExecuteAllButton(b);
     }
 
     /**
@@ -807,7 +808,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     new Thread(new Runnable() {
                         public void run() {
-                            executeRun();
+                            executeRun(false);
                         }
                     }).start();
                 }
@@ -859,8 +860,11 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         showMessage("Would have extracted run");
         // TODO code extract run
     }
-
-    protected void executeRun() {
+    
+    /**
+     * Takes a boolean condition whether to override stop on first failure condition
+     */
+    protected void executeRun(boolean overrideStopOnFirstFailedTestCase) {
 
         executeTimeMS = 0;
         System.gc();
@@ -876,6 +880,11 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         
        // getManualRunResultsPanel().clear();
         setEnabledButtonStatus(false);
+
+        // Set override to execute all testcases
+        if (overrideStopOnFirstFailedTestCase) {
+            executable.setOverrideStopOnFirstFailedTestCase(true);
+        }
         executable.execute();
         
         // Dump execution results files to log
@@ -1519,6 +1528,17 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     private TestResultsFrame getTestResultsFrame() {
         if (testResultsFrame == null) {
             testResultsFrame = new TestResultsFrame();
+            // Add action listener whether Test results pane button is clicked
+            testResultsFrame.addActionListenerToExecuteAll(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    new Thread(new Runnable() {
+                        public void run() {
+                            executeRun(true);
+                        }
+                    }).start();
+                }
+            });
             testResultsFrame.setContestAndController(getContest(), getController());
             FrameUtilities.centerFrame(testResultsFrame);
         }

--- a/src/edu/csus/ecs/pc2/ui/TestCaseResultsTableModel.java
+++ b/src/edu/csus/ecs/pc2/ui/TestCaseResultsTableModel.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.util.Vector;

--- a/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import edu.csus.ecs.pc2.core.IInternalController;

--- a/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
@@ -102,5 +102,18 @@ public class TestResultsFrame extends javax.swing.JFrame implements UIPlugin {
         getMultiTestSetOutputViewerPane().setValidatorOutputFileNames(filenames);
     }
 
+    /**
+     * Enables/Disables Execute All button
+    */
+    public void setExecuteAllButton(boolean b) {
+        getMultiTestSetOutputViewerPane().setExecuteAllButton(b);
+    }
+
+    /**
+     * Adds action listeners to Execute All Button
+    */
+    public void addActionListenerToExecuteAll(java.awt.event.ActionListener e) {
+        getMultiTestSetOutputViewerPane().addActionListenerToExecuteAll(e);
+    }
 
 } // @jve:decl-index=0:visual-constraint="10,10"

--- a/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsFrame.java
@@ -105,15 +105,15 @@ public class TestResultsFrame extends javax.swing.JFrame implements UIPlugin {
     /**
      * Enables/Disables Execute All button
     */
-    public void setExecuteAllButton(boolean b) {
-        getMultiTestSetOutputViewerPane().setExecuteAllButton(b);
+    public void enableExecuteAllButton(boolean b) {
+        getMultiTestSetOutputViewerPane().enableExecuteAllButton(b);
     }
 
     /**
      * Adds action listeners to Execute All Button
     */
-    public void addActionListenerToExecuteAll(java.awt.event.ActionListener e) {
-        getMultiTestSetOutputViewerPane().addActionListenerToExecuteAll(e);
+    public void addActionListenerToExecuteAllButton(java.awt.event.ActionListener e) {
+        getMultiTestSetOutputViewerPane().addActionListenerToExecuteAllButton(e);
     }
 
 } // @jve:decl-index=0:visual-constraint="10,10"

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -1013,13 +1013,6 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             resultsPaneButtonPanel.add(getCompareSelectedButton());
 
             //add space
-            Component horizontalStrut_4 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanel.add(horizontalStrut_4);
-            
-            // add a control button to invoke comparison of the team and judge output files for selected row(s)
-            resultsPaneButtonPanel.add(getExecuteAllButton());
-
-            //add space
             Component horizontalGlue_3 = Box.createHorizontalGlue();
             horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
             resultsPaneButtonPanel.add(horizontalGlue_3);
@@ -1028,6 +1021,63 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             resultsPaneButtonPanel.add(getResultsPaneCloseButton());
         }
         return resultsPaneButtonPanel;
+    }
+
+    /**
+     * refreshes the resultspanebuttonpanel
+     * includes/removes execute all button based on stop-on-first-failure
+     */
+    private void updateResultsPaneButtonPanel() {
+        
+        if (resultsPaneButtonPanel == null) {
+            resultsPaneButtonPanel = new JPanel();
+        }
+
+        resultsPaneButtonPanel.removeAll();
+            
+        //add a checkbox to allow filtering between all test cases and only failed test cases
+        resultsPaneButtonPanel.add(getShowFailuresOnlyCheckbox());
+
+        //add space
+        Component horizontalStrut_1 = Box.createHorizontalStrut(20);
+        resultsPaneButtonPanel.add(horizontalStrut_1);
+
+        //add a button to select all test cases in the grid
+        resultsPaneButtonPanel.add(getSelectAllButton());
+            
+        //add space
+        Component horizontalStrut_3 = Box.createHorizontalStrut(20);
+        resultsPaneButtonPanel.add(horizontalStrut_3);
+            
+        //add a button to unselect all the test cases in the grid
+        resultsPaneButtonPanel.add(getUnselectAllButton());
+
+        //add space
+        Component horizontalStrut_2 = Box.createHorizontalStrut(20);
+        resultsPaneButtonPanel.add(horizontalStrut_2);
+            
+        // add a control button to invoke comparison of the team and judge output files for selected row(s)
+        resultsPaneButtonPanel.add(getCompareSelectedButton());
+
+        if (currentProblem != null && currentProblem.isStopOnFirstFailedTestCase()) {
+            //add space
+            Component horizontalStrut_4 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanel.add(horizontalStrut_4);
+            
+            // add a control button to execute all test cases
+            resultsPaneButtonPanel.add(getExecuteAllButton());
+        }
+
+        //add space
+        Component horizontalGlue_3 = Box.createHorizontalGlue();
+        horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
+        resultsPaneButtonPanel.add(horizontalGlue_3);
+
+        // add a control button to dismiss the frame
+        resultsPaneButtonPanel.add(getResultsPaneCloseButton());
+
+        resultsPaneButtonPanel.revalidate();
+        resultsPaneButtonPanel.repaint();
     }
     
     /**
@@ -2429,6 +2479,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         this.currentRunFiles = runFiles;
         this.currentProblem = problem;
         this.currentProblemDataFiles = problemDataFiles;
+        updateResultsPaneButtonPanel();
         executableDir = getExecuteDir();
         populateGUI();
         try {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -1184,6 +1184,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         }
 
         setTeamOutputFileNames(executable.getTeamsOutputFilenames());
+        setTeamStderrFileNames(executable.getTeamsStderrFilenames());
         setValidatorOutputFileNames(executable.getValidatorOutputFilenames());
         setValidatorStderrFileNames(executable.getValidatorErrFilenames());
         // only if do not show output is not checked
@@ -2493,6 +2494,37 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         }
 
         this.currentTeamOutputFileNames = teamOutputNames;
+    }
+
+    public void setTeamStderrFileNames(List<String> savedTeamStderrFileNames) {
+
+        String[] teamStderrNames = null;
+
+        // add entries from actual team test stderr
+        if (savedTeamStderrFileNames != null) {
+            int size = getProblemDataFiles().getJudgesDataFiles().length;
+            if (size < savedTeamStderrFileNames.size()) {
+                size = savedTeamStderrFileNames.size();
+            }
+            if (size < 1) {
+                size = 1;
+            }
+            teamStderrNames = new String[size];
+
+            // null out list
+            for (int i = 0; i < size; i++) {
+                teamStderrNames[i] = null;
+            }
+
+            for (int i = 0; i < savedTeamStderrFileNames.size(); i++) {
+                teamStderrNames[i] = savedTeamStderrFileNames.get(i);
+                if (new File(teamStderrNames[i]).length() == 0) {
+                    teamStderrNames[i] = null; 
+                }
+            }
+        }
+        
+        this.currentTeamStderrFileNames = teamStderrNames;
     }
 
     public void setValidatorOutputFileNames(List<String> savedValidatorOutputFileNames) {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -241,11 +241,6 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 
     private JPanel resultsPaneButtonPanel;
 
-    // Separate the close button to readily add buttons in between
-    private JPanel resultsPaneButtonPanelLeft;
-
-    private JPanel resultsPaneButtonPanelRight;
-
     private JCheckBox showFailuresOnlyCheckBox;
 
     private JButton selectAllButton;
@@ -260,8 +255,6 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 
     // Horizotal Strut to be added/removed before execute all button
     private Component executeAllHorizontalStrut;
-
-    private boolean isExecuteAllButtonVisible = false;
 
     private JButton resultsPaneCloseButton;
     private JLabel lblTotalTestCases;
@@ -983,7 +976,6 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
     
     /**
      * Returns a JPanel containing control buttons for the Results Pane.
-     * Separated into Left and Right Button Panels
      * @return the resultsPaneButtonPanel
      */
     private JPanel getResultsPaneButtonPanel() {
@@ -992,109 +984,57 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             
             resultsPaneButtonPanel = new JPanel();
 
-            // Add Left end buttons of resultsPaneButtonPanel
-            resultsPaneButtonPanel.add(getResultsPaneButtonPanelLeft());
+            //add a checkbox to allow filtering between all test cases and only failed test cases
+            resultsPaneButtonPanel.add(getShowFailuresOnlyCheckbox());
 
-            // Add Right end buttons of resultsPaneButtonPanel
-            resultsPaneButtonPanel.add(getResultsPaneButtonPanelRight());
+            //add space
+            Component horizontalStrut_1 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanel.add(horizontalStrut_1);
+
+            //add a button to select all test cases in the grid
+            resultsPaneButtonPanel.add(getSelectAllButton());
+            
+            //add space
+            Component horizontalStrut_3 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanel.add(horizontalStrut_3);
+            
+            //add a button to unselect all the test cases in the grid
+            resultsPaneButtonPanel.add(getUnselectAllButton());
+
+            //add space
+            Component horizontalStrut_2 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanel.add(horizontalStrut_2);
+            
+            // add a control button to invoke comparison of the team and judge output files for selected row(s)
+            resultsPaneButtonPanel.add(getCompareSelectedButton());
+
+            //add space specific for Execute All Button
+            resultsPaneButtonPanel.add(getExecuteAllHorizontalStrut());
+            
+            // add a control button to execute all test cases
+            resultsPaneButtonPanel.add(getExecuteAllButton());
+
+            //add space
+            Component horizontalGlue_3 = Box.createHorizontalGlue();
+            horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
+            resultsPaneButtonPanel.add(horizontalGlue_3);
+
+            // add a control button to dismiss the frame
+            resultsPaneButtonPanel.add(getResultsPaneCloseButton());
         }
         return resultsPaneButtonPanel;
     }
 
     /**
-     * Returns a JPanel containing control buttons for the left end of Results Pane.
-     * @return the resultsPaneButtonPanelLeft
+     * Sets the visibility of Execute All Button based on condition
      */
-    private JPanel getResultsPaneButtonPanelLeft() {
-        
-        if (resultsPaneButtonPanelLeft == null) {
-            
-            resultsPaneButtonPanelLeft = new JPanel();
+    private void setExecuteAllButtonVisible(boolean b) {
 
-            //add a checkbox to allow filtering between all test cases and only failed test cases
-            resultsPaneButtonPanelLeft.add(getShowFailuresOnlyCheckbox());
-
-            //add space
-            Component horizontalStrut_1 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanelLeft.add(horizontalStrut_1);
-
-            //add a button to select all test cases in the grid
-            resultsPaneButtonPanelLeft.add(getSelectAllButton());
-            
-            //add space
-            Component horizontalStrut_3 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanelLeft.add(horizontalStrut_3);
-            
-            //add a button to unselect all the test cases in the grid
-            resultsPaneButtonPanelLeft.add(getUnselectAllButton());
-
-            //add space
-            Component horizontalStrut_2 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanelLeft.add(horizontalStrut_2);
-            
-            // add a control button to invoke comparison of the team and judge output files for selected row(s)
-            resultsPaneButtonPanelLeft.add(getCompareSelectedButton());
-        }
-        return resultsPaneButtonPanelLeft;
-    }
-
-    /**
-     * Returns a JPanel containing control buttons for the right end Results Pane.
-     * @return the resultsPaneButtonPanelLeft
-     */
-    private JPanel getResultsPaneButtonPanelRight() {
-        
-        if (resultsPaneButtonPanelRight == null) {
-            
-            resultsPaneButtonPanelRight = new JPanel();
-
-            //add space
-            Component horizontalGlue_3 = Box.createHorizontalGlue();
-            horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
-            resultsPaneButtonPanelRight.add(horizontalGlue_3);
-
-            // add a control button to dismiss the frame
-            resultsPaneButtonPanelRight.add(getResultsPaneCloseButton());
-        }
-        return resultsPaneButtonPanelRight;
-    }
-
-    /**
-     * refreshes the resultspane button panel left
-     * includes/removes execute all button based on stop-on-first-failure
-     */
-    private void updateResultsPaneButtonPanelLeft() {
-
-        if (currentProblem != null && currentProblem.isStopOnFirstFailedTestCase()) {
-
-            if (!isExecuteAllButtonVisible) {
-                //add space
-                getResultsPaneButtonPanelLeft().add(getExecuteAllHorizontalStrut());
+        // Set the space visible/invisible based on condition
+        getExecuteAllHorizontalStrut().setVisible(b);
                 
-                // add a control button to execute all test cases
-                getResultsPaneButtonPanelLeft().add(getExecuteAllButton());
-
-                getResultsPaneButtonPanelLeft().revalidate();
-                getResultsPaneButtonPanelLeft().repaint();
-
-                isExecuteAllButtonVisible = true;
-            }
-        }
-        else {
-
-            if (isExecuteAllButtonVisible) {
-                //Remove space
-                getResultsPaneButtonPanelLeft().remove(getExecuteAllHorizontalStrut());
-                
-                // Remove control button to execute all test cases
-                getResultsPaneButtonPanelLeft().remove(getExecuteAllButton());
-
-                getResultsPaneButtonPanelLeft().revalidate();
-                getResultsPaneButtonPanelLeft().repaint();
-
-                isExecuteAllButtonVisible = false;
-            }
-        }
+        // Set the Execute All Button visible/invisible based on condition
+        getExecuteAllButton().setVisible(b);
     }
     
     /**
@@ -1177,6 +1117,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 
         if (executeAllButton == null) {
             executeAllButton = new JButton("Execute All");
+            executeAllButton.setVisible(false);
         }
         return executeAllButton;
     }
@@ -1188,6 +1129,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 
         if (executeAllHorizontalStrut == null) {
             executeAllHorizontalStrut = Box.createHorizontalStrut(20);
+            executeAllHorizontalStrut.setVisible(false);
         }
         return executeAllHorizontalStrut;
     }
@@ -2438,7 +2380,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         this.currentRunFiles = runFiles;
         this.currentProblem = problem;
         this.currentProblemDataFiles = problemDataFiles;
-        updateResultsPaneButtonPanelLeft();
+        setExecuteAllButtonVisible(currentProblem != null && currentProblem.isStopOnFirstFailedTestCase());
         executableDir = getExecuteDir();
         populateGUI();
         try {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -57,7 +57,9 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 
 import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.Executable;
+import edu.csus.ecs.pc2.core.execute.ExecuteTimerFrame;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientSettings;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -244,6 +246,8 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
     private JCheckBox showFailuresOnlyCheckBox;
 
     private JButton selectAllButton;
+
+    private JButton executeAllButton;
 
     private JButton unselectAllButton;
 
@@ -1004,6 +1008,13 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             resultsPaneButtonPanel.add(getCompareSelectedButton());
 
             //add space
+            Component horizontalStrut_4 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanel.add(horizontalStrut_4);
+            
+            // add a control button to invoke comparison of the team and judge output files for selected row(s)
+            resultsPaneButtonPanel.add(getExecuteAllButton());
+
+            //add space
             Component horizontalGlue_3 = Box.createHorizontalGlue();
             horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
             resultsPaneButtonPanel.add(horizontalGlue_3);
@@ -1085,6 +1096,46 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             });
         }
         return selectAllButton;
+    }
+
+    private JButton getExecuteAllButton() {
+
+        if (executeAllButton == null) {
+
+            executeAllButton = new JButton("Execute All");
+            executeAllButton.addActionListener(new ActionListener() {
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    new Thread(new Runnable() {
+                        public void run() {
+                            executeAllRun();
+                        }
+                    }).start();
+                }
+            });
+        }
+        return executeAllButton;
+    }
+
+    protected void executeAllRun() {
+
+        long executeTimeMS = 0;
+        System.gc();
+
+        ExecuteTimerFrame executeFrame = new ExecuteTimerFrame();
+
+        Executable executable = new Executable(getContest(), getController(), currentRun, currentRunFiles, executeFrame);
+
+        String temporaryExecuteableDirectory = executable.getExecuteDirectoryName();
+        
+        if (! new File(temporaryExecuteableDirectory).isDirectory()) {
+            // create directory if not present, needed for cleardirectory
+            log.info("Creating directory "+temporaryExecuteableDirectory);
+            Utilities.insureDir(temporaryExecuteableDirectory);
+        }
+        
+        executable.clearDirectory(temporaryExecuteableDirectory);
     }
     
     /**

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -1154,11 +1154,17 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         return executeAllButton;
     }
 
-    public void addActionListenerToExecuteAll(java.awt.event.ActionListener e) {
+    /**
+     * Adds action listeners to Execute All Button
+    */
+    public void addActionListenerToExecuteAllButton(java.awt.event.ActionListener e) {
         getExecuteAllButton().addActionListener(e);
     }
 
-    public void setExecuteAllButton(boolean b) {
+    /**
+     * Enables/Disables Execute All button
+    */
+    public void enableExecuteAllButton(boolean b) {
         getExecuteAllButton().setEnabled(b && currentRunFiles != null);
     }
     

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -241,6 +241,11 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 
     private JPanel resultsPaneButtonPanel;
 
+    // Separate the close button to readily add buttons in between
+    private JPanel resultsPaneButtonPanelLeft;
+
+    private JPanel resultsPaneButtonPanelRight;
+
     private JCheckBox showFailuresOnlyCheckBox;
 
     private JButton selectAllButton;
@@ -252,6 +257,11 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
     private JButton compareSelectedButton;
 
     private JButton optionsPaneCloseButton;
+
+    // Horizotal Strut to be added/removed before execute all button
+    private Component executeAllHorizontalStrut;
+
+    private boolean isExecuteAllButtonVisible = false;
 
     private JButton resultsPaneCloseButton;
     private JLabel lblTotalTestCases;
@@ -973,6 +983,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
     
     /**
      * Returns a JPanel containing control buttons for the Results Pane.
+     * Separated into Left and Right Button Panels
      * @return the resultsPaneButtonPanel
      */
     private JPanel getResultsPaneButtonPanel() {
@@ -981,96 +992,109 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
             
             resultsPaneButtonPanel = new JPanel();
 
-            //add a checkbox to allow filtering between all test cases and only failed test cases
-            resultsPaneButtonPanel.add(getShowFailuresOnlyCheckbox());
+            // Add Left end buttons of resultsPaneButtonPanel
+            resultsPaneButtonPanel.add(getResultsPaneButtonPanelLeft());
 
-            //add space
-            Component horizontalStrut_1 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanel.add(horizontalStrut_1);
-
-            //add a button to select all test cases in the grid
-            resultsPaneButtonPanel.add(getSelectAllButton());
-            
-            //add space
-            Component horizontalStrut_3 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanel.add(horizontalStrut_3);
-            
-            //add a button to unselect all the test cases in the grid
-            resultsPaneButtonPanel.add(getUnselectAllButton());
-
-            //add space
-            Component horizontalStrut_2 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanel.add(horizontalStrut_2);
-            
-            // add a control button to invoke comparison of the team and judge output files for selected row(s)
-            resultsPaneButtonPanel.add(getCompareSelectedButton());
-
-            //add space
-            Component horizontalGlue_3 = Box.createHorizontalGlue();
-            horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
-            resultsPaneButtonPanel.add(horizontalGlue_3);
-
-            // add a control button to dismiss the frame
-            resultsPaneButtonPanel.add(getResultsPaneCloseButton());
+            // Add Right end buttons of resultsPaneButtonPanel
+            resultsPaneButtonPanel.add(getResultsPaneButtonPanelRight());
         }
         return resultsPaneButtonPanel;
     }
 
     /**
-     * refreshes the resultspanebuttonpanel
+     * Returns a JPanel containing control buttons for the left end of Results Pane.
+     * @return the resultsPaneButtonPanelLeft
+     */
+    private JPanel getResultsPaneButtonPanelLeft() {
+        
+        if (resultsPaneButtonPanelLeft == null) {
+            
+            resultsPaneButtonPanelLeft = new JPanel();
+
+            //add a checkbox to allow filtering between all test cases and only failed test cases
+            resultsPaneButtonPanelLeft.add(getShowFailuresOnlyCheckbox());
+
+            //add space
+            Component horizontalStrut_1 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanelLeft.add(horizontalStrut_1);
+
+            //add a button to select all test cases in the grid
+            resultsPaneButtonPanelLeft.add(getSelectAllButton());
+            
+            //add space
+            Component horizontalStrut_3 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanelLeft.add(horizontalStrut_3);
+            
+            //add a button to unselect all the test cases in the grid
+            resultsPaneButtonPanelLeft.add(getUnselectAllButton());
+
+            //add space
+            Component horizontalStrut_2 = Box.createHorizontalStrut(20);
+            resultsPaneButtonPanelLeft.add(horizontalStrut_2);
+            
+            // add a control button to invoke comparison of the team and judge output files for selected row(s)
+            resultsPaneButtonPanelLeft.add(getCompareSelectedButton());
+        }
+        return resultsPaneButtonPanelLeft;
+    }
+
+    /**
+     * Returns a JPanel containing control buttons for the right end Results Pane.
+     * @return the resultsPaneButtonPanelLeft
+     */
+    private JPanel getResultsPaneButtonPanelRight() {
+        
+        if (resultsPaneButtonPanelRight == null) {
+            
+            resultsPaneButtonPanelRight = new JPanel();
+
+            //add space
+            Component horizontalGlue_3 = Box.createHorizontalGlue();
+            horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
+            resultsPaneButtonPanelRight.add(horizontalGlue_3);
+
+            // add a control button to dismiss the frame
+            resultsPaneButtonPanelRight.add(getResultsPaneCloseButton());
+        }
+        return resultsPaneButtonPanelRight;
+    }
+
+    /**
+     * refreshes the resultspane button panel left
      * includes/removes execute all button based on stop-on-first-failure
      */
-    private void updateResultsPaneButtonPanel() {
-        
-        if (resultsPaneButtonPanel == null) {
-            resultsPaneButtonPanel = new JPanel();
-        }
-
-        resultsPaneButtonPanel.removeAll();
-            
-        //add a checkbox to allow filtering between all test cases and only failed test cases
-        resultsPaneButtonPanel.add(getShowFailuresOnlyCheckbox());
-
-        //add space
-        Component horizontalStrut_1 = Box.createHorizontalStrut(20);
-        resultsPaneButtonPanel.add(horizontalStrut_1);
-
-        //add a button to select all test cases in the grid
-        resultsPaneButtonPanel.add(getSelectAllButton());
-            
-        //add space
-        Component horizontalStrut_3 = Box.createHorizontalStrut(20);
-        resultsPaneButtonPanel.add(horizontalStrut_3);
-            
-        //add a button to unselect all the test cases in the grid
-        resultsPaneButtonPanel.add(getUnselectAllButton());
-
-        //add space
-        Component horizontalStrut_2 = Box.createHorizontalStrut(20);
-        resultsPaneButtonPanel.add(horizontalStrut_2);
-            
-        // add a control button to invoke comparison of the team and judge output files for selected row(s)
-        resultsPaneButtonPanel.add(getCompareSelectedButton());
+    private void updateResultsPaneButtonPanelLeft() {
 
         if (currentProblem != null && currentProblem.isStopOnFirstFailedTestCase()) {
-            //add space
-            Component horizontalStrut_4 = Box.createHorizontalStrut(20);
-            resultsPaneButtonPanel.add(horizontalStrut_4);
-            
-            // add a control button to execute all test cases
-            resultsPaneButtonPanel.add(getExecuteAllButton());
+
+            if (!isExecuteAllButtonVisible) {
+                //add space
+                getResultsPaneButtonPanelLeft().add(getExecuteAllHorizontalStrut());
+                
+                // add a control button to execute all test cases
+                getResultsPaneButtonPanelLeft().add(getExecuteAllButton());
+
+                getResultsPaneButtonPanelLeft().revalidate();
+                getResultsPaneButtonPanelLeft().repaint();
+
+                isExecuteAllButtonVisible = true;
+            }
         }
+        else {
 
-        //add space
-        Component horizontalGlue_3 = Box.createHorizontalGlue();
-        horizontalGlue_3.setPreferredSize(new Dimension(20, 20));
-        resultsPaneButtonPanel.add(horizontalGlue_3);
+            if (isExecuteAllButtonVisible) {
+                //Remove space
+                getResultsPaneButtonPanelLeft().remove(getExecuteAllHorizontalStrut());
+                
+                // Remove control button to execute all test cases
+                getResultsPaneButtonPanelLeft().remove(getExecuteAllButton());
 
-        // add a control button to dismiss the frame
-        resultsPaneButtonPanel.add(getResultsPaneCloseButton());
+                getResultsPaneButtonPanelLeft().revalidate();
+                getResultsPaneButtonPanelLeft().repaint();
 
-        resultsPaneButtonPanel.revalidate();
-        resultsPaneButtonPanel.repaint();
+                isExecuteAllButtonVisible = false;
+            }
+        }
     }
     
     /**
@@ -1146,12 +1170,26 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         return selectAllButton;
     }
 
+    /**
+     * Returns JButton Execute All to by-pass stop-on-first-failure and run all test cases
+     */
     private JButton getExecuteAllButton() {
 
         if (executeAllButton == null) {
             executeAllButton = new JButton("Execute All");
         }
         return executeAllButton;
+    }
+
+    /**
+     * Returns Horizontal strut to be added before execute all button
+     */
+    private Component getExecuteAllHorizontalStrut() {
+
+        if (executeAllHorizontalStrut == null) {
+            executeAllHorizontalStrut = Box.createHorizontalStrut(20);
+        }
+        return executeAllHorizontalStrut;
     }
 
     /**
@@ -2400,7 +2438,7 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         this.currentRunFiles = runFiles;
         this.currentProblem = problem;
         this.currentProblemDataFiles = problemDataFiles;
-        updateResultsPaneButtonPanel();
+        updateResultsPaneButtonPanelLeft();
         executableDir = getExecuteDir();
         populateGUI();
         try {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsPane.java
@@ -25,6 +25,8 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Vector;
+import java.util.List;
+import java.util.Properties;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -57,9 +59,10 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 
 import edu.csus.ecs.pc2.core.IInternalController;
-import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.Executable;
+import edu.csus.ecs.pc2.core.execute.ExecutionData;
 import edu.csus.ecs.pc2.core.execute.ExecuteTimerFrame;
+import edu.csus.ecs.pc2.core.execute.JudgementUtilities;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientSettings;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -69,6 +72,8 @@ import edu.csus.ecs.pc2.core.model.ProblemDataFiles;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.model.RunFiles;
 import edu.csus.ecs.pc2.core.model.RunTestCase;
+import edu.csus.ecs.pc2.core.model.Judgement;
+import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.ui.cellRenderer.CheckBoxCellRenderer;
 import edu.csus.ecs.pc2.ui.cellRenderer.LinkCellRenderer;
 import edu.csus.ecs.pc2.ui.cellRenderer.RightJustifiedCellRenderer;
@@ -1118,24 +1123,77 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
         return executeAllButton;
     }
 
+    public void setEnabledButtonStatus(boolean b) {
+        getExecuteAllButton().setEnabled(b && currentRunFiles != null);
+    }
+
+    private ProblemDataFiles getProblemDataFiles() {
+        Problem problem = getContest().getProblem(currentRun.getProblemId());
+        return getContest().getProblemDataFile(problem);
+    }
+
     protected void executeAllRun() {
 
-        long executeTimeMS = 0;
         System.gc();
 
         ExecuteTimerFrame executeFrame = new ExecuteTimerFrame();
 
         Executable executable = new Executable(getContest(), getController(), currentRun, currentRunFiles, executeFrame);
 
-        String temporaryExecuteableDirectory = executable.getExecuteDirectoryName();
-        
-        if (! new File(temporaryExecuteableDirectory).isDirectory()) {
-            // create directory if not present, needed for cleardirectory
-            log.info("Creating directory "+temporaryExecuteableDirectory);
-            Utilities.insureDir(temporaryExecuteableDirectory);
+        // only if do not show output is not checked, clear the results pane
+        if (!getContest().getProblem(currentRun.getProblemId()).isHideOutputWindow()) {
+            resetResultsTable();
         }
-        
-        executable.clearDirectory(temporaryExecuteableDirectory);
+
+        setEnabledButtonStatus(false);
+        // Set override to execute all testcases 
+        executable.setOverrideStopOnFirstFailedTestCase(true);
+        executable.execute();
+
+        // Dump execution results files to log
+        String executeDirctoryName = JudgementUtilities.getExecuteDirectoryName(getContest().getClientId());
+        Problem juProblem = getContest().getProblem(currentRun.getProblemId());
+        ClientId clientId = getContest().getClientId();
+        List<Judgement> judgements = JudgementUtilities.getLastTestCaseJudgementList(getContest(), currentRun);
+        JudgementUtilities.dumpJudgementResultsToLog(log, clientId, currentRun, executeDirctoryName, juProblem, judgements, executable.getExecutionData(), "", new Properties());
+
+        ExecutionData executionData = executable.getExecutionData();
+        if (executionData != null && executionData.getExecutionException() != null) {
+            Exception ex = executionData.getExecutionException();
+            Language lang = getContest().getLanguage(currentRun.getLanguageId());
+
+            //TODO: the following assignment and 'if' don't make sense (the assignment inside the 'if' is 
+            //     the same as the one preceding the 'if').   jlc
+            // JB - I *think* the intent was to call lang.getProgramExecuteCommandLine() if the judge
+            //      command line is null.  That is, if no specific judge command, use
+            //      the default.
+            String command = lang.getJudgeProgramExecuteCommandLine();
+            if (command == null) {
+                command = lang.getJudgeProgramExecuteCommandLine();
+            }
+            
+            //TODO:  the command line needs to be adjusted to reflect the (possible) presence of a sandbox.  jlc
+            String commandLine = executable.substituteAllStrings(currentRun, command);
+            log.warning("Error executing command: " + commandLine);
+            log.warning("Error is: " + ex.getMessage());
+
+            JOptionPane.showMessageDialog(this,  "Error executing command: " + commandLine + "\n\n" + ex.getMessage(), "Error during execute",JOptionPane.ERROR_MESSAGE);
+
+            setEnabledButtonStatus(true);
+            return;
+        }
+
+        setTeamOutputFileNames(executable.getTeamsOutputFilenames());
+        setValidatorOutputFileNames(executable.getValidatorOutputFilenames());
+        setValidatorStderrFileNames(executable.getValidatorErrFilenames());
+        // only if do not show output is not checked
+        if (!getContest().getProblem(currentRun.getProblemId()).isHideOutputWindow()) {
+            // the run gets modified in Executable to have testCases, so resend the data
+            Problem problem = getContest().getProblem(currentRun.getProblemId());
+            setData(currentRun, currentRunFiles, problem, getProblemDataFiles());
+        }
+
+        setEnabledButtonStatus(true);
     }
     
     /**
@@ -2404,6 +2462,103 @@ public class TestResultsPane extends JPanePlugin implements TableModelListener {
 
     public void setValidatorStderrFileNames(String[] filenames) {
         this.currentValidatorStderrFileNames = filenames ;
+    }
+
+    public void setTeamOutputFileNames(List<String> savedTeamOutputFileNames) {
+
+        String[] teamOutputNames = null;
+
+        // add entries from actual team test output
+        if (savedTeamOutputFileNames != null) {
+            int size = getProblemDataFiles().getJudgesDataFiles().length;
+            if (size < savedTeamOutputFileNames.size()) {
+                size = savedTeamOutputFileNames.size();
+            }
+            if (size < 1) {
+                size = 1;
+            }
+            teamOutputNames = new String[size];
+
+            // null out list
+            for (int i = 0; i < size; i++) {
+                teamOutputNames[i] = null;
+            }
+
+            for (int i = 0; i < savedTeamOutputFileNames.size(); i++) {
+                teamOutputNames[i] = savedTeamOutputFileNames.get(i);
+                if (new File(teamOutputNames[i]).length() == 0) {
+                    teamOutputNames[i] = null; 
+                }
+            }
+        }
+
+        this.currentTeamOutputFileNames = teamOutputNames;
+    }
+
+    public void setValidatorOutputFileNames(List<String> savedValidatorOutputFileNames) {
+
+        int arraySize = 0;
+        if (savedValidatorOutputFileNames!=null && savedValidatorOutputFileNames.size() > 0) {
+            arraySize = savedValidatorOutputFileNames.size();
+        }
+            
+        //an array to hold the validator output file names
+        String[] validatorOutputFileNames = new String[arraySize];
+
+        // null out array (probably not necessary since Java defaults object refs to null...)
+        for (int i = 0; i < validatorOutputFileNames.length; i++) {
+            validatorOutputFileNames[i] = null;
+        }
+
+        // add entries from actual team test case output validation results
+        if (savedValidatorOutputFileNames != null) {
+
+            for (int i = 0; i < savedValidatorOutputFileNames.size(); i++) {
+                
+                //save the validator output file name
+                validatorOutputFileNames[i] = savedValidatorOutputFileNames.get(i);
+                
+                //wipe out the entry if the file is empty (zero-length)
+                if (new File(validatorOutputFileNames[i]).length() == 0) {
+                    validatorOutputFileNames[i] = null; 
+                }
+            }
+        }
+
+        this.currentValidatorOutputFileNames = validatorOutputFileNames;
+    }
+
+    public void setValidatorStderrFileNames(List<String> savedValidatorErrFileNames) {
+
+        int arraySize = 0;
+        if (savedValidatorErrFileNames!=null && savedValidatorErrFileNames.size()>0) {
+            arraySize = savedValidatorErrFileNames.size();
+        }
+            
+        //an array to hold the validator stderr file names
+        String[] validatorStdErrFileNames = new String[arraySize];
+
+        // null out array (probably not necessary since Java defaults object refs to null...)
+        for (int i = 0; i < validatorStdErrFileNames.length; i++) {
+            validatorStdErrFileNames[i] = null;
+        }
+
+        // add entries from actual team test output validation stderr
+        if (savedValidatorErrFileNames != null) {
+
+            for (int i = 0; i < savedValidatorErrFileNames.size(); i++) {
+                    
+                //save the validator stderr file name
+                validatorStdErrFileNames[i] = savedValidatorErrFileNames.get(i);
+                    
+                //wipe out the entry if the file is empty (zero-length)
+                if (new File(validatorStdErrFileNames[i]).length() == 0) {
+                    validatorStdErrFileNames[i] = null; 
+                }
+            }
+        }
+
+        this.currentValidatorStderrFileNames = validatorStdErrFileNames;
     }
 
     private Component getHorizontalGlue_9() {

--- a/src/edu/csus/ecs/pc2/ui/TestResultsRowData.java
+++ b/src/edu/csus/ecs/pc2/ui/TestResultsRowData.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 /**
  * 
  */


### PR DESCRIPTION
### Description of what the PR does
Add `Execute All` button on `TestResultsPane`. It can bypass stop on first failure condition and run the code on all testcases if a judge desires.

### Issue which the PR addresses
Fixes #39 

### Environment in which the PR was developed (OS, IDE, Java version, etc.)

Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8), C++ 13.2.0

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Run the Ant script build.xml in the pc2v9 project.
- Start a PC2 server, loading a sample contest such as "mini".
- Start a PC2 Admin.
- In `Problems` pane make sure one of the problems have judging type set to Manual, if not edit and set to Manual. Also check the box for stop-on-first-failure.
- In `Auto Judge` pane make sure one of the judges have Problems `(none selected)`, if not edit and set.
- Start the contest.
- Start a PC2 team.
- Make a submission for a problem which had manual judging type set. Make sure it fails on the first testcase.
- Starte a PC2 judge. Make sure to use the one which no problems set for auto-judge.
- Select the submission from `New Runs` pane and request run.
- In `Select Judgement for Run {:id}` window click on Execute Run.
- It will fail on first test case and the rest are not executed.
- Now click on `Execute All` button in Test Results Pane. It should now execute all test cases despite failures.

![image](https://github.com/pc2ccs/pc2v9/assets/24360328/153b566b-f774-4763-946e-df8b20e860b2)

![image](https://github.com/pc2ccs/pc2v9/assets/24360328/1e31026f-6165-4374-bafd-6818637350a4)

