### PR TITLE
i_927 Promote develop branch to Version 9.11build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@
         value="${date.english} ${time.english}" />
 
     <!-- version is used in the jar manifest & in package.xml -->
-    <property name="version" value="9.10build"/>
+    <property name="version" value="9.11build"/>
 
     <path id="project.classpath">
         <pathelement location="${build.prod.dir}"/>


### PR DESCRIPTION
Modify build.xml to use new version property.

### Description of what the PR does
Changes the **version** property from **9.10build** to **9.11build**

### Issue which the PR addresses
Fixes #927 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
JDK 1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Rebuild
2) Check the contents of the `build/VERSION` file.  Should say something like:

```
CSUS Programming Contest Control System
Version 9.11build 20240228 6969 (Wednesday, February 28 2024 01:43 UTC)
```

