### PR TITLE
add results.csv bits

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/board/ScoreboardCommon.java
+++ b/src/edu/csus/ecs/pc2/ui/board/ScoreboardCommon.java
@@ -290,6 +290,18 @@ public class ScoreboardCommon {
                 log.log(Log.WARNING, "Trouble creating results.tsv", e);
             }
             try {
+                ResultsFile resultsFile = new ResultsFile();
+                String[] createCSVFileLines = resultsFile.createCSVFileLines(contest, group);
+                log.log(Log.DEBUG, "found " + createCSVFileLines.length + " lines");
+                FileWriter outputFile = new FileWriter(outputResultsDirFile + File.separator + makeGroupFilename("results.csv", groupName));
+                for (int i = 0; i < createCSVFileLines.length; i++) {
+                    outputFile.write(createCSVFileLines[i] + System.getProperty("line.separator"));
+                }
+                outputFile.close();
+            } catch (IOException e) {
+                log.log(Log.WARNING, "Trouble creating results.csv", e);
+            }
+            try {
                 ScoreboardFile scoreboardFile = new ScoreboardFile();
                 String[] createTSVFileLines = scoreboardFile.createTSVFileLines(contest, group);
                 FileWriter outputFile = new FileWriter(outputResultsDirFile + File.separator + makeGroupFilename("scoreboard.tsv", groupName));


### PR DESCRIPTION
fixes #351


tested with pc2-real.zip from pacnw2023 contest held on Feb 24th 2024.
compared with the results files that John Buck emailed.

Note as I was testing on MacOS i had to convert those Buck results to unix format for the compare to be close.

Even with that on D2 I saw these minor changes:
```
--- results_D2.csv	2024-02-25 23:04:36
+++ /Users/boudreat/Downloads/results_D2.csv	2024-02-25 23:01:53
@@ -69,9 +69,9 @@
 964880,,Honorable,1,58,58,,
 964853,,Honorable,1,80,60,,
 964018,,Honorable,1,271,211,,
-964881,,Honorable,0,0,0,,
+964015,,Honorable,0,0,0,,
 964389,,Honorable,0,0,0,,
+964881,,Honorable,0,0,0,,
 964930,,Honorable,0,0,0,,
 965050,,Honorable,0,0,0,,
 965057,,Honorable,0,0,0,,
-964015,,Honorable,0,0,0,,
```

But results_D1.csv matched exactly.