### PR TITLE
i935 Fix incorrect string comparisons that caused shadow reconnects

### DIFF
--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -1,10 +1,9 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,18 +42,18 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException;
  * PC2 "Shadow Mode" facility, which can be used to "shadow" a remote Contest Control System -- that is, to
  * monitor the remote CCS by obtaining runs from it and computing standings in parallel for purposes of verification
  * of the remote system.
- * 
+ *
  * The class is instantiated with an {@link IInternalController} (a PC2 Controller for a local instance of a contest)
  * along with an {@link IInternalContest} (a PC2 Contest model).
- * It obtains, from the local PC2 Server, information on the remote system to be shadowed, and uses classes behind (comprising) 
+ * It obtains, from the local PC2 Server, information on the remote system to be shadowed, and uses classes behind (comprising)
  * the facade to obtain team submissions as well as scoreboard information from the remote system.
  * It uses the provided PC2 controller to perform local operations as if teams on the remote CCS were submitting to the local PC2
  * CCS.
- * 
- * The class (facade) presumes that the remote system implements the 
- * <A href="https://clics.ecs.baylor.edu/index.php?title=Contest_API">CLICS Contest API</a>; 
- * this is how it communicates with the remote system to obtain team submissions and remote scoreboard information. 
- * 
+ *
+ * The class (facade) presumes that the remote system implements the
+ * <A href="https://clics.ecs.baylor.edu/index.php?title=Contest_API">CLICS Contest API</a>;
+ * this is how it communicates with the remote system to obtain team submissions and remote scoreboard information.
+ *
  * @author John Clevenger, PC2 Development Team, pc2@ecs.csus.edu
  *
  */
@@ -71,23 +70,23 @@ public class ShadowController {
     private String remoteCCSPassword;
 
     private RemoteEventFeedMonitor monitor;
-    
+
     private IShadowMonitorStatus shadowMonitorStatus = null;
-    
+
     private String lastToken = null;
-    
+
     public enum SHADOW_CONTROLLER_STATUS {
-        
-        SC_NEVER_STARTED("Shadow Controller has never been started"), 
-        SC_STARTING("Shadow Controller is starting"), 
-        SC_RUNNING("Shadow Controller is running"), 
-        SC_STOPPING("Shadow Controller is stopping"), 
-        SC_STOPPED("Shadow Controller is stopped"), 
+
+        SC_NEVER_STARTED("Shadow Controller has never been started"),
+        SC_STARTING("Shadow Controller is starting"),
+        SC_RUNNING("Shadow Controller is running"),
+        SC_STOPPING("Shadow Controller is stopping"),
+        SC_STOPPED("Shadow Controller is stopped"),
         SC_CONNECTION_FAILED("Shadow Controller failes to connect to remote CCS"),
         SC_INVALID_REMOTE_CONFIG("Shadow Controller received an invalid or null configuration from the remote CCS"),
         SC_CONTEST_CONFIG_MISMATCH("Contest configuration received from remote CCS does not match local PC2 contest configuration"),
         SC_MONITOR_STARTUP_FAILED("Shadow Controller was unable to start a Remote CCS Monitor");
-        
+
         private final String label;
         private SHADOW_CONTROLLER_STATUS(String label) {
             this.label=label;
@@ -96,7 +95,7 @@ public class ShadowController {
             return this.label;
         }
     }
-    
+
     private SHADOW_CONTROLLER_STATUS controllerStatus = null ;
     private RemoteContestConfiguration remoteContestConfig;
     private Thread monitorThread;
@@ -106,7 +105,7 @@ public class ShadowController {
 
     /**
      * a ContestInformation Listener
-     * 
+     *
      * @author ICPC
      *
      */
@@ -143,9 +142,9 @@ public class ShadowController {
     }
 
     /**
-     * Constructs a new ShadowController for the remote CCS specified by the data in the 
-     * specified {@link IInternalContest} and {@link IInternalContest}. 
-     * 
+     * Constructs a new ShadowController for the remote CCS specified by the data in the
+     * specified {@link IInternalContest} and {@link IInternalContest}.
+     *
      * @param localContest a PC2 Contest to be used by the Shadow Controller
      * @param localController a PC2 Controller to be used by the Shadow Controller
      */
@@ -159,9 +158,9 @@ public class ShadowController {
     }
 
     /**
-     * Constructs a new ShadowController for the remote CCS specified by the data in the 
-     * specified {@link IInternalContest} and {@link IInternalContest}. 
-     * 
+     * Constructs a new ShadowController for the remote CCS specified by the data in the
+     * specified {@link IInternalContest} and {@link IInternalContest}.
+     *
      * @param localContest a PC2 Contest to be used by the Shadow Controller
      * @param localController a PC2 Controller to be used by the Shadow Controller
      */
@@ -175,9 +174,9 @@ public class ShadowController {
     }
 
     /**
-     * Constructs a new ShadowController for the remote CCS specified by the data in the 
-     * specified {@link IInternalContest} and {@link IInternalContest}. 
-     * 
+     * Constructs a new ShadowController for the remote CCS specified by the data in the
+     * specified {@link IInternalContest} and {@link IInternalContest}.
+     *
      * @param localContest a PC2 Contest to be used by the Shadow Controller
      * @param localController a PC2 Controller to be used by the Shadow Controller
      * @param mon optional monitor status handler
@@ -194,14 +193,14 @@ public class ShadowController {
 
     /**
      * Constructs a new ShadowController for the remote CCS specified by the input parameters.
-     * 
+     *
      * @param localContest a PC2 Contest to be used by the Shadow Controller
      * @param localController a PC2 Controller to be used by the Shadow Controller
      * @param remoteURL the URL of the remote CCS
      * @param remoteCCSLogin
      * @param remoteCCSPassword
      */
-    public ShadowController(IInternalContest localContest, IInternalController localController, 
+    public ShadowController(IInternalContest localContest, IInternalController localController,
                             String remoteURL, String remoteCCSLogin, String remoteCCSPassword) {
 
         this(localContest, localController, null, null,
@@ -212,7 +211,7 @@ public class ShadowController {
 
     /**
      * Constructs a new ShadowController for the remote CCS specified by the input parameters.
-     * 
+     *
      * @param localContest a PC2 Contest to be used by the Shadow Controller
      * @param localController a PC2 Controller to be used by the Shadow Controller
      * @param remoteURL the URL of the remote CCS
@@ -234,28 +233,28 @@ public class ShadowController {
     }
 
     /**
-     * This method starts Shadow Mode operations running.  
-     * 
+     * This method starts Shadow Mode operations running.
+     *
      * It first checks the validity of the URL string which was passed to the Shadow Controller when it was constructed;
      * if the URL is invalid then it logs a warning and returns false.
      * If the URL string is valid then it obtains an adapter with which to access
-     * a remote CCS, then uses the adapter to fetch the remote contest configuration.   
+     * a remote CCS, then uses the adapter to fetch the remote contest configuration.
      * It then compares the obtained (remote) contest configuration with the local contest configuration,
      * and if they match then it creates and starts a {@link RemoteRunMonitor} listening to the remote contest
      * specified by the remote contest URL provided when the class is constructed.
-     * 
+     *
      * @return true if remote shadowing operations were started successfully; false if not
      */
     public boolean start() {
 
         log = getLog();
-        
+
         log.info("Starting shadowing for URL '"+ remoteCCSURLString + "' using login '" + remoteCCSLogin + "'");
-//        System.out.println ("ShadowController: starting shadowing for URL '" + remoteCCSURLString 
+//        System.out.println ("ShadowController: starting shadowing for URL '" + remoteCCSURLString
 //                            + "' using login '" + remoteCCSLogin + "'");
-        
+
         setStatus(SHADOW_CONTROLLER_STATUS.SC_STARTING);
-        
+
         //verify that the current "URL string" is a valid URL
         URL remoteCCSURL = null;
         try {
@@ -263,26 +262,26 @@ public class ShadowController {
         } catch (MalformedURLException e) {
             log.log(Level.WARNING, "Malformed Remote CCS URL: \"" + remoteCCSURLString + "\" ", e);
             controllerStatus = SHADOW_CONTROLLER_STATUS.SC_CONNECTION_FAILED ;
-            
+
             try {
                 // Send message to Shaodow connectStatusTable so user can view error
                 MessageManager.fireMessageListener(new MessageRecord("Malformed Remote CCS URL: \"" + remoteCCSURLString + "\" ", MessageScope.SHADOW_UI, e));
             } catch (Exception e2) {
                 log.log(Level.WARNING, "Exception while attempting to sent message update: " + e.getMessage(), e2);
             }
-            
+
             return false;
         }
-        
+
         //get an adapter which connects to the remote Contest API
         remoteContestAPIAdapter = createRemoteContestAPIAdapter(remoteCCSURL, remoteCCSLogin, remoteCCSPassword);
-        
+
 //        //get a remote contest configuration from the adapter
 //        remoteContestConfig  = remoteContestAPIAdapter.getRemoteContestConfiguration();
-//                        
+//
 //        //make sure we got a remote config
 //        if (remoteContestConfig != null) {
-//            
+//
 //            //check if the local contest has the same config as the remote contest (the one being shadowed)
 //            if (!remoteContestConfig.isSameAs(localContest)) {
 //
@@ -301,41 +300,41 @@ public class ShadowController {
 //        } else {
 //            //we didn't get a remote config
 //            log.log(Level.WARNING, "Contest configuration from remote CCS is null; cannot proceed with shadowing");
-// 
+//
 //            setStatus(SHADOW_CONTROLLER_STATUS.SC_INVALID_REMOTE_CONFIG);
-//            
+//
 //            return false;
 //        }
-        
-        
+
+
         //if we get here we know the remote contest configuration matches the local contest configuration
-        
+
         //construct a RunSubmitter that can be used to submit runs (received from the remote contest) to the local PC2 contest
         RemoteRunSubmitter submitter = new RemoteRunSubmitter(localController);
 
         try {
-            
+
             //construct an EventFeedMonitor for keeping track of the remote CCS events
             log.info("Constructing new RemoteEventFeedMonitor");
             monitor = new RemoteEventFeedMonitor(localController, remoteContestAPIAdapter, remoteCCSURL, remoteCCSLogin, remoteCCSPassword, submitter, shadowMonitorStatus);
 
             if (! remoteContestAPIAdapter.testConnection()){
-                
+
                 return false;
             }
-            
+
             // tell monitor where to start feed from (can be null to start from the beginning)
             monitor.setStartAfterToken(lastToken);
 
             //start the monitor running as a thread listening for submissions from the remote CCS
             monitorThread = new Thread(monitor);
             monitorThread.start();
-            
+
             log.info("RemoteEventFeedMonitor started");
             setStatus(SHADOW_CONTROLLER_STATUS.SC_RUNNING);
             return true;
-           
-            
+
+
         } catch (Exception e) {
             // TODO figure out how to return the exception to the caller cleanly
             log.log(Log.SEVERE, "Exception starting RemoteEventFeedMonitor: " + e, e);
@@ -344,7 +343,7 @@ public class ShadowController {
             e.printStackTrace();
             return false;
         }
-                
+
     }
 
     private IRemoteContestAPIAdapter createRemoteContestAPIAdapter(URL url, String login, String password) {
@@ -357,89 +356,89 @@ public class ShadowController {
             return new RemoteContestAPIAdapter(url, login, password);
         }
     }
-    
+
     /**
      * Returns a Map which maps submissionIDs to {@link ShadowJudgementInfo}s
-     * containing information on the comparison of a specific submission by PC2 and 
+     * containing information on the comparison of a specific submission by PC2 and
      * the remote CCS.
-     * 
+     *
      * Each {@link ShadowJudgementInfo} in the returned map contains the SubmissionID, TeamID, LanguageID, ProblemID, and
      * a {@link ShadowJudgementPair} map giving the PC2 Shadow and Remote CCS judgements.
-     * 
+     *
      * If the property "convertJudgementsToBig5" is true, this method attempts to convert all judgements
      * to one of the so-called "CLICS Big-5" (the five judgement values defined for ICPC World Finals by the
      * CLICS specification at https://clics.ecs.baylor.edu/index.php?title=Contest_API#Judgement_Types).
      * This means that all judgements would be one of "AC", "WA", "TLE", "RTE", or "CE";  user-defined
-     * judgements such as "OLE" (Output Limit Exceeded) would be converted to one of these "Big 5" 
+     * judgements such as "OLE" (Output Limit Exceeded) would be converted to one of these "Big 5"
      * using the methods defined in {@link CLICSJudgementType}.
-     * 
+     *
      * This method is only operative while Shadow operations are running; if shadowing is not running
      * then the method returns null.
-     * 
+     *
      * @return a Map mapping submissions to shadow judgement information, or null if shadowing isn't running
      */
     public Map<String, ShadowJudgementInfo> getJudgementComparisonInfo() {
-        
+
         if (getStatus()!= SHADOW_CONTROLLER_STATUS.SC_RUNNING) {
-            log.warning("Shadow Controller 'getJudgementComparisonInfo()' called when Shadow controller is not running"); 
+            log.warning("Shadow Controller 'getJudgementComparisonInfo()' called when Shadow controller is not running");
             return null;
         } else {
             log.info("Constructing Shadow Judgement comparisons");
-                       
+
             //get the runs (submissions) currently in PC2 (i.e. runs already received from the remote CCS and submitted to the PC2 server)
             Run[] pc2Runs = localContest.getRuns();
-                        
+
             //get a map from submissionID to ShadowJudgementInfo for each submission which PC2 knows about
             Map<String,ShadowJudgementInfo> judgementsMap = getJudgementsMap(pc2Runs);
-            
+
             //At this point we have a Map ("judgementsMap") which maps every submissionId that PC2 knows about to a ShadowJudgementInfo object
-                        
+
             //get the submission judgements which have been reported by the remote CCS
             Map<String,String> remoteSubmissionsToJudgementsMap = getRemoteSubmissionsToJudgementsMap();
-                        
+
             //check every submission reported to have a judgement by the remote CCS
             for (String key : remoteSubmissionsToJudgementsMap.keySet()) {
-                
+
                 //check if PC2 has seen this submission (it might not have yet due to lags with RemoteEventFeedMonitor submitting to PC2)
                 if (judgementsMap.containsKey(key)) {
-                    
+
                     //we found a submission, known to PC2, for which the remote CCS has reported a judgement; update the remote judgement info under that key
                     ShadowJudgementInfo info = judgementsMap.get(key);
                     ShadowJudgementPair pair = info.getShadowJudgementPair();
                     pair.setRemoteCCSJudgement(remoteSubmissionsToJudgementsMap.get(key));
                 }
             }
- 
+
             //we now have a complete map from submissions known to PC2 to ShadowJudgementInfo objects containing known PC2 judgements and known remote CCS judgements
-            
+
             //if specified, convert judgements to "Big 5"
             if (isConvertJudgementsToBig5()) {
                 log.info("Converting judgements to 'CLICS Big 5'");
                 convertMapToBig5(judgementsMap);
             }
-            
+
             return judgementsMap;
         }
-        
+
     }
-    
- 
+
+
     /**
      * Returns an array of {@link ShadowScoreboardRowComparison}s, each element of which contains a comparison of
      * corresponding rows of the current PC2 and remote CCS scoreboards.
-     * 
+     *
      * Each ShadowScoreboardRowComparison contains a pair of {@link TeamScoreRow}s, one each from the PC2 and remote CCS
      * scoreboards, along with a boolean flag indicating whether the rows are equal or not (that is, whether or not the rows
      * contain the same rank, teamId, number of problems solved, and total (penalty) points).  If for some reason a row exists
-     * in one of the scoreboards but not the other, the corresponding entry in the ShadowScoreboardRowComparison will be null 
+     * in one of the scoreboards but not the other, the corresponding entry in the ShadowScoreboardRowComparison will be null
      * (an indication of scoreboards which inherently are not equal).
-     * 
+     *
      * This method is only operative while Shadow operations are running; if shadowing is not running
      * then the method returns an empty array (that is, an array of size zero).
-     * 
-     * The method also returns an empty array if an error occurs when fetching either the PC2 or the remote CCS 
+     *
+     * The method also returns an empty array if an error occurs when fetching either the PC2 or the remote CCS
      * JSON scoreboard  strings, or when parsing those strings.
-     * 
+     *
      * @return an array of ShadowScoreboardRowComparison information, or an empty array if shadowing isn't running
      *          or an error occurs during processing either of the JSON strings representing the two scoreboards.
      */
@@ -478,19 +477,19 @@ public class ShadowController {
 
    /**
      * This method constructs a PC2 {@link ScoreboardJson} object and uses it to return a String
-     * containing the current PC2 scoreboard in CLICS Contest API format. 
-     * 
+     * containing the current PC2 scoreboard in CLICS Contest API format.
+     *
      * @return a String containing the PC2 scoreboard JSON.
      */
     private String getPC2ScoreboardJSON() {
-        
+
         ScoreboardJson sbJsonObject = new ScoreboardJson();
         String pc2Json ;
         try {
             pc2Json = sbJsonObject.createJSON(localContest, log);
         } catch (IllegalContestState | JAXBException | IOException e) {
             log.log(Log.WARNING,"Exception creating PC2 scoreboard JSON: " + e.getMessage(), e);
-            
+
             try {
                 // Send message to Shaodow connectStatusTable so user can view error
                 MessageManager.fireMessageListener(new MessageRecord("Exception creating PC2 scoreboard JSON: " + e.getMessage(), MessageScope.SHADOW_UI, e));
@@ -500,52 +499,52 @@ public class ShadowController {
 
             return null;
         }
-        
+
         return pc2Json;
     }
 
     /**
      * This method returns a String containing the current remote CCS scoreboard as obtained from the
-     * remote CCS Contest API "/scoreboard" endpoint. 
-     * 
+     * remote CCS Contest API "/scoreboard" endpoint.
+     *
      * @return a String containing the remote CCS scoreboard JSON.
      */
     private String getRemoteScoreboardJSON() {
-        
+
         //get scoreboard from remoteAPIAdaptor
         String remoteJson = remoteContestAPIAdapter.getRemoteJSON("/scoreboard");
-        
+
         //return scoreboard
         return remoteJson;
-        
+
     }
 
     /**
      * This method returns a String containing the current PC2 team list as obtained from the
-     * PC2 server, converted into CLICS Contest API "/teams" endpoint format 
-     * (see https://ccs-specs.icpc.io/contest_api#teams). 
-     * 
+     * PC2 server, converted into CLICS Contest API "/teams" endpoint format
+     * (see https://ccs-specs.icpc.io/contest_api#teams).
+     *
      * @return a String containing the PC2 team list JSON.
      */
     public String getPC2TeamsJSON() {
-        
+
         log.info("Fetching PC2 team JSON");
-        
+
         //get the PC2 team account list from the InternalContest model
         Vector<Account> teamAccounts = localContest.getAccounts(Type.TEAM);
-        
+
         //open the return string as an array of teams
-        String retJson = "["; 
-        
+        String retJson = "[";
+
         //convert PC2 team accounts into CLICS JSON format (see https://ccs-specs.icpc.io/contest_api#teams)
         boolean first = true;
         for (Account teamAcct : teamAccounts) {
-            
+
             //get the required values out of the team account
             ClientId clientId = teamAcct.getClientId();
             String teamId = "" + clientId.getClientNumber();
             String teamName = teamAcct.getDisplayName();
-            
+
             //add this team element to the return JSON, preceded by a comma if it's not the first element
             if (!first) {
                 retJson += ",";
@@ -555,13 +554,13 @@ public class ShadowController {
             retJson += ",";
             retJson += "\"name\":\"" + teamName + "\"";
             retJson += "}";
-            
+
             first = false ;
         }
-        
+
         //close the array of teams
         retJson += "]";
-                
+
         //return the PC2 teams JSON
         return retJson;
     }
@@ -569,33 +568,33 @@ public class ShadowController {
 
     /**
      * This method returns a String containing the current remote CCS team list as obtained from the
-     * remote CCS Contest API "/teams" endpoint. 
-     * 
+     * remote CCS Contest API "/teams" endpoint.
+     *
      * @return a String containing the remote CCS team list JSON.
      */
     public String getRemoteTeamsJSON() {
-        
+
         log.info("Fetching Remote CCS team JSON");
-        
+
         //get team list from remoteAPIAdaptor
         String remoteJson = remoteContestAPIAdapter.getRemoteJSON("/teams");
-                
+
         //return team list
         return remoteJson;
-        
+
     }
 
    /**
      * Returns a Map which maps remote CCS submissionIds to a judgement acronym.
-     * 
-     * Any judgements from the Remote CCS which are null, which have values which are null or empty, which 
+     *
+     * Any judgements from the Remote CCS which are null, which have values which are null or empty, which
      * have submissionIds which are null or empty, or which have judgement acronyms which are null or empty,
      * are silently ignored (not represented in the map returned by this method).
-     * 
+     *
      * @return a Map with entries mapping a submissionId String to an acronym String.
      */
     private Map<String, String> getRemoteSubmissionsToJudgementsMap() {
-        
+
         //get a copy of the RemoteEventFeedMonitor's Judgements map, which maps "judgementIds" to a String of the form "submissionId:acronym"
         Map<String, String> remoteJudgementsMap = RemoteEventFeedMonitor.getRemoteJudgementsMapSnapshot();
 
@@ -617,8 +616,8 @@ public class ShadowController {
         }
         return remoteSubmissionsToJudgementsMap;
     }
-    
-    
+
+
     /**
      * Returns a Map which maps submissionIds to {@link ShadowJudgementInfo} objects for every submission (run) in the
      * specified array of PC2 Runs.
@@ -626,7 +625,7 @@ public class ShadowController {
     protected Map<String, ShadowJudgementInfo> getJudgementsMap(Run[] pc2Runs) {
 
         Map<String, ShadowJudgementInfo> pc2JudgementInfoMap = new HashMap<String, ShadowJudgementInfo>();
-        
+
         log = getLog();
 
         // check each PC2 run (submission)
@@ -692,7 +691,7 @@ public class ShadowController {
                         }
 
                         if (acronym != null) {
-                            
+
                             //get the id of who applied the most recent judgement
                             ClientId judgerClientID = jr.getJudgerClientId();
 
@@ -700,7 +699,7 @@ public class ShadowController {
                             ShadowJudgementPair pair = new ShadowJudgementPair(submissionId, acronym.name(), "<pending>");
 
 //                            System.out.print("Debug: adding to judgementsMap: ");
-//                            System.out.println("  submissionID=" + submissionId + " teamID=" + teamID + " problemID=" + problemID + " languageID=" + languageID 
+//                            System.out.println("  submissionID=" + submissionId + " teamID=" + teamID + " problemID=" + problemID + " languageID=" + languageID
 //                                    + " pc2Judgement=" + acronym.name() + " remoteJudgement=" + "<pending>");
 
                             ShadowJudgementInfo info = new ShadowJudgementInfo(submissionId, teamID, problemID, languageID, judgerClientID, pair);
@@ -720,7 +719,7 @@ public class ShadowController {
                                  */
                                 String acronymnName = judgement.getAcronym().toString();
 
-                                // Add ShadowJudgementInfo for run into pc2JudgementInfoMap 
+                                // Add ShadowJudgementInfo for run into pc2JudgementInfoMap
                                 ClientId judgerClientID = jr.getJudgerClientId();
                                 ShadowJudgementPair pair = new ShadowJudgementPair(submissionId, acronymnName, "<pending>");
                                 ShadowJudgementInfo info = new ShadowJudgementInfo(submissionId, teamID, problemID, languageID, judgerClientID, pair);
@@ -734,20 +733,20 @@ public class ShadowController {
                     } else {
                         // we got a null judgment record from the run, but it's supposedly been judged -- error!
                         log.severe("Error: found a (supposedly) judged PC2 run with no PC2 JudgementRecord!" + " (Submission id = " + run.getNumber() + ")");
-                        
-                        
+
+
                     }
 
                 } else {
-                    
+
                     // we have a run which has not yet been judged by PC2; assign "pending" for both the PC2 and remote judgement and null for the judgerId
                     ShadowJudgementPair pair = new ShadowJudgementPair(submissionId, "<pending>", "<pending>");
                     ShadowJudgementInfo info = new ShadowJudgementInfo(submissionId, teamID, problemID, languageID, null, pair);
-                    
+
 //                    System.out.print("Debug: adding to judgementsMap: ");
-//                    System.out.println("  submissionID=" + submissionId + " teamID=" + teamID + " problemID=" + problemID + " languageID=" + languageID 
+//                    System.out.println("  submissionID=" + submissionId + " teamID=" + teamID + " problemID=" + problemID + " languageID=" + languageID
 //                            + " pc2Judgement=" + "<pending>" + " remoteJudgement=" + "<pending>");
-                    
+
                     pc2JudgementInfoMap.put(submissionId, info);
                 }
 
@@ -756,32 +755,32 @@ public class ShadowController {
             }
 
         } // end for each PC2 run
-                        
+
         return pc2JudgementInfoMap;
-        
+
     }
-    
-    
+
+
     /**
      * Returns a list of differences between the currently-configured remote contest
      * and the configuration of the local PC2 contest, or null if no remote contest configuration
      * has been obtained.
-     * 
+     *
      * @return a List<String> of contest configuration differences, or null if no remote configuration is available
      */
     public List<String> getConfigurationDiffs() {
-        
+
         List<String> diffs = null;
         if (remoteContestConfig != null) {
             diffs = remoteContestConfig.diff(localContest);
         }
         return diffs ;
     }
-    
+
     /**
-     * This method writes the given list of differences between the local and remote contest configurations 
+     * This method writes the given list of differences between the local and remote contest configurations
      * into the specified log.
-     * 
+     *
      * @param diffs a List<String> giving the configuration differences
      */
     @SuppressWarnings("unused")
@@ -791,31 +790,31 @@ public class ShadowController {
     }
 
     /**
-     * This method stops the Shadow Mode listener thread.  
+     * This method stops the Shadow Mode listener thread.
      */
     public void stop() {
-        
+
         setStatus(SHADOW_CONTROLLER_STATUS.SC_STOPPING) ;
-        
+
         if (monitor!=null) {
-            
+
             monitor.stop();
-            
+
             //garbage-collect the monitor
-            monitor = null;        
-            
+            monitor = null;
+
             // nullifying the monitor, will close the connection
             if(shadowMonitorStatus != null) {
                 shadowMonitorStatus.connectClosed("Connection closed by PC2");
             }
         }
-        
+
         setStatus(SHADOW_CONTROLLER_STATUS.SC_STOPPED) ;
     }
 
     /**
      * Returns the current status of this ShadowController.
-     * 
+     *
      * @return a SHADOW_CONTROLLER_STATUS enum element giving the controller status
      */
     public SHADOW_CONTROLLER_STATUS getStatus() {
@@ -824,33 +823,33 @@ public class ShadowController {
 
     /**
      * Updates the ShadowController status.
-     * 
+     *
      * @param controllerStatus the controllerStatus to set
      */
     protected void setStatus(SHADOW_CONTROLLER_STATUS controllerStatus) {
         this.controllerStatus = controllerStatus;
     }
-    
+
     /**
      * Returns the indicator of whether judgements should be restricted to "Big 5" form.
      * The purpose of this method (rather than simply accessing the boolean variable)
      * is to support future extensions which may obtain this property from elsewhere.
-     * 
+     *
      * TODO:  add a checkbox to the Shadow GUI which allows setting/saving this property;
      *          return the value of that flag instead of a local variable.
-     * @return the flag indicating whether judgements should be restricted/converted to 
+     * @return the flag indicating whether judgements should be restricted/converted to
      *              CLICS "Big 5" judgements
      */
     private boolean isConvertJudgementsToBig5() {
         return convertJudgementsToBig5 ;
     }
-    
+
 //    /**
-//     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms if a corresponding CLICS Big 5 acronym 
+//     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms if a corresponding CLICS Big 5 acronym
 //     * can be found.  If no corresponding acronym can be found, then a check is made to see if the initial acronym contains the
 //     * substring "pending"; if so, the original acronym is retained, if not then the acronym is replaced with a string of the form
 //     * "<NoBig5:xxx>" where "xxx" is the original acronym.
-//     * 
+//     *
 //     * @param map the map to be converted
 //     */
 //    private void convertMapToBig5 (Map<String,String> map) {
@@ -881,42 +880,42 @@ public class ShadowController {
 //    }
 
     /**
-     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms if a corresponding CLICS Big 5 acronym 
+     * Converts the given map so that all judgement acronyms are CLICS "Big 5" acronyms if a corresponding CLICS Big 5 acronym
      * can be found.  If no corresponding acronym can be found, then a check is made to see if the initial acronym contains the
      * substring "pending"; if so, the original acronym is retained, if not then the acronym is replaced with a string of the form
      * "<NoBig5:xxx>" where "xxx" is the original acronym.
-     * 
+     *
      * @param map the map to be converted
      */
     private void convertMapToBig5 (Map<String,ShadowJudgementInfo> map) {
-        
+
         //process each submission in the specified map
         for (String submissionID : map.keySet()) {
-            
+
             //get the judgement info out of the submission
             ShadowJudgementInfo info = map.get(submissionID) ;
-            
+
             //get the ShadowJudgementPair out of the judgement info
             ShadowJudgementPair pair = info.getShadowJudgementPair();
-            
+
             String judgementAcronym = pair.getPc2Judgement();
             pair.setPc2Judgement(convertJudgementToCLICSBig5(judgementAcronym));
-            
+
             judgementAcronym = pair.getRemoteCCSJudgement();
             pair.setRemoteCCSJudgement(convertJudgementToCLICSBig5(judgementAcronym));
-            
+
         }
     }
-    
+
     /**
      * Returns a String representing the "CLICS Big5 acronym" (one of WA/RTE/TLE/CE/AC) corresponding to the specified judgement acronym tring.
      * If there is no corresponding conversion (as defined by {@link CLICSJudgementType#getBig5EquivalentAcronym()},
      * then if the specified judgement string contains the substring "pending" then the specified judgement string is returned,
      * otherwise a String of the form "<NoBig5:xxx>" (where xxx is the input string) is returned.
-     * 
+     *
      * @param judgementAcronym the string to be converted to its "CLICS Big 5" equivalent.
-     * 
-     * @return a String containing a CLICS Big5 acronym if there is such an acronym matching the input judgement; otherwise 
+     *
+     * @return a String containing a CLICS Big5 acronym if there is such an acronym matching the input judgement; otherwise
      *              returns the input judgement or a string containing the input judgement.
      */
     private String convertJudgementToCLICSBig5(String judgementAcronym) {
@@ -925,7 +924,7 @@ public class ShadowController {
 
         //construct dummy "JudgementType" representing the input judgement string
         CLICSJudgementType judgement = new CLICSJudgementType (judgementAcronym, "dummy", false, false) ;
-        
+
         //try to get a "BIG5" acronym string corresponding to the input acronym judgement string
         String big5AcronymString = judgement.getBig5EquivalentAcronym();
 
@@ -942,7 +941,7 @@ public class ShadowController {
                 // it does contain pending; keep the original judgement string
                 retStr = judgementAcronym;
             }
-            
+
         } else {
             //there was a CLICS Big5 acronym matching the input string; return the CLICS Big5 string
             retStr = big5AcronymString;
@@ -950,7 +949,7 @@ public class ShadowController {
 
         return retStr;
     }
-    
+
 
 
 
@@ -963,8 +962,8 @@ public class ShadowController {
     }
 
     private void showMessage(String message) {
-        System.out.println(new Date() + " " +message);
-//        getLog().info(message);
+//        System.out.println(new Date() + " " +message);
+        getLog().info(message);
     }
 
     private void updateCached(ContestInformation ci) {
@@ -981,7 +980,7 @@ public class ShadowController {
     }
 
     /**
-     * 
+     *
      * @param ci
      * @return True if shadow server is started (including restarted), else False.
      */
@@ -992,16 +991,16 @@ public class ShadowController {
                 // we are suppose to be running, and we were running
                 // check for differences
                 String message = "";
-                if (ci.getPrimaryCCS_URL() != remoteCCSURLString) {
+                if (!ci.getPrimaryCCS_URL().equals(remoteCCSURLString)) {
                     message = "shadowRemoteURL changed from " + remoteCCSURLString + " to " + ci.getPrimaryCCS_URL() + "\n";
                 }
-                if (ci.getPrimaryCCS_user_login() != remoteCCSLogin) {
+                if (!ci.getPrimaryCCS_user_login().equals(remoteCCSLogin)) {
                     message = message + "shadowLogin changed from " + remoteCCSLogin + " to " + ci.getPrimaryCCS_user_login() + "\n";
                 }
-                if (ci.getPrimaryCCS_user_pw() != remoteCCSPassword) {
+                if (!ci.getPrimaryCCS_user_pw().equals(remoteCCSPassword)) {
                     message = message + "shadow_user_password changed from " + remoteCCSPassword + " to " + ci.getPrimaryCCS_user_pw() + "\n";
                 }
-                if (message != "") {
+                if (!message.isEmpty()) {
                     message = message + "Restarting shadow controller";
                     showMessage(message);
                     stop();
@@ -1012,7 +1011,7 @@ public class ShadowController {
             }
         } else {
             // check if we were running (but we should not be)
-            if (!ci.isShadowMode() && getStatus().equals(SHADOW_CONTROLLER_STATUS.SC_RUNNING)) {
+            if ((ci == null || !ci.isShadowMode()) && getStatus().equals(SHADOW_CONTROLLER_STATUS.SC_RUNNING)) {
                 // stop it
                 showMessage("Stopping shadow controller");
                 updateCached(ci);


### PR DESCRIPTION
### Description of what the PR does
String object compares were being used as opposed to string value compares for **ContestInformation** properties.  This caused the compares to always show differences, which would cause a disconnect/reconnect on the shadow since it thought that the contest settings changed.

CI: log messages instead of using console **System.out**

### Issue which the PR addresses
Fixes #935 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ubuntu 22.04 (contest image)
jdk1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Set up a primary CSS (or connect to a known on-line CCS)
2. Set up a shadow PC2 instance using the same CDP as the primary
3. Start the server
4. Start an _administrator_ account
5. Start a _feeder_ account.
6. Set appropriate connection information on the **Shadow** tab to connect to a remote CCS running a contest or contest playback. (Note: this is the hard part - setting up a primary ccs to shadow that has enough runs.)
7. Start shadowing a contest - make sure there are enough events or the reading of the event feed will finish before you can do the rest of procedure.
8. On the administrator,  go to the **Settings** tab and change something that causes a **ContestInformation** change, such as maximum output bytes.  This causes a **ContestInformationEvent** update, which previously would cause a disconnect by the shadow from the primary CCS and start and endless loop of disconnect/reconnect.

**Note**: MOST of the changes are for spaces that were at the end of lines, and the Eclipse options I have set remove those.  I was asked to set that option.  Perhaps I should turn it off in the future since it causes unnecessary differences.  For the reader's digest version, the only real differences start at line 994 and extend through line 1014.
