### PR TITLE
I815 Allow shadowing if contest not started

### DIFF
--- a/src/edu/csus/ecs/pc2/shadow/IShadowMonitorStatus.java
+++ b/src/edu/csus/ecs/pc2/shadow/IShadowMonitorStatus.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
 /**
@@ -6,7 +6,7 @@ package edu.csus.ecs.pc2.shadow;
  * A user of the RemoteEventFeedMonitor has the option to get upcalls for various
  * counters that change, such as the number of events processed or the number of
  * records read.  In addition, the user can keep track of disconnects and reconnects.
- * 
+ *
  * @author John Buck
  *
  */
@@ -14,43 +14,57 @@ public interface IShadowMonitorStatus {
 
     /**
      * Updates last processed token
-     * 
+     *
      * @param token the last token received and processed on the feed
      */
     public void updateShadowLastToken(String token);
-    
+
     /**
      * Updates number of records received
-     * 
+     *
      * @param number of records received
      */
     public void updateShadowNumberofRecords(int nRec);
-    
+
+    /**
+     * Updates number of tossed records due to the contest not being staretd
+     *
+     * @param number of records tossed
+     */
+    public void updateShadowNumberofTossedRecords(int nRec);
+
     /**
      * Could not establish connection to primary
-     * 
+     *
      * @param token last successfully processed event
      */
     public void connectFailed(String token);
-    
+
     /**
      * Connection to primary succeeded
-     * 
+     *
      * @param token where to start feed from (after this)
      */
     public void connectSucceeded(String token);
-    
+
     /**
      * Normal close of remote
-     * 
+     *
      * @param msg string describing what happened
      */
     public void connectClosed(String Msg);
-    
+
     /**
      * Unexpected close of remote
-     * 
+     *
      * @param errMsg string describing what happened
      */
     public void errorDisconnect(String errMsg);
+
+    /**
+     * General information message
+     *
+     * @param infoMsg string describing what happened
+     */
+    public void statusMessage(String errMsg);
 }

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -552,7 +552,7 @@ public class RemoteEventFeedMonitor implements Runnable {
                                     } else if ("judgements".equals(eventType)) {
 
                                         if(!allowSubmitsAndJudgments) {
-                                             log.info("Skipping judgment event since the contest has not started and allowPrestartActivity is false.");
+                                            log.info("Skipping judgment event since the contest has not started and allowPrestartActivity is false.");
                                             event = reader.readLine();
                                             tossedMessages++;
                                             if(monitorStatus != null) {
@@ -632,7 +632,7 @@ public class RemoteEventFeedMonitor implements Runnable {
                                             // Can set this to indicate we want to put a message in the GUI log
                                             String statusMessage = null;
 
-                                            //convert state data into a ShadowRunSubmission object
+                                            //convert state data into a ShadowStateMessage object
                                             ShadowStateMessage contestState = createStateMessage((Map<String, Object>) eventMap.get("data"));
 
                                             Date remoteStart = contestState.getStarted();

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -668,9 +668,14 @@ public class RemoteEventFeedMonitor implements Runnable {
                                                         // contest never started, but remote says it's go time.  If the contest was already started
                                                         // manually, we ignore it.
                                                         remoteCCSStarted = true;
-                                                        statusMessage = "Primary started the contest at " + getISODateString(remoteStart);
+                                                        if (!isReadOnlyClient()) {
+                                                            statusMessage = "Primary started the contest at " + getISODateString(remoteStart);
+                                                            pc2Controller.startAllContestTimes();
+                                                        } else {
+                                                            statusMessage = "Primary indicates contest start at " + getISODateString(remoteStart) +
+                                                                " but this is a read only client";
+                                                        }
                                                         logAndDebugPrint(log, Level.INFO, statusMessage);
-                                                        pc2Controller.startAllContestTimes();
                                                     } else {
                                                         statusMessage = "First started state from Primary has ended set as well - not starting";
                                                         logAndDebugPrint(log, Level.INFO, statusMessage);
@@ -691,9 +696,13 @@ public class RemoteEventFeedMonitor implements Runnable {
                                                         remoteCCSEnded = true;
                                                          // can only stop contest if it is running now
                                                         if(pc2Controller.getContest().getContestTime().isContestRunning()) {
-                                                            statusMessage = "Primary ends the contest at " +
-                                                                getISODateString(remoteEnd);
-                                                            pc2Controller.stopAllContestTimes();
+                                                            if (!isReadOnlyClient()) {
+                                                                statusMessage = "Primary ends the contest at " + getISODateString(remoteEnd);
+                                                                pc2Controller.stopAllContestTimes();
+                                                            } else {
+                                                                statusMessage = "Primary indicates contest end at " + getISODateString(remoteStart) +
+                                                                    " but this is a read only client";
+                                                            }
                                                         } else {
                                                             statusMessage = "Primary wants to end the contest but it's stopped";
                                                         }

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -1210,7 +1210,6 @@ public class RemoteEventFeedMonitor implements Runnable {
          ZoneId defZone = ZoneId.systemDefault();
          ZonedDateTime zoneDate = dateInst.atZone(defZone);
          return(zoneDate.toString());
-//         return(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(zoneDate.to);
      }
 
      /**

--- a/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitor.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
 import java.io.BufferedReader;
@@ -7,12 +7,17 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+
+import javax.xml.bind.DatatypeConverter;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,14 +37,14 @@ import edu.csus.ecs.pc2.ui.ShadowCompareRunsPane;
 
 /**
  * This class listens for submission events in the event feed input stream from a remote CCS CLICS Contest API Event Feed.
- * 
+ *
  * Events of type "submissions" result in fetching the submission files from the remote CCS and submitting those files
  * as a submission to the local (Shadow) PC2 system.
- * 
+ *
  * Events of type "judgements" result in updating a global map of judgements received from the remote system; this map
  * is subsequently used by the {@link ShadowCompareRunsPane} class to display comparisons between local (shadow) judgements
  * and the corresponding judgements from the remote CCS.
- * 
+ *
  * @author pc2@ecs.csus.edu
  *
  */
@@ -48,25 +53,33 @@ public class RemoteEventFeedMonitor implements Runnable {
     public static final int REMOTE_EVENT_FEED_DELAYMS = 0;
     public static final int RECONNECT_RETRY_DELAY = 5000;
     public static final boolean ATTEMPT_RECONNECTS = true;
-    
+    public static final boolean ALLOW_PRESTART_ACTIVITY = false;
+
     private IRemoteContestAPIAdapter remoteContestAPIAdapter;
     private URL remoteURL;
     private String login;
     private String password;
     private RemoteRunSubmitter submitter;
-    
+
     private boolean keepRunning ;
-    
+
+    // contest state from remote CCS
+    private boolean remoteCCSStarted = false;
+    private boolean remoteCCSEnded = false;
+    private boolean remoteCCSFrozen = false;
+    private boolean remoteCCSThawed = false;
+    private boolean remoteCCSFinalized = false;
+
     //set this to true to filter out all but those submissions/judgements listed in "submissionFilterIDs"
-    private boolean respectSubmissionFilter = false; 
-    
+    private boolean respectSubmissionFilter = false;
+
     //a list of submissions which are the only ones we are interested in if respectSubmissionFilter is true
     private String [] submissionFilterIDs = {
 
             /* PacNW submissions of interest
              * "286", "414", "908", "1414", "1437", "1460", "1464", "1481", "1531", "1611"
-             */        
-            
+             */
+
             /* DOMJudge SystestA submissions of interest
              */
             "248603", //cpp, first judgement (which is null)
@@ -74,29 +87,33 @@ public class RemoteEventFeedMonitor implements Runnable {
             "248611", //java
             "248609", //py2
             "249388"  //py3
-            
+
         } ;
-    
+
     //a list form of the above, created in the class constructor
     private List<String> submissionFilterIDsList;
-    
+
     private boolean listening;
     private IInternalController pc2Controller;
     private InputStream remoteInputStream;
     private IShadowMonitorStatus monitorStatus;
-    
+
     //for support of reconnecting to the primary
     private String lastToken = null;
     private String msg;
     private int nRecords;
     private int retryConnectDelay = RECONNECT_RETRY_DELAY;
     private boolean attemptConnectRetries = ATTEMPT_RECONNECTS;
-        
+    private int tossedMessages = 0;
+
+    // Should we allow submissions/judgements from remote prior to contest start
+    private boolean allowPrestartActivity = ALLOW_PRESTART_ACTIVITY;
+
    /**
-     * A Map mapping remote judgement ids to corresponding submission ids and the judgement applied to that submission.
-     */
+    * A Map mapping remote judgement ids to corresponding submission ids and the judgement applied to that submission.
+    */
     private static Map<String,String> remoteJudgements;
-    
+
     /**
      * A lock for synchronizing access to the above map.
      */
@@ -104,7 +121,7 @@ public class RemoteEventFeedMonitor implements Runnable {
 
     /**
      * Constructs a RemoteEventFeedMonitor with the specified values.  The RemoteEventFeedMonitor
-     * is used to listen for submission events in the event feed from a remote CCS contest.  
+     * is used to listen for submission events in the event feed from a remote CCS contest.
      *
      * @param pc2Controller an {@link IInternalController} for passing error handling back to the local PC2 system
      * @param remoteContestAPIAdapter an adapter for accessing the remote contest API
@@ -117,10 +134,10 @@ public class RemoteEventFeedMonitor implements Runnable {
                                   URL remoteURL, String login, String password, RemoteRunSubmitter submitter) {
         this(pc2Controller, remoteContestAPIAdapter, remoteURL, login, password, submitter, null);
     }
-    
+
     /**
      * Constructs a RemoteEventFeedMonitor with the specified values.  The RemoteEventFeedMonitor
-     * is used to listen for submission events in the event feed from a remote CCS contest.  
+     * is used to listen for submission events in the event feed from a remote CCS contest.
      *
      * @param pc2Controller an {@link IInternalController} for passing error handling back to the local PC2 system
      * @param remoteContestAPIAdapter an adapter for accessing the remote contest API
@@ -140,27 +157,29 @@ public class RemoteEventFeedMonitor implements Runnable {
         this.password = password;
         this.submitter = submitter;
         this.monitorStatus = mon;
-        
+
         //create a filter for submissions (only used if respectSubmmissionFilter = true)
         submissionFilterIDsList = new ArrayList<String>(submissionFilterIDs.length);
         Collections.addAll( submissionFilterIDsList, submissionFilterIDs);
 
     }
-    
+
     @Override
     public void run() {
         boolean bDelay;
         boolean bOpened = false;
+        boolean allowSubmitsAndJudgments = false;
+
         Thread.currentThread().setName("RemoteEventFeedMonitorThread");
         // local map to look for duplicate submissions
         Map<String, Boolean> mapSubmissions = new HashMap<String, Boolean>();
         Boolean bFound;
-        
+
         keepRunning = true;
         nRecords = 0;
-       
+
         Log log = pc2Controller.getLog();
-        
+
         while(keepRunning) {
             // open or reopen connection to remoteURL event-feed endpoint
             // make up nice message for log
@@ -176,7 +195,7 @@ public class RemoteEventFeedMonitor implements Runnable {
             }
             logAndDebugPrint(log, Level.INFO, msg);
             remoteInputStream = remoteContestAPIAdapter.getRemoteEventFeedInputStream(lastToken);
-    
+
             if (remoteInputStream == null) {
                 //  TODO: improve error handling (more than just logging?)
                 logAndDebugPrint(log, Level.SEVERE, "Error opening event feed stream");
@@ -185,37 +204,39 @@ public class RemoteEventFeedMonitor implements Runnable {
                     monitorStatus.connectFailed(lastToken);
                 }
             } else {
-    
+
                 String event = "null event";
-                
+
                 bOpened = true;
                 if(monitorStatus != null) {
                     // if someone is monitoring, inform them we are connected
                     monitorStatus.connectSucceeded(lastToken);
                 }
                 try {
-    
+
                     //wrap the event stream (which consists of newline-delimited character strings representing events)
                     // in a BufferedReader
                     BufferedReader reader = new BufferedReader(new InputStreamReader(remoteInputStream));
-    
+
                     //read the next event from the event feed stream
                     event = reader.readLine();
-    
+
+                    tossedMessages = 0;
+
                     //process the next event
                     while ((event != null) && keepRunning) {
-    
+
                         //if the remote system feeds events too fast (which happens when testing with a completed contest/eventfeed, and could
                         // in theory happen during a live contest), this RemoteEventFeedMonitor thread overwhelms the JVM scheduler, causing
                         // things like AWT Dispatch thread GUI updates to become hung.
                         //Let's sleep for a moment to allow other threads to run.
                         //Note1: it might seem more logical to put this sleep at the END of the while-loop; however, there are multiple places
                         // within the loop which invoke "continue", which would SKIP the sleep if it was at the end of the loop...
-                        //Note2:  the value "10ms" was experimentally determined using the NADC21 Kattis event feed, which contains over 53,300 
+                        //Note2:  the value "10ms" was experimentally determined using the NADC21 Kattis event feed, which contains over 53,300
                         // events (lines).  Any value below 10ms caused the GUI to freeze up.
-                        //Note3: an attempt was made to change the priority of this thread to a higher number (so, lower priority) than that 
+                        //Note3: an attempt was made to change the priority of this thread to a higher number (so, lower priority) than that
                         // assigned to the AWT Event Dispatch thread, and then to use Thread.yield() here instead of Thread.sleep().  In theory
-                        // this should have allowed the AWT thread to gain the CPU when it was ready to run, but in practice GUI lockups were 
+                        // this should have allowed the AWT thread to gain the CPU when it was ready to run, but in practice GUI lockups were
                         // still seen.  This could be because the AWT thread has multiple blocking conditions and each one of these allows this
                         // Event Feed Monitor thread to get back to the CPU (and use it for a full scheduling timeslice).
                         // So it was determined that the following was the best solution, at least in the short term...
@@ -225,10 +246,10 @@ public class RemoteEventFeedMonitor implements Runnable {
                         // delay for will set the bDelay to true, such as submissions and judgements (which is currently all we process anyway)
                         // by default, we will NOT delay.  This lets messages like organizations, runs, teams, etc, fly by quickly.
                         bDelay = false;
-                       
+
                         //skip blank lines and any that do not start/end with "{...}"
                         if ( event.length()>0 && event.trim().startsWith("{") && event.trim().endsWith("}") ) {
-                            
+
                             if(lastToken != null) {
                                 msg = "Got event string (last token " + lastToken + "): " + event;
                             } else {
@@ -236,7 +257,7 @@ public class RemoteEventFeedMonitor implements Runnable {
                             }
                             logAndDebugPrint(log, Level.INFO, msg);
                             try {
-    
+
                                 /**
                                  *
                                 Sample submissions JSON from finals 2019 dom judge event feed.
@@ -245,14 +266,14 @@ public class RemoteEventFeedMonitor implements Runnable {
                                 {"id":"279031","type":"submissions","op":"create","data":{"language_id":"java","time":"2019-04-03T18:57:55.228+01:00","contest_time":"-17:02:04.771","id":"10549","externalid":null,"team_id":"148","problem_id":"azulejos","entry_point":null,"files":[{"href":"contests/finals/submissions/10549/files","mime":"application/zip"}]},"time":"2019-04-03T18:57:55.235+01:00"}
                                 {"id":"279032","type":"submissions","op":"create","data":{"language_id":"java","time":"2019-04-03T18:57:55.244+01:00","contest_time":"-17:02:04.755","id":"10550","externalid":null,"team_id":"148","problem_id":"azulejos","entry_point":null,"files":[{"href":"contests/finals/submissions/10550/files","mime":"application/zip"}]},"time":"2019-04-03T18:57:55.251+01:00"}
                                  */
-    
+
                                 // extract the event into a map of event element names/values
                                 Map<String, Object> eventMap = getMap(event);
-    
+
                                 if (eventMap == null) {
                                     // could not parse event
                                     logAndDebugPrint(log, Level.WARNING, "Could not parse event: " + event);
-    
+
                                 } else {
                                     // Get event token, if present
                                     String evToken = (String)eventMap.get("token");
@@ -263,99 +284,113 @@ public class RemoteEventFeedMonitor implements Runnable {
                                             monitorStatus.updateShadowLastToken(lastToken);
                                         }
                                     }
-   
+
                                     // find event type
                                     String eventType = (String) eventMap.get("type");
-                                    
+
                                     logAndDebugPrint(log, Level.INFO, "Found event of type " + eventType + ": " + event);
-    
+
+                                    boolean isContestRunning = pc2Controller.getContest().getContestTime().isContestRunning();
+
+                                    // we will process submissions/judgments if we are allowed precontest or the contest is running
+                                    allowSubmitsAndJudgments = allowPrestartActivity | isContestRunning;
+
                                     if ("submissions".equals(eventType)) {
-    
+
                                         if (isReadOnlyClient()) {
                                             log.info("Skipping submission event due to being logged in as a read-only client (not Feeder1)");
                                             event = reader.readLine();
                                             continue;
                                         }
 
-    
+                                        if(!allowSubmitsAndJudgments) {
+                                            log.info("Skipping submission event since the contest has not started and allowPrestartActivity is false.");
+                                            event = reader.readLine();
+                                            tossedMessages++;
+                                            if(monitorStatus != null) {
+                                                monitorStatus.updateShadowNumberofTossedRecords(tossedMessages);
+                                            }
+                                            continue;
+                                        }
+
                                         //process a submission event
                                         try {
-    
+
                                             logAndDebugPrint(log, Level.INFO, "Processing submission event: " + event);
-    
+
                                             //get a map of the data comprising the submission
                                             Map<String, Object> submissionEventDataMap = (Map<String, Object>) eventMap.get("data");
-    
+
                                             //get the submission ID out of the submission event data map
                                             String submissionID = (String) submissionEventDataMap.get("id");
-                                            
+
                                             //check if the current submission is to be ignored due to filtering
                                             // (submissionFilterIDsList is a list of submissions we WANT TO KEEP; typically used for debugging...)
                                             if (respectSubmissionFilter && !submissionFilterIDsList.contains(submissionID)) {
-    
+
                                                 logAndDebugPrint(log, Level.INFO, "Ignoring submission " + submissionID + " due to filter");
                                                 event = reader.readLine();
                                                 continue;
                                             }
-    
-                                            bFound = (Boolean)mapSubmissions.get(submissionID);
+
+                                            bFound = mapSubmissions.get(submissionID);
                                             if(bFound != null && bFound.booleanValue() == true) {
-                                                
+
                                                 logAndDebugPrint(log, Level.INFO, "Quickly Ignoring submission " + submissionID + " due to it already having been submitted");
 
                                                 event = reader.readLine();
                                                 continue;
                                             }
-                                            
+
                                             //make sure we haven't seen this submission before (this could happen if
                                             // we've done a restart but already processed this submission on a prior shadow run)
                                             if (RunUtilities.isAlreadySubmitted(pc2Controller.getContest(),submissionID) ) {
-                                                
+
                                                 logAndDebugPrint(log, Level.INFO, "Ignoring submission " + submissionID + " due to it already having been submitted");
 
                                                 event = reader.readLine();
                                                 continue;
                                             }
-    
+
                                             // add to local map to detect quick duplicate before they get entered into the system
                                             mapSubmissions.put(submissionID, true);
-                                            
+
                                             // This is the commit point for a submission, so we will want to delay at the end of the loop
                                             bDelay = true;
-                                            
+
                                             //convert submission data into a ShadowRunSubmission object
                                             ShadowRunSubmission runSubmission = createRunSubmission(submissionEventDataMap);
-    
+
                                             if (runSubmission == null) {
-                                                
+
                                                 logAndDebugPrint(log, Level.SEVERE, "Error parsing submission data: " + event);
                                                 throw new Exception("Error parsing submission data " + event);
-                                                
+
                                             } else {
-    
+
                                                 logAndDebugPrint(log, Level.INFO, "Found run " + runSubmission.getId() + " from team " +
                                                         runSubmission.getTeam_id() + ": event= " + event);
-    
+
                                                 //construct the override values to be used for the shadow submission
                                                 long overrideTimeMS = Utilities.convertCLICSContestTimeToMS(runSubmission.getContest_time());
                                                 long overrideSubmissionID = Utilities.stringToLong(runSubmission.getId());
-    
+
         //The entire following block of commented-out code is intended to be used to support fetching submission files from the remote system by using the
         // "href" element found within the "files" element of a submission event.  However, the href element cannot be properly used
-        // until the "Primary CCS URL" property is split into "Primary CCS BaseURL" and "Primary CCS ContestID Path" elements.  
+        // until the "Primary CCS URL" property is split into "Primary CCS BaseURL" and "Primary CCS ContestID Path" elements.
         // Until that update is made throughout the code, the following block is commented out and we're using a default URL
         // created by calling the RemoteContestAPIAdapter with just the submissionID; the RemoteContestAPIAdapter constructs the
         // default URL by appending "/submissions/<submissionID>/files" to the current value of "Primary CCS URL" and then
         // fetches the submission files from that URL.
         // See also the comment in interface IRemoteContestAPIAdapter; the additional (commented-out) method there must be uncommented
         // for the following block of code to work.
-    
+
     //                                            //define the path to where the remote zip file containing the submissions files can be found
     //                                            String defaultSubmissionFilesURLString = "/submissions/" + runSubmission.getId() + "/files"; //our default path
     //                                            String submissionFilesURLString = null;  //this one we hope to pull out of the submission event, below
-    //                                            
-    //                                            
-    //                                            //Note about the next set of code: the CLICS ContestAPI spec says that a submission event has numerous fields, 
+    //
+    //
+    //                                            //Note about the next set of code: the CLICS ContestAPI spec says that a submission event has numerous fields,
     //                                            // one of which is "files".  The value found in the "files" element is specified as an ARRAY of "zip file references",
     //                                            // where each "zip file reference" has the form  {href:path/to/zip,mime:application/zip}.  Thus there
     //                                            // can in principle be multiple zip files on the remote system, with each zip file containing multiple files.
@@ -363,16 +398,16 @@ public class RemoteEventFeedMonitor implements Runnable {
     //                                            // so what we do is fetch the array (as a List, where each list element is one "zip file reference" (consisting of
     //                                            // two parts:  href:path and mime:zip)), then pull the first element out of the array (List), pull the href
     //                                            // out of that Map, and use that to form the URL to fetch the zip file containing the submission files.  *whew*
-    //                          
+    //
     //                                            //get from the ShadowRunSubmission object the list of references to zip files.
     //                                            List<Map<String, String>> filesList = runSubmission.getFiles();
-    //                                            
+    //
     //                                            //make sure we got a valid list from the submission
     //                                            if (filesList.size() >= 1){
-    //                                                
+    //
     //                                                //get out of the list the first zip file reference (which is a map containing "href:path" and "mime:zip" elements)
     //                                                Map<String, String> zipFileReferenceMap = filesList.get(0);
-    //                                                
+    //
     //                                                //make sure we got a valid zip file reference map (the map should contain exactly "href" and "mime" keys)
     //                                                if (zipFileReferenceMap.size() == 2){
     //                                                    String filesPath = zipFileReferenceMap.get("href");
@@ -406,47 +441,47 @@ public class RemoteEventFeedMonitor implements Runnable {
     //                                            } else {
     //                                                System.out.println("debug 22 getRemoteSubmissionFiles GOT "+files.size()+" files");
     //                                            }
-    
+
                                                 //this block is a temporary substitute for the above commented-out block
                                                 List<IFile> files = null;
-                                                
+
                                                 logAndDebugPrint(log, Level.INFO, "Fetching files from remote system using id "+overrideSubmissionID);
-                                                
+
                                                 //try up to maxTries times to get files without having a SocketTimeout
                                                 int tryNum = 1;
                                                 int maxTries = 10;
                                                 boolean success = false ;
                                                 Exception ex = null;
-                                                
+
                                                 while (!success && tryNum<=maxTries) {
-                                                    try {              
+                                                    try {
                                                         //request files from remote CCS
                                                         files = remoteContestAPIAdapter.getRemoteSubmissionFiles("" + overrideSubmissionID);
-                                                        
+
                                                         //if we get here, no exception was thrown while getting the files
                                                         success = true;
-    
+
                                                     } catch (Exception e) {
-                                                        
+
                                                         //we got an exception attempting to get the files for the submission from the remote CCS;
                                                         //see if the underlying cause of the exception was a socket timeout
                                                         Throwable cause = e.getCause();
                                                         if (cause!=null && cause instanceof SocketTimeoutException) {
-    
+
                                                                 logAndDebugPrint(log, Level.WARNING, "SocketTimeoutException getting files for submission " +
                                                                         overrideSubmissionID + " on try " + tryNum + "; trying up to " + maxTries + " times");
                                                                 tryNum++;
-                                                                
+
                                                                 //save the exception so we can rethrow it if we never get "success"
                                                                 ex = e;
-                                                            
+
                                                         } else {
                                                             //we got an exception other than a socket timeout; rethrow it outward (which will be logged in the catch clause)
                                                             throw e;
                                                         }
                                                     }
                                                 }
-                                                
+
                                                 //if after maxTries we still weren't successful getting files, log it and rethrow the last exception
                                                 if (!success) {
                                                     logAndDebugPrint(log, Level.SEVERE, "Unable to get files for submission " + overrideSubmissionID
@@ -454,71 +489,81 @@ public class RemoteEventFeedMonitor implements Runnable {
                                                     throw ex;
                                                 } else {
                                                     //we got files from the remote CCS; log how many tries it took
-                                                    String pluralizer = tryNum==1 ? " try." : " tries."; 
-                                                    logAndDebugPrint(log, Level.INFO, "Got files for submission id " + overrideSubmissionID + " from remote CCS after " 
+                                                    String pluralizer = tryNum==1 ? " try." : " tries.";
+                                                    logAndDebugPrint(log, Level.INFO, "Got files for submission id " + overrideSubmissionID + " from remote CCS after "
                                                             + tryNum + pluralizer);
                                                 }
-                                                
+
                                                 //if we get here we at least know we got a "success" from the above communication with the remote CCS
                                                 if (files==null) {
                                                     logAndDebugPrint(log, Level.SEVERE, "Null file list returned from remote system while processing event: " + event);
                                                     throw new Exception("Null file list returned from remote system while processing event: " + event);
                                                 }
-                                                
+
                                                 IFile mainFile = null;
-    
+
                                                 if (files.size() <= 0) {
-                                                    
+
                                                     logAndDebugPrint(log, Level.SEVERE, "Empty file list returned from remote system while processing event: " + event);
                                                     throw new Exception("Empty file list returned from remote system while processing event: " + event);
-                                                    
+
                                                 } else {
-                                                    
+
                                                     logAndDebugPrint(log, Level.INFO, "Received files from remote system for id " + overrideSubmissionID);
-    
+
                                                     mainFile = files.get(0);
                                                 }
-    
+
                                                 List<IFile> auxFiles = null;
                                                 if (files.size() > 1) {
                                                     auxFiles = files.subList(1, files.size());
                                                 }
-    
-                                                logAndDebugPrint(log, Level.INFO, "Invoking submitter.submitRun() for team " + runSubmission.getTeam_id() 
-                                                    + " problem " + runSubmission.getProblem_id() 
+
+                                                logAndDebugPrint(log, Level.INFO, "Invoking submitter.submitRun() for team " + runSubmission.getTeam_id()
+                                                    + " problem " + runSubmission.getProblem_id()
                                                     + " language " +  runSubmission.getLanguage_id()
                                                     + " entry_point " + runSubmission.getEntry_point()
-                                                    + " time " + overrideTimeMS 
+                                                    + " time " + overrideTimeMS
                                                     + " submissionID " + overrideSubmissionID);
                                                 try {
                                                     submitter.submitRun(runSubmission.getTeam_id(), runSubmission.getProblem_id(), runSubmission.getLanguage_id(),
                                                             runSubmission.getEntry_point(), mainFile, auxFiles, overrideTimeMS, overrideSubmissionID);
                                                 } catch (Exception e) {
-                                                    
+
                                                     // Send message, message will add to connectStatusTable
                                                     MessageManager.fireMessageListener(new MessageRecord("Unable to submit run " + overrideSubmissionID + " " + e.getMessage(), MessageScope.SHADOW_UI, e));
-                                                    
+
                                                     // TODO design error handling reporting
                                                     logAndDebugPrint(log, Level.WARNING, "Exception submitting run for event: " + event, e);
                                                 }
                                             }
-    
+
                                         } catch (Exception e) {
-                                            
+
                                             // Send message, message will add to connectStatusTable
                                             MessageManager.fireMessageListener(new MessageRecord("Exception processing event: " + event, MessageScope.SHADOW_UI, e));
-                                            
+
                                             // TODO design error handling reporting (logging?)
                                             logAndDebugPrint(log, Level.WARNING, "Exception processing event: " + event, e);
                                         }
-    
+
                                     } else if ("judgements".equals(eventType)) {
-                                        
+
+                                        if(!allowSubmitsAndJudgments) {
+                                             log.info("Skipping judgment event since the contest has not started and allowPrestartActivity is false.");
+                                            event = reader.readLine();
+                                            tossedMessages++;
+                                            if(monitorStatus != null) {
+                                                monitorStatus.updateShadowNumberofTossedRecords(tossedMessages);
+                                            }
+                                            continue;
+                                        }
+
                                         // Delay on judgments
                                         bDelay = true;
-                                    
+
                                         logAndDebugPrint(log, Level.INFO, "Found event of type " + eventType + ": " + event);
-    
+
                                         //process a judgment event
                                         try {
                                             if(isDeleteOperation(eventMap)) {
@@ -530,64 +575,150 @@ public class RemoteEventFeedMonitor implements Runnable {
                                                 // (there might not be such an element; "create" operations do not always have a judgment)
                                                 // get a map of the data elements for the judgment
                                                 Map<String, Object> judgementEventDataMap = (Map<String, Object>) eventMap.get("data");
-                                                
+
                                                 String judgement = (String) judgementEventDataMap.get("judgement_type_id");
                                                 if (judgement != null && !judgement.equals("")) {
-    
-    
+
+
                                                     // there is a judgement; get the relevant IDs
                                                     String judgementID = (String) judgementEventDataMap.get("id");
                                                     String submissionID = (String) judgementEventDataMap.get("submission_id");
-    
+
                                                     //check if the submission for this judgement is to be ignored due to filtering
                                                     // (submissionFilterIDsList is a list of submissions we WANT TO KEEP; typically used for debugging...)
                                                    if (respectSubmissionFilter && !submissionFilterIDsList.contains(submissionID)) {
-                                                        
-                                                       logAndDebugPrint(log, Level.INFO, "Ignoring judgement " + judgementID + 
+
+                                                       logAndDebugPrint(log, Level.INFO, "Ignoring judgement " + judgementID +
                                                                " for submission " + submissionID + " due to filter");
                                                         event = reader.readLine();
                                                         continue;
                                                     }
-                                                       
-                                                       //TODO: make sure this is a judgement for a submission we know about.  
-                                                       //  Question: isn't it possible the remote system will send us a "judgement" before it sends us 
+
+                                                       //TODO: make sure this is a judgement for a submission we know about.
+                                                       //  Question: isn't it possible the remote system will send us a "judgement" before it sends us
                                                        //  the "submission" associated with that judgement?  It seems that this is both allowed by the CLICS
                                                        //  specification, and in fact does happen (e.g. in Kattis) when it sends "judgements" at the beginning
                                                        //  of the event stream which specify a "create" op and have "null" for values such as "judgement_type_id".
-             
+
                                                     // this (appears to be) a judgement we want; save it in the global judgements map under a key of
                                                     // the judgement ID with value "submissionID:judgement"
-    //                                                System.out.println ("Adding judgement " + judgementID + " for submission " + submissionID + " with judgement " + judgement + " to RemoteJudgements Map");                                                
+    //                                                System.out.println ("Adding judgement " + judgementID + " for submission " + submissionID + " with judgement " + judgement + " to RemoteJudgements Map");
                                                     synchronized (remoteJudgementsMapLock) {
                                                         getRemoteJudgementsMap().put(judgementID, submissionID + ":" + judgement);
                                                     }
                                                 }
                                             }
-    
+
                                         } catch (Exception e) {
                                             // TODO design error handling reporting (logging?)
-                                            logAndDebugPrint(log, Level.SEVERE, "Exception processing event: " + event, e); 
+                                            logAndDebugPrint(log, Level.SEVERE, "Exception processing event: " + event, e);
                                         }
-    
+
+                                    } else if ("state".equals(eventType)) {
+
+                                        // State messages look like this (Sample from DOMjudge Event feed Dhaka WF 2022):
+                                        // {"token":"151701","id":null,"type":"state",
+                                        //  "data":{"started":"2022-11-10T10:53:36.000+06:00","ended":null,"frozen":null,"thawed":null,"finalized":null,"end_of_updates":null},"time":"2022-11-10T10:53:36.014+06:00"}
+                                        // {"token":"229483","id":null,"type":"state",
+                                        //  "data":{"started":"2022-11-10T10:53:36.000+06:00","ended":null,"frozen":"2022-11-10T14:53:36.000+06:00","thawed":null,"finalized":null,"end_of_updates":null},"time":"2022-11-10T14:53:36.112+06:00"}
+                                        // {"token":"257177","id":null,"type":"state",
+                                        //  "data":{"started":"2022-11-10T10:53:36.000+06:00","ended":"2022-11-10T15:53:36.000+06:00","frozen":"2022-11-10T14:53:36.000+06:00","thawed":null,"finalized":null,"end_of_updates":null},"time":"2022-11-10T15:53:36.035+06:00"}
+
+                                        try {
+                                            logAndDebugPrint(log, Level.INFO, "Found event of type " + eventType + ": " + event);
+
+                                            // Can set this to indicate we want to put a message in the GUI log
+                                            String statusMessage = null;
+
+                                            //convert state data into a ShadowRunSubmission object
+                                            ShadowStateMessage contestState = createStateMessage((Map<String, Object>) eventMap.get("data"));
+
+                                            Date remoteStart = contestState.getStarted();
+
+                                            // if startTime is null, we are uninterested in this event.
+                                            if(remoteStart != null) {
+                                                // only interested if remote hasn't already started
+                                                if(!remoteCCSStarted) {
+                                                    Calendar calStart = pc2Controller.getContest().getContestInformation().getScheduledStartTime();
+                                                    if(calStart != null) {
+                                                        Date pc2Start = calStart.getTime();
+                                                        if(pc2Start != null) {
+                                                            if(remoteStart.compareTo(pc2Start) != 0) {
+                                                                statusMessage ="Primary specified wrong start time " +
+                                                                        DateFormat.getDateInstance().format(remoteStart) +
+                                                                        " instead of configured " +
+                                                                        DateFormat.getDateInstance().format(pc2Start);
+                                                                logAndDebugPrint(log, Level.WARNING, statusMessage);
+                                                            }
+                                                        }
+                                                    }
+                                                    // if the contest has never been started, then we are allowed to start. If the contest
+                                                    // has previously been started remotely, or from a previous invocation, we ignore the CCS
+                                                    // state change.
+                                                    if(pc2Controller.getContest().getContestTime().getContestStartTime() == null) {
+                                                        // contest never started, but remote says it's go time.  If the contest was already started
+                                                        // manually, we ignore it.
+                                                        remoteCCSStarted = true;
+                                                        statusMessage = "Primary started the contest at " + DateFormat.getDateInstance().format(remoteStart);
+                                                        logAndDebugPrint(log, Level.INFO, statusMessage);
+                                                        pc2Controller.startAllContestTimes();
+                                                    }
+                                                }
+                                                // If anything related to the startTime decided it wants a status message in the GUI, here is where it comes out
+                                                if(statusMessage != null && monitorStatus != null) {
+                                                    monitorStatus.statusMessage(statusMessage);
+                                                }
+                                                statusMessage = null;
+
+                                                // Now check for end of contest from remote
+                                                Date remoteEnd = contestState.getEnded();
+
+                                                if(remoteEnd != null) {
+                                                    // Only interested if we haven't seen "ended" yet from primary ccs.
+                                                    if(!remoteCCSEnded) {
+                                                        remoteCCSEnded = true;
+                                                         // can only stop contest if it is running now
+                                                        if(pc2Controller.getContest().getContestTime().isContestRunning()) {
+                                                            statusMessage = "Primary ends the contest at " +
+                                                                DateFormat.getDateInstance().format(remoteEnd);
+                                                            pc2Controller.stopAllContestTimes();
+                                                        } else {
+                                                            statusMessage = "Primary wants to end the contest but it's stopped";
+                                                        }
+                                                    }
+                                                }
+                                                // If anything related to the endTime decided it wants a status message in the GUI, here is where it comes out
+                                                if(statusMessage != null && monitorStatus != null) {
+                                                    logAndDebugPrint(log, Level.INFO, statusMessage);
+                                                    monitorStatus.statusMessage(statusMessage);
+                                                }
+
+                                                // we do not really care about these state changes (yet), but, we like to know things.
+                                                remoteCCSFrozen = generalStateCheck(contestState.getFrozen(), remoteCCSFrozen, "Frozen");
+                                                remoteCCSThawed = generalStateCheck(contestState.getThawed(), remoteCCSThawed, "Thawed");
+                                                remoteCCSFinalized = generalStateCheck(contestState.getFinalized(), remoteCCSFinalized, "Finalized");
+                                            } else {
+                                                logAndDebugPrint(log, Level.INFO, "Ignored state event with null start time");
+                                            }
+                                        } catch (Exception e) {
+                                        }
                                     } else {
-    
-                                        logAndDebugPrint(log, Level.INFO, "Ignoring " + eventType + " event"); 
+                                        logAndDebugPrint(log, Level.INFO, "Ignoring " + eventType + " event");
                                     }
-    
-                                } // else
+                                }
                             } catch (Exception e) {
                                 // TODO design error handling reporting (logging?)
-                                logAndDebugPrint(log, Level.SEVERE, "Exception processing event: " + event, e); 
-                            } 
+                                logAndDebugPrint(log, Level.SEVERE, "Exception processing event: " + event, e);
+                            }
                         } else {
-                            
+
                             //we're skipping an event feed input line -- log the reason
                             if (event.length()<=0) {
                                 log.log(Level.INFO, "Skipping event feed input line (length is " + event.length() + ")");
                             } else if (!event.trim().startsWith("{")) {
                                 log.log(Level.INFO, "Skipping event feed input line (does not start with \"{\"): " + event.toString());
                             } else if (!event.trim().endsWith("}")) {
-                                log.log(Level.INFO, "Skipping event feed input line (does not end with \"}\"): " + event.toString());                            
+                                log.log(Level.INFO, "Skipping event feed input line (does not end with \"}\"): " + event.toString());
                             } else {
                                 log.log(Level.WARNING, "Skipping event feed input line (sorry - no explanation for why): " + event.toString());
                             }
@@ -598,12 +729,12 @@ public class RemoteEventFeedMonitor implements Runnable {
                         if(monitorStatus != null) {
                             monitorStatus.updateShadowNumberofRecords(nRecords);
                         }
-                        
+
                         if(bDelay) {
                             Thread.sleep(REMOTE_EVENT_FEED_DELAYMS);
                         }
                         event = reader.readLine();
-    
+
                     } // while
                 } catch (IOException ioe) {
                     if(lastToken != null) {
@@ -618,10 +749,10 @@ public class RemoteEventFeedMonitor implements Runnable {
                     }
                 } catch (Exception e) {
                     // TODO design error handling reporting (logging?)
-                    logAndDebugPrint(log, Level.SEVERE, "Exception reading event from stream: " + event, e); 
+                    logAndDebugPrint(log, Level.SEVERE, "Exception reading event from stream: " + event, e);
                 }
             } // end else
-            
+
             // In all cases of a connection disconnect or exception or other failure, we want
             // to see if connect retries are indicated, and if so, then pause a bit and retry, otherwise
             // we break out and give up.  We have to delay here if we are retrying or we'll just go into
@@ -643,30 +774,30 @@ public class RemoteEventFeedMonitor implements Runnable {
             }
         } // keepRunning
     }
-    
-    
+
+
     /**
      * Returns an indication of whether the current client is a "read-only shadow" client.
-     * 
+     *
      * Currently, account "feeder1" is allowed to be a read-write Shadow (meaning, it has the ability
      * to actually submit runs to the PC2 server when they are received from the Remote CCS); all
      * other accounts are considered "read-only" -- meaning they can look at submissions,
      * the scoreboards, etc. but they will not actually submit runs received from the Remote CCS to
      * the PC2 server.
-     * 
+     *
      * TODO: extend this function to allow a broader definition and control of when a client
      *      is considered "read-only"; for example, managing this by Permissions and/or via
      *      Admin settings.  See https://github.com/pc2ccs/pc2v9/issues/240.
-     * 
+     *
      * @return true if the current client is a "read-only Shadow" client; false if the client
      *          is allowed to do read-write operations (such as submitting a run from the Remote CCS
      *          to the PC2 server).
      */
     private boolean isReadOnlyClient() {
-        ClientId clientId = pc2Controller.getContest().getClientId(); 
+        ClientId clientId = pc2Controller.getContest().getClientId();
         ClientType.Type clientType = clientId.getClientType();
         int clientNum = clientId.getClientNumber();
-        
+
         if (clientType.equals(Type.FEEDER) && clientNum==1) {
             //client is Feeder1; it is NOT a "read-only" client
             return false;
@@ -679,13 +810,13 @@ public class RemoteEventFeedMonitor implements Runnable {
     /**
      * Initializes the Map<String,String> which holds mappings of judgement id's to corresponding submissions and judgement
      * types (acronymns).
-     * 
+     *
      * The keys to the map are Strings containing the numerical value of a judgement id as received from the remote CCS;
      * the values under each key are the concatenation of the submission id corresponding to the judgement with the
      * judgement type id (i.e., the judgement acronym), separated by a colon (":").
-     * 
+     *
      * Note that this method is PRIVATE; external clients wanting access to the remoteJudgementsMap should use method {@link #getRemoteJudgementsMapSnapshot()}.
-     * 
+     *
      * @return a Mapping of judgement id's to the corresponding submission and judgement type (value).
      *              If no remote judgements have yet been received the returned Map will be empty (but not null).
      */
@@ -698,32 +829,32 @@ public class RemoteEventFeedMonitor implements Runnable {
         }
     }
 
- 
+
     /**
-     * Returns a snapshot of the current contents of the Map<String,String> which holds mappings of judgement id's to corresponding 
+     * Returns a snapshot of the current contents of the Map<String,String> which holds mappings of judgement id's to corresponding
      * submissions and judgement types (acronymns).
-     * 
+     *
      * The keys to the map are Strings containing the numerical value of a judgement id as received from the remote CCS;
      * the values under each key are the concatenation of the submission id corresponding to the judgement with the
      * judgement type id (i.e., the judgement acronym), separated by a colon (":").
-     * 
-     * Note that this method returns a <I>copy</i> which is a <I>snapshot</i>; there is no guarantee that the map will not subsequently be 
-     * changed by other threads. However, the method does provide internal synchronization to insure that the map is not simultaneously 
+     *
+     * Note that this method returns a <I>copy</i> which is a <I>snapshot</i>; there is no guarantee that the map will not subsequently be
+     * changed by other threads. However, the method does provide internal synchronization to insure that the map is not simultaneously
      * altered while the snapshot is being created.
-     * 
+     *
      * @return a snapshot copy of the current Mapping of judgement id's to the corresponding submission and judgement type (value).
      *              If no remote judgements have yet been received the returned Map will be empty (but not null).
      */
     public static Map<String,String> getRemoteJudgementsMapSnapshot() {
-        
+
         synchronized (remoteJudgementsMapLock) {
             Map<String, String> currentMap = getRemoteJudgementsMap();
-            
+
             Map<String, String> copy = new HashMap<String,String>();
             for (String key : currentMap.keySet()) {
                 copy.put(key, currentMap.get(key));
             }
-           
+
             return copy;
         }
     }
@@ -733,18 +864,18 @@ public class RemoteEventFeedMonitor implements Runnable {
      * This method uses the Jackson {@link ObjectMapper} to perform the conversion from the JSON
      * string to a Map.  Note that the ObjectMapper recurses for nested JSON elements, returning
      * a appropriate Object in the Map under the corresponding key string.
-     * 
+     *
      * @param jsonString a JSON string to be converted to a Map
      * @return a Map mapping the keys in the JSON string to corresponding values, or null if the input
      *          String is null or if an exception occurs while converting the JSON to a Map.
      */
     @SuppressWarnings("unchecked")
     protected static Map<String, Object> getMap(String jsonString) {
-        
+
         if (jsonString == null){
             return null;
         }
-        
+
         ObjectMapper mapper = new ObjectMapper();
         try {
             Map<String, Object> map = mapper.readValue(jsonString, Map.class);
@@ -756,7 +887,7 @@ public class RemoteEventFeedMonitor implements Runnable {
     }
 
     ShadowRunSubmission createRunSubmission2(String jsonString){
-        
+
         Map<String, Object> map = getMap(jsonString);
         if (map == null) {
             // could not parse.
@@ -786,22 +917,22 @@ public class RemoteEventFeedMonitor implements Runnable {
 
     /**
      * Return if an event is a delete operation
-     * 
+     *
      * For older event feed events, the "op" property will be checked for existence
      * and if it's a "delete".
      * For newer event feed (2022-07), there is no "op", but if the "data" object
      * is null, then it's a delete.
-     * 
+     *
      * @param eventMap map of all properties in the event
      * @return true if this is the event map passed in specifies a delete operation
-     */  
+     */
     private boolean isDeleteOperation(Map<String, Object> eventMap)
     {
         boolean bDelete = false;
-        
+
         // "op" property, if it's there - old feed format uses this
         String operation = (String) eventMap.get("op");
-        
+
         if(operation != null) {
             // Old feed
             if(operation.equals("delete")) {
@@ -812,26 +943,26 @@ public class RemoteEventFeedMonitor implements Runnable {
         }
         return(bDelete);
     }
-    
+
     /** Delete the judgment specified by the supplied eventMap properties
-     * 
+     *
      * For older event feed events, the "op" property will be checked for existence
      * and if it's a "delete", we use the eventDataMap's "id" property.
      * For newer event feed (2022-07), there is no "op", and no "data" object
      * but the "id" is in the eventMap.
-     * 
+     *
      * @param eventMap map of all properties in the event
      * @return true if this is the event map passed in specifies a delete operation
-     */  
+     */
     private boolean deleteJudgment(Map<String, Object> eventMap)
     {
         String operation = (String) eventMap.get("op");
         String idToDelete = null;
         boolean bDeleted = false;
-        
+
         // Determine feed version, and where to get the judgement id.
         // For the 2022-07 (and 2021-11) clics spec, "operation" will always be null since the "op" field was removed
-        // For the 2020-03 the "op" field will be non-null.  This is how we determine the feed type.                                        
+        // For the 2020-03 the "op" field will be non-null.  This is how we determine the feed type.
        if (operation == null) {
            // 2022-07 (newer) feed - the ID of the judgment is in the notification object since there is
            // no data object.
@@ -839,7 +970,7 @@ public class RemoteEventFeedMonitor implements Runnable {
        } else if(operation.equals("delete")) {
            // 2020-03 feed, "op" field present and is an explicit delete, judgment id is in "data" object
            Map<String, Object> judgmentEventDataMap = (Map<String, Object>) eventMap.get("data");
-           
+
            if(judgmentEventDataMap != null) {
                idToDelete = (String) judgmentEventDataMap.get("id");
            }
@@ -863,109 +994,159 @@ public class RemoteEventFeedMonitor implements Runnable {
         return mapper.convertValue(eventDataMap, ShadowRunSubmission.class);
     }
 
-    
+    protected static ShadowStateMessage createStateMessage(Map<String, Object> eventDataMap) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false);
+        return mapper.convertValue(eventDataMap, ShadowStateMessage.class);
+    }
+
+
     /**
      * Set lastToken starting point for next open of remote feed
-     * 
-     * 
+     *
+     *
      * @param token where to start reading remote feed from
-     */  
+     */
     public void setStartAfterToken(String token) {
         lastToken = token;
     }
 
-    
+
     /**
      * Get lastToken starting point for next open of remote feed
-     * 
-     * 
+     *
+     *
      * @return token of last processed event
-     */  
+     */
     public String getStartAfterToken() {
         return(lastToken);
     }
 
-    
+
     /**
      * Get the number of records read from remote.  This is NOT the number of
      * events processed.  This includes events we do not care about.
-     * 
-     * 
+     *
+     *
      * @return number of records read
-     */  
+     */
     public int getRecordsRead() {
         return(nRecords);
     }
 
-    
+
     /**
      * Set the delay of how long to wait between reconnect attempts
      * to the primary
-     * 
+     *
      * @param delay how long to wait (in ms) between connect attempts to primary
-     */  
+     */
     public void setRetryConnectDelay(int delay) {
         retryConnectDelay = delay;
     }
 
-    
+
     /**
      * Get the delay of how long to wait between reconnect attempts
      * to the primary
-     * 
+     *
      * @return number of ms to delay before a reconnect attempt (0 is allowed)
-     */  
+     */
     public int getRetryConnectDelay() {
         return(retryConnectDelay);
     }
 
-    
+
     /**
      * Set whether or not connection retries are being attempted
-     * 
-     * 
+     *
+     *
      * @param attemptRetries is true to attempt retries on connection failures
-     */  
+     */
     public void setAttemptConnectRetries(boolean attemptRetries) {
         attemptConnectRetries = attemptRetries;
     }
 
-    
+
     /**
      * Get whether or not connection retries are being attempted
-     * 
-     * 
+     *
+     *
      * @return true if attempts are being attempted on errors
-     */  
+     */
     public boolean getAttemptConnectRetries() {
         return(attemptConnectRetries);
     }
-       
-    
+
+    /**
+     * Set whether or not we accept submissions/judgments from primary
+     * prior to contest start.
+     *
+     * @param allowPrecontestActivity is true to allow precontest submissions and judgments
+     */
+    public void setAllowPrecontestActivity(boolean allowPrecontestActivity) {
+        this.allowPrestartActivity = allowPrecontestActivity;
+    }
+
+
+    /**
+     * Get whether or not we accept submissions/judgments from primary
+     * prior to contest start.
+     *
+     * @return true if we allow precontest submissions/judgments
+     */
+    public boolean getAllowPrecontestActivity() {
+        return(this.allowPrestartActivity);
+    }
+
+    /**
+     * Check a for a state change of the provided state string
+     *
+     * @param when indicating when this state changed
+     * @param currentPrimaryState whether or not we saw the state change from the primary yet
+     * @param what is the property
+     * @return the possibly new state if it's the first time we saw this
+     */
+    private boolean generalStateCheck(Date when, boolean currentPrimaryState, String what)
+    {
+        if(when != null) {
+            if(currentPrimaryState == false) {
+                currentPrimaryState = true;
+                String statusMessage = "Primary indicates state '" + what + "' at " +
+                        DateFormat.getDateInstance().format(when);
+                logAndDebugPrint(pc2Controller.getLog(), Level.INFO, statusMessage);
+                if(monitorStatus != null) {
+                    monitorStatus.statusMessage(statusMessage);
+                }
+            }
+        }
+        return(currentPrimaryState);
+    }
+
     /** Shorthand method to print a message if debugging is enable, but always
      * log the message
-     * 
+     *
      * @param logger where to log the message
      * @param lLev logging level
      * @param msg string to print/log
-     * @return 
-     */  
+     * @return
+     */
     private void logAndDebugPrint(Log logger, Level lLev, String msg) {
         if (Utilities.isDebugMode()) {
             System.err.println(msg);
         }
         logger.log(lLev, msg);
     }
-    
+
      /** Shorthand method to print a message and exception if debugging is enable, but always
       * log the message
-      * 
+      *
       * @param logger where to log the message
       * @param lLev logging level
       * @param msg string to print/log
       * @param thrown an exception that was thrown that should be printed
-      * @return 
-      */  
+      * @return
+      */
      private void logAndDebugPrint(Log logger, Level lLev, String msg, Throwable thrown) {
          if (Utilities.isDebugMode()) {
              System.err.println(msg + thrown.toString());
@@ -973,8 +1154,24 @@ public class RemoteEventFeedMonitor implements Runnable {
          }
          logger.log(lLev, msg, thrown);
      }
-    
-   
+
+     /*
+      * Convert an iso time to a date.  Returns null if it's a bad time.
+      *
+      * @param isoTime The time to convert
+      * @return Date representing the isoTime or null if it's bad.
+      */
+     public Date parseISO8601Date(String isoTime) {
+         Date dateRet = null;
+
+         try {
+             dateRet = DatatypeConverter.parseDateTime(isoTime).getTime();
+         } catch(Exception e) {
+             logAndDebugPrint(pc2Controller.getLog(), Level.WARNING, "Invalid ISO Date: " + isoTime, e);
+         }
+         return dateRet;
+     }
+
     /**
      * This method is used to terminate the RemoteEventFeedListener thread.
      */

--- a/src/edu/csus/ecs/pc2/shadow/ShadowStateMessage.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowStateMessage.java
@@ -1,0 +1,46 @@
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.shadow;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Contest State change from a remote CCS via the REST event-feed API.
+ *
+ * @author John Buck, PC^2 Team, pc2@ecs.csus.edu
+ */
+public class ShadowStateMessage {
+
+    @JsonProperty
+    private Date started;
+    @JsonProperty
+    private Date ended;
+    @JsonProperty
+    private Date frozen;
+    @JsonProperty
+    private Date thawed;
+    @JsonProperty
+    private Date finalized;
+    @JsonProperty
+    private Date end_of_updates;
+
+    public Date getStarted() {
+        return started;
+    }
+    public Date getEnded() {
+        return ended;
+    }
+    public Date getFrozen() {
+        return frozen;
+    }
+    public Date getThawed() {
+        return thawed;
+    }
+    public Date getFinalized() {
+        return finalized;
+    }
+    public Date getEndOfUpdates( ) {
+        return end_of_updates;
+    }
+}

--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -63,28 +63,28 @@ import edu.csus.ecs.pc2.shadow.ShadowController.SHADOW_CONTROLLER_STATUS;
 
 /**
  * This class provides a GUI for configuring and starting Shadowing operations on a remote CCS.
- * 
- * The remote CCS must support the <A href="https://clics.ecs.baylor.edu/index.php?title=Contest_API">CLICS Contest API</a>. 
- * 
- * This class is a {@link JPanePlugin} which allows specifying the remote CCS URL/login/password, 
+ *
+ * The remote CCS must support the <A href="https://clics.ecs.baylor.edu/index.php?title=Contest_API">CLICS Contest API</a>.
+ *
+ * This class is a {@link JPanePlugin} which allows specifying the remote CCS URL/login/password,
  * along with "last event id" (that is, the value for the "since_id" parameter on the CLICS event-feed endpoint).
- * 
+ *
  * @author John Clevenger, PC2 Development Team, pc2@ecs.csus.edu
  */
 
 public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStatus {
 
     private static final long serialVersionUID = 1;
-    
+
     private static final int VERT_PAD = 2;
     private static final int HORZ_PAD = 20;
-    
+
     private static final String CCS_API_ENDPOINT = "/";
 
     private JPanel buttonPanel = null;
 
     private JButton startStopButton = null;
-    
+
     private JButton testConnectionButton;
 
     private JPanel centerPanel = null;
@@ -100,58 +100,69 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private JPanel lastEventIDPane;
 
     private JPanel shadowingOnOffStatusPane;
-    
+
     private JScrollPane connectStatusPane;
 
     private JLabel shadowingStatusValueLabel;
 
     private JTextField lastEventTextfield;
-    
+
     private ContestInformation savedContestInformation;
-    
+
     private JButton compareRunsButton;
 
     private JButton compareScoreboardsButton;
 
     private JTextField lastRecordTextfield;
-    
+
+    private JTextField lastTossedRecordTextfield;
+
     private JTextField lastEventTimeTextField;
-    
+
     private JTableCustomized connectStatusTable;
-    
+
     private DefaultTableModel connectStatusTableModel;
-    
+
     private int statusScrollBarMax = 0;
-    
+
     private int numRecord = 0;
-    
+    private int numTossedRecord = 0;
+
     private String lastToken = null;
-    
+
     private SimpleDateFormat lastDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    
+
     // Lightish green for success
     private Color statusColorSuccess = new Color(128, 255, 128);
     // Lightish red for failure
     private Color statusColorFailure = new Color(255, 128, 128);
+    // Lightish cyan for status messages
+    private Color statusColorStatus = new Color(128, 255, 255);
+
+    private static final String notStartedMessage = "<html>The contest has not started yet." +
+            "<p><p>It will not be started until a valid " +
+            "CLICS <b><i>state</i></b> message with a non-null <b>started</b> property is received." +
+            "<p><p>Do you wish to continue and start shadowing anyway?</html>";
 
     // Status column for JTable notifications
     enum ShadowStatus {
         SUCCESS,
         FAILURE,
-        INFO
+        INFO,
+        STATUS
     };
 
     /**
      * Constructs a new ShadowControlPane using the specified Contest and Controller.
-     * 
+     *
      * This constructor invokes the superclass ({@link JPanePlugin}) method
      * {@link JPanePlugin#setContestAndController(IInternalContest, IInternalController)} passing to it
      * the received {@link IInternalContest} and {@link IInternalController}, making it unnecessary for
      * the caller to explicitly invoke that method.
-     * 
+     *
      * @param inContest the PC2 IInternalContest representing the local contest acting as the shadow
      * @param inController the PC2 IInternalController for the local contest acting as the shadow
-     * 
+     *
      */
     public ShadowControlPane(IInternalContest inContest, IInternalController inController) {
         super();
@@ -162,7 +173,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
     /**
      * This method initializes the ShadowControlPane.
-     * 
+     *
      */
     private void initialize() {
         this.setLayout(new BorderLayout());
@@ -195,7 +206,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
     /**
      * This method initializes the Button Panel containing the Start and Stop buttons
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getButtonPanel() {
@@ -224,6 +235,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             updateButton.setMnemonic(KeyEvent.VK_S);
             updateButton.setToolTipText("Save the updated Remote CCS settings");
             updateButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
 //                    System.out.println("Update pressed...");
                     updateContestInformation();
@@ -237,7 +249,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     /**
      * This method initializes the startStopButton which starts or stops
      * shadowing operations.
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getStartStopButton() {
@@ -248,15 +260,20 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             startStopButton.setToolTipText("Start shadowing operations on the specified remote CCS");
             startStopButton.addActionListener(new java.awt.event.ActionListener() {
 
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (!currentlyShadowing) {
-                        
+
                         if (!getContest().getContestTime().isContestRunning()) {
-                            showErrorMessage("Contest clock STOPPED, cannot start shadowing", "Cannot start shadowing");
-                            return;
+                            // inform the user the contest is not started, and it wont be started until the
+                            // primary says so. (valid "state" message received)
+                            if(showConfirmMessage(notStartedMessage, "Notice") == JOptionPane.NO_OPTION) {
+                                return;
+                            }
                         }
 
                     	SwingUtilities.invokeLater(new Runnable() {
+                            @Override
                             public void run() {
                                 startShadowing();
                             }
@@ -264,6 +281,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
                     } else {
                         SwingUtilities.invokeLater(new Runnable() {
+                            @Override
                             public void run() {
 
                                 int result = FrameUtilities.yesNoCancelDialog(null, "Are you sure you want to stop shadowing?", "Stop Shadowing");
@@ -284,10 +302,10 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
     /**
      * Starts a Shadow Controller (a facade which manages the Shadowing system classes).
-     * 
+     *
      */
     private void startShadowing() {
- 
+
         //the following was carried over from WebServerPane (from which this class was initially copied)
 
 //        Properties properties = new Properties();
@@ -298,13 +316,13 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 //        properties.put(WebServer.FETCH_RUN_SERVICE_ENABLED_KEY, Boolean.toString(getChckbxFetchRuns().isSelected()));
 //
 //        getWebServer().startWebServer(getContest(), getController(), properties);
-        
+
 
         boolean shadowCheckboxEnabled = getShadowSettingsPane().getShadowModeCheckbox().isSelected();
         boolean shadowDataComplete = verifyShadowControls();
-        
+
         if (shadowCheckboxEnabled && shadowDataComplete) {
-            shadowController = new ShadowController(this.getContest(), this.getController(), (IShadowMonitorStatus)this, lastToken) ;
+            shadowController = new ShadowController(this.getContest(), this.getController(), this, lastToken) ;
             boolean success = shadowController.start();
             if (success) {
                 currentlyShadowing = true;
@@ -325,32 +343,32 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
     /**
      * This method is invoked when a call to ShadowController.start() returns false (failure in starting shadowing).
-     * 
+     *
      */
     private void handleStartFailure() {
-        
+
         SHADOW_CONTROLLER_STATUS failureStatus = shadowController.getStatus();
-        
+
         String failureReason = failureStatus.getLabel();
-        
+
         showErrorMessage(failureReason, "Shadow Controller Failed To Start");
-        
+
     }
 
     /**
      * Checks all the components on the ShadowModePane, returns true if they all have sane values
      * (meaning, they all have values which will work for starting shadowing); false otherwise.
-     * 
+     *
      * Specifically, this means that in order for "true" to be returned, ALL of the following must be true:
      * <pre>
      *   - the "Enable Shadow Mode" checkbox is checked (selected)
      *   - the RemoteCCS textfields for URL, Login, and Password are ALL non-null and not the empty string
      * </pre>
-     * 
+     *
      * @return an indication of whether the GUI controls are set for shadowing to start
      */
     private boolean verifyShadowControls() {
-        
+
         ShadowSettingsPane shadowPane = getShadowSettingsPane();
         if (shadowPane==null) {
             return false;
@@ -372,13 +390,14 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     }
 
     /**
-     * Displays a message in a simple dialog format.
+     * Displays a message in a simple Yes/No dialog format along with a title.
      * @param string the message to be displayed
+     * @param title for the dialog
      */
-    private void showMessage(String string) {
-        JOptionPane.showMessageDialog(this, string);
+    private int showConfirmMessage(String message, String title) {
+        return(JOptionPane.showConfirmDialog(this, message, title, JOptionPane.YES_NO_OPTION));
     }
-    
+
     /**
      * Displays an error message dialog; also logs the Error Message.
      * @param message the message to be displayed and logged.
@@ -390,7 +409,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     }
 
     /**
-     * Stops shadowing operations if running. 
+     * Stops shadowing operations if running.
      */
     protected void stopShadowing() {
 
@@ -409,13 +428,13 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
     /**
      * This method initializes centerPanel
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getCenterPanel() {
         if (centerPanel == null) {
             centerPanel = new JPanel();
-            
+
            /*
              * We use a GridBagLayout instead of a FlowLayout since we want to make
              * the notification JTable resize as the window gets bigger so you can see more
@@ -428,35 +447,35 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
              */
             centerPanel.setLayout(new GridBagLayout());
             GridBagConstraints c = new GridBagConstraints();
-            
+
             // Each pane uses exactly one cell in the layout
             c.gridwidth = 1;
             c.gridheight = 1;
             // Since it's only 1 column wide, all cells start in the first column
             c.gridx = 0;
-            
+
             c.fill = GridBagConstraints.NONE;
             c.gridy = 0;
             centerPanel.add(getShadowingOnOffStatusPane(), c);
-            
+
             c.gridy = 1;
             centerPanel.add(getShadowSettingsPane(), c);
-            
+
             // Fill horizontally or it will chop it off.
             c.fill = GridBagConstraints.HORIZONTAL;
             c.gridy = 2;
-            // This is needed due to the way the pane is created.  We have to 
+            // This is needed due to the way the pane is created.  We have to
             // allow the height to expand a tiny bit, or it chops the pane off.
             c.weighty = 0.01;
             centerPanel.add(getLastEventIDPane(), c);
-            
+
             // Fill both width and height as needed as display area expands
             c.fill = GridBagConstraints.BOTH;
             c.gridy = 3;
             c.weighty = 0.5;
             // Was bumping up against the edge, so leave some elbow room
             c.insets = new Insets(0, 20, 0, 20);
-            centerPanel.add(getConnectStatusPane(), c);          
+            centerPanel.add(getConnectStatusPane(), c);
         }
         return centerPanel;
     }
@@ -466,14 +485,15 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
      * Constructs a new {@link ShadowSettingsPane} if none exists.
      * Construction includes adding keylisteners and actionlisteners to the ShadowSettingsPane
      * components.
-     * 
+     *
      * @return a ShadowSettingsPane with listeners attached to its active components
      */
     private ShadowSettingsPane getShadowSettingsPane() {
         if (shadowSettingsPane==null) {
             shadowSettingsPane = new ShadowSettingsPane();
-            
+
             KeyListener keyListener = new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableButtons();
                 }
@@ -483,6 +503,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             shadowSettingsPane.getRemoteCCSPasswdTextfield().addKeyListener(keyListener);
 
             ActionListener actionListener = new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     enableButtons();
                 }
@@ -499,40 +520,50 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private JPanel getLastEventIDPane() {
         if (lastEventIDPane==null) {
             lastEventIDPane = new JPanel();
-            
+
             lastEventIDPane.setLayout(new FlowLayout(FlowLayout.CENTER));
-            
+
             JLabel lastEventDateLabel = new JLabel("Last Event Processed At:");
             lastEventDateLabel.setToolTipText("The time the last event was processed");
             lastEventIDPane.add(lastEventDateLabel);
-            
+
             // 2022-09-27 23:02:03.009 (23 chars), but that's too many columns for our font
-            lastEventTimeTextField = new JTextField("N/A", 16);
+            lastEventTimeTextField = new JTextField("N/A", 14);
             lastEventTimeTextField.setEditable(false);
             lastEventIDPane.add(lastEventTimeTextField);
-            
-            JLabel lastEventIDLabel = new JLabel("Last Event ID:");
-            lastEventIDLabel.setToolTipText("The ID of the last event already received; i.e., the \"since_id\" for events being requested");
+
+            JLabel lastEventIDLabel = new JLabel("Last Token:");
+            lastEventIDLabel.setToolTipText("The Token ID of the last event already received; i.e., the \"since_id\" for events being requested");
             lastEventIDPane.add(lastEventIDLabel);
-            
+
             lastEventTextfield = new JTextField(10);
             lastEventTextfield.addKeyListener(new KeyAdapter() {
+                @Override
                 public void keyReleased(KeyEvent e) {
                     enableButtons();
                 }
             });
             lastEventTextfield.setHorizontalAlignment(JTextField.RIGHT);
             lastEventIDPane.add(lastEventTextfield);
-            
+
+            JLabel lastTossedRecordLabel = new JLabel("Tossed:");
+            lastTossedRecordLabel.setToolTipText("The number of JSON event records read from the primary that were tossed since the contest was not started yet");
+            lastEventIDPane.add(lastTossedRecordLabel);
+
+            lastTossedRecordTextfield = new JTextField(5);
+            lastTossedRecordTextfield.setEditable(false);
+            lastTossedRecordTextfield.setHorizontalAlignment(JTextField.RIGHT);
+            lastEventIDPane.add(lastTossedRecordTextfield);
+
             JLabel lastRecordLabel = new JLabel("Records Read:");
             lastRecordLabel.setToolTipText("The number of JSON event records read from the primary");
             lastEventIDPane.add(lastRecordLabel);
-            
-            lastRecordTextfield = new JTextField(10);
+
+            lastRecordTextfield = new JTextField(5);
             lastRecordTextfield.setEditable(false);
             lastRecordTextfield.setHorizontalAlignment(JTextField.RIGHT);
             lastEventIDPane.add(lastRecordTextfield);
-            
+
         }
         return lastEventIDPane;
     }
@@ -546,21 +577,22 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
             // make it so it always scrolls to the bottom of the pane
             connectStatusPane.getVerticalScrollBar().addAdjustmentListener(new AdjustmentListener() {
+                @Override
                 public void adjustmentValueChanged(AdjustmentEvent e) {
                     if(statusScrollBarMax == e.getAdjustable().getMaximum()) {
                         return;
                     }
                     statusScrollBarMax = e.getAdjustable().getMaximum();
-                    e.getAdjustable().setValue(statusScrollBarMax);  
+                    e.getAdjustable().setValue(statusScrollBarMax);
                 }
             });
         }
-        
+
         return connectStatusPane;
     }
-    
+
     private JTableCustomized getConnectStatusTable() {
-    
+
         connectStatusTable = new JTableCustomized() {
             private static final long serialVersionUID = 1L;
 
@@ -572,7 +604,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
                 //default to normal background
                 c.setBackground(getBackground());
-              
+
                 if(connectStatusTableModel != null) {
                     //map the specified row index number to the corresponding model row (index numbers can change due
                     // to sorting/scrolling; model row numbers never change).
@@ -582,14 +614,15 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                         case SUCCESS: c.setBackground(statusColorSuccess); break;
                         case FAILURE: c.setBackground(statusColorFailure); break;
                         case INFO: c.setBackground(getBackground()); break;
+                        case STATUS: c.setBackground(statusColorStatus); break;
                     }
                 }
-                
-                
+
+
                 return(c);
             }
         };
-        
+
         return(connectStatusTable);
     }
 
@@ -599,19 +632,19 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private JPanel getShadowingOnOffStatusPane() {
         if (shadowingOnOffStatusPane==null) {
             shadowingOnOffStatusPane = new JPanel();
-            
+
             shadowingOnOffStatusPane.setLayout(new FlowLayout(FlowLayout.CENTER));
-            
+
             JLabel shadowingStatusLabel = new JLabel();
             shadowingStatusLabel.setFont(new Font("Dialog", Font.BOLD, 14));
             shadowingStatusLabel.setHorizontalAlignment(SwingConstants.CENTER);
             shadowingStatusLabel.setText("Shadowing is currently: ");
             shadowingOnOffStatusPane.add(shadowingStatusLabel);
-            
+
             shadowingStatusValueLabel = new JLabel();
             shadowingStatusValueLabel.setFont(new Font("Dialog", Font.BOLD, 14));
             shadowingStatusValueLabel.setHorizontalAlignment(SwingConstants.CENTER);
-            shadowingStatusValueLabel.setText("UNDEFINED");  
+            shadowingStatusValueLabel.setText("UNDEFINED");
             shadowingOnOffStatusPane.add(shadowingStatusValueLabel);
 
         }
@@ -626,8 +659,8 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         if (getCurrentShadowInformation(getContest().getContestInformation()).isSameAs(newChoice)) {
             getUpdateButton().setEnabled(false);
             getStartStopButton().setEnabled(true);
-            getTestConnectionButton().setEnabled(!currentlyShadowing);            
-            
+            getTestConnectionButton().setEnabled(!currentlyShadowing);
+
         } else {
             getUpdateButton().setEnabled(true);
             getStartStopButton().setEnabled(false);
@@ -642,7 +675,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
      * @return
      */
     private ShadowInformation getCurrentShadowInformation(ContestInformation contestInformation) {
-        
+
         ShadowInformation newShadowInfo = new ShadowInformation();
 
         newShadowInfo.setShadowModeEnabled(contestInformation.isShadowMode());
@@ -657,7 +690,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
         Object[] columns = { "Time             ", "Status", "Description               " };
         connectStatusTable.removeAll();
-        
+
         connectStatusTableModel = new DefaultTableModel(columns, 0) {
             @Override
             public boolean isCellEditable(int row, int col) {
@@ -669,18 +702,18 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
         // Sorters
         TableRowSorter<DefaultTableModel> trs = new TableRowSorter<DefaultTableModel>(connectStatusTableModel);
-        
+
         connectStatusTable.setRowSorter(trs);
         connectStatusTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-        
+
         ArrayList<SortKey> sortList = new ArrayList<SortKey>();
-        
+
         /*
          * Column headers left justified
          */
         ((DefaultTableCellRenderer)connectStatusTable.getTableHeader().getDefaultRenderer()).setHorizontalAlignment(JLabel.LEFT);
         connectStatusTable.setRowHeight(connectStatusTable.getRowHeight() + VERT_PAD);
-                     
+
         int idx = 0;
 
         // These are in sort order
@@ -691,16 +724,17 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         trs.setSortKeys(sortList);
         resizeColumnWidth(connectStatusTable);
     }
-    
+
     private void resizeColumnWidth(JTableCustomized table) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 TableColumnAdjuster tca = new TableColumnAdjuster(table, HORZ_PAD);
                 tca.adjustColumns();
             }
         });
     }
-    
+
     /**
      * Updates the GUI to correspond to the current state.
      */
@@ -709,12 +743,12 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         ContestInformation contestInformation = getContest().getContestInformation();
 
 //        System.out.println ("UpdateGUI(): got the following shadow info:");
-//        System.out.println ("   Shadow Enabled: " + contestInformation.isShadowMode() 
+//        System.out.println ("   Shadow Enabled: " + contestInformation.isShadowMode()
 //                          + "\n              URL: " + contestInformation.getPrimaryCCS_URL()
 //                          + "\n            login: " + contestInformation.getPrimaryCCS_user_login()
 //                          + "\n           passwd: " + contestInformation.getPrimaryCCS_user_pw()
 //                          + "\n        lastEvent: " + contestInformation.getLastShadowEventID() );
-//        
+//
 
         getStartStopButton().setEnabled(true);
         getUpdateButton().setEnabled(false);
@@ -728,14 +762,14 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             getStartStopButton().setText("Start shadowing");
             getStartStopButton().setToolTipText("Start shadowing the currently specified remote CCS");
         }
-        
+
         updateShadowSettingsPane(currentlyShadowing);
         lastToken = contestInformation.getLastShadowEventID();
         lastEventTextfield.setText(lastToken);
     }
-    
+
     private void updateShadowSettingsPane(boolean currentlyShadowing) {
-        
+
         ContestInformation contestInformation = getContest().getContestInformation();
 
         getShadowSettingsPane().getShadowModeCheckbox().setSelected(contestInformation.isShadowMode());
@@ -755,9 +789,9 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
      * @return a ShadowInformation object
      */
     protected ShadowInformation getFromFields() {
-        
-        ShadowInformation newShadowInformation = new ShadowInformation();                
-        
+
+        ShadowInformation newShadowInformation = new ShadowInformation();
+
         //fill in Shadow Mode information from this pane
         newShadowInformation.setShadowModeEnabled(getShadowSettingsPane().getShadowModeCheckbox().isSelected());
         newShadowInformation.setRemoteCCSURL(getShadowSettingsPane().getRemoteCCSURLTextfield().getText());
@@ -771,33 +805,33 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     /**
      * Updates the current {@link ContestInformation} on the server with the current shadow settings
      * in this GUI pane.
-     * 
+     *
      */
     private void updateContestInformation() {
         ShadowInformation shadowInfo = getFromFields();
-        
+
 //        System.out.println ("UpdateContestInformation(): got the following shadow info:");
 //        System.out.println ("   Shadow Enabled: " + shadowInfo.isShadowModeEnabled()
 //                          + "\n              URL: " + shadowInfo.getRemoteCCSURL()
 //                          + "\n            login: " + shadowInfo.getRemoteCCSLogin()
 //                          + "\n           passwd: " + shadowInfo.getRemoteCCSPassword()
 //                          + "\n        lastEvent: " + shadowInfo.getLastEventID());
-//        
+//
 //        System.out.println ("UpdateContestInformation(): savedContestInformation contains the following shadow info:");
 //        System.out.println ("   Shadow Enabled: " + savedContestInformation.isShadowMode()
 //                          + "\n              URL: " + shadowInfo.getRemoteCCSURL()
 //                          + "\n            login: " + shadowInfo.getRemoteCCSLogin()
 //                          + "\n           passwd: " + shadowInfo.getRemoteCCSPassword()
 //                          + "\n        lastEvent: " + shadowInfo.getLastEventID());
-        
+
         ContestInformation contestInfo = getContest().getContestInformation();
-        
+
         contestInfo.setShadowMode(shadowInfo.isShadowModeEnabled());
         contestInfo.setPrimaryCCS_URL(shadowInfo.getRemoteCCSURL());
         contestInfo.setPrimaryCCS_user_login(shadowInfo.getRemoteCCSLogin());
         contestInfo.setPrimaryCCS_user_pw(shadowInfo.getRemoteCCSPassword());
         contestInfo.setLastShadowEventID(shadowInfo.getLastEventID());
-        
+
         getController().updateContestInformation(contestInfo);
     }
 
@@ -805,28 +839,33 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
 
 
 
+        @Override
         public void contestInformationAdded(ContestInformationEvent event) {
 //            System.out.println ("contestInformationAdded listener: event = " + event);
             savedContestInformation = event.getContestInformation();
             updateGUI();
         }
 
+        @Override
         public void contestInformationChanged(ContestInformationEvent event) {
 //            System.out.println ("contestInformationChanged listener: event = " + event);
            savedContestInformation = event.getContestInformation();
             updateGUI();
         }
 
+        @Override
         public void contestInformationRemoved(ContestInformationEvent event) {
             // TODO Auto-generated method stub
         }
 
+        @Override
         public void contestInformationRefreshAll(ContestInformationEvent contestInformationEvent) {
 //            System.out.println ("contestInformationRefreshAll listener: event = " + contestInformationEvent);
             savedContestInformation = contestInformationEvent.getContestInformation();
             updateGUI();
         }
-        
+
+        @Override
         public void finalizeDataChanged(ContestInformationEvent contestInformationEvent) {
             // Not used
         }
@@ -839,9 +878,10 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         	compareRunsButton.setMnemonic(KeyEvent.VK_R);
         	compareRunsButton.setToolTipText("Display run comparison results");
         	compareRunsButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (shadowController==null) {
-                        showErrorMessage("No shadow controller available; cannot show runs comparison", "Missing Controller"); 
+                        showErrorMessage("No shadow controller available; cannot show runs comparison", "Missing Controller");
                     } else if (!ShadowController.SHADOW_CONTROLLER_STATUS.SC_RUNNING.equals(shadowController.getStatus())) {
                         showErrorMessage("Cannot compare runs, shadow not running","Shadow not running");
                     } else {
@@ -852,29 +892,31 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                         shadowCompareRunsFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                         shadowCompareRunsFrame.setVisible(true);
                     }
-                    
+
                 }
             });
 
         }
         return compareRunsButton;
     }
-    
+
     private JButton getCompareScoreboardsButton() {
         if (compareScoreboardsButton == null) {
             compareScoreboardsButton = new JButton("Compare Scoreboards");
             compareScoreboardsButton.setMnemonic(KeyEvent.VK_S);
             compareScoreboardsButton.setToolTipText("Display scoreboard comparison results");
             compareScoreboardsButton.addActionListener(new java.awt.event.ActionListener() {
-        	    
+
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
 
                 	SwingUtilities.invokeLater(new Runnable() {
-                		
-                		public void run() {
-                		
+
+                		@Override
+                        public void run() {
+
                             if (shadowController==null) {
-                                showErrorMessage("No shadow controller available; cannot show scoreboard comparison", "Missing Controller"); 
+                                showErrorMessage("No shadow controller available; cannot show scoreboard comparison", "Missing Controller");
                             } else if (!ShadowController.SHADOW_CONTROLLER_STATUS.SC_RUNNING.equals(shadowController.getStatus())) {
                                 showErrorMessage("Cannot compare scoreboard, shadow not running","Shadow not running");
                             } else {
@@ -886,7 +928,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                 shadowCompareScoreboardFrame.setVisible(true);
                             }
                 		}
-                	}); 
+                	});
                 };
 
             });
@@ -894,16 +936,18 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         }
         return compareScoreboardsButton;
     }
-    
+
     private JButton getTestConnectionButton() {
         if (testConnectionButton == null) {
             testConnectionButton = new JButton("Test Connection");
             testConnectionButton.addActionListener(new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent arg0) {
-                    
+
                     SwingUtilities.invokeLater(new Runnable() {
+                        @Override
                         public void run() {
-                            
+
                                IRemoteContestAPIAdapter remoteContestAPIAdapter = null;
                                 try {
                                     ShadowInformation shadowInfo = getCurrentShadowInformation(getContest().getContestInformation());
@@ -918,7 +962,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                     } else {
                                         addConnectTableEntry(ShadowStatus.FAILURE, "Test connection to remote CCS");
                                     }
-                                    
+
                                     // Try to get the remote API version
                                     String infoStr = getRemoteAPIVersionInfo(remoteURLString, remoteLogin, remotePW);
                                     // infoStr is supposed to be non-null all the time, but let's be sure
@@ -929,7 +973,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                 } catch (Exception e) {
                                     showErrorMessage("Exception attempting to test connection to remote system:\n" + e, "Exception in connecting");
                                     getController().getLog().log(Log.SEVERE, "Exception attempting to test connection to remote system: " + e.getMessage(), e);
-                                    
+
                                 } finally {
                                     if (remoteContestAPIAdapter != null) {
                                         remoteContestAPIAdapter = null;
@@ -938,7 +982,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                         }
                     });
 
-                    
+
                 }
             });
         }
@@ -950,18 +994,18 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
      * This method uses the Jackson {@link ObjectMapper} to perform the conversion from the JSON
      * string to a Map.  Note that the ObjectMapper recurses for nested JSON elements, returning
      * a appropriate Object in the Map under the corresponding key string.
-     * 
+     *
      * @param jsonString a JSON string to be converted to a Map
      * @return a Map mapping the keys in the JSON string to corresponding values, or null if the input
      *          String is null or if an exception occurs while converting the JSON to a Map.
      */
     @SuppressWarnings("unchecked")
     protected static Map<String, Object> getMap(String jsonString) {
-        
+
         if (jsonString == null){
             return null;
         }
-        
+
         ObjectMapper mapper = new ObjectMapper();
         try {
             Map<String, Object> map = mapper.readValue(jsonString, Map.class);
@@ -975,12 +1019,13 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private void addConnectTableEntry(ShadowStatus stat, String msg)
     {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 Object[] objects = new Object[3];
-                
+
                 try {
                     GregorianCalendar cal = new GregorianCalendar();
-                    
+
                     lastDateFormat.setCalendar(cal);
                     objects[0] = lastDateFormat.format(cal.getTime());
                 } catch(Exception e) {
@@ -996,15 +1041,16 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                 resizeColumnWidth(connectStatusTable);
             }
         });
-        
+
     }
-    
+
     /*
      * IShadowMonitorStatus implementaiton
      */
     /**
      * {@inheritDoc}
      */
+    @Override
     public void updateShadowLastToken(String token)
     {
         // if the value supplied is valid and different from what we last saw,
@@ -1018,7 +1064,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                 lastEventTextfield.setText(lastToken);
                 try {
                     GregorianCalendar cal = new GregorianCalendar();
-                    
+
                     lastDateFormat.setCalendar(cal);
                     lastEventTimeTextField.setText(lastDateFormat.format(cal.getTime()));
                 } catch(Exception e) {
@@ -1027,10 +1073,11 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             }
         }
     }
-    
+
     /**
      * {@inheritDoc}
      */
+    @Override
     public void updateShadowNumberofRecords(int nRec)
     {
         // if the number of records is different from what we last display and it's valid
@@ -1042,10 +1089,27 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             lastRecordTextfield.setText(String.valueOf(numRecord));
         }
     }
-    
+
     /**
      * {@inheritDoc}
      */
+    @Override
+    public void updateShadowNumberofTossedRecords(int nRec)
+    {
+        // if the number of tossed records is different from what we last display and it's valid
+        // update the instrumentation.
+        if(nRec != numTossedRecord && nRec >= 0) {
+            // TODO: Do we want to "InvokeLater" this (simple) update to a text field?
+            numTossedRecord = nRec;
+            // Save to file? Send to server contestinfo?
+            lastTossedRecordTextfield.setText(String.valueOf(numTossedRecord));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void connectFailed(String token)
     {
         if(token == null || token.isEmpty()) {
@@ -1058,6 +1122,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     /**
      * {@inheritDoc}
      */
+    @Override
     public void connectSucceeded(String token)
     {
         if(token == null || token.isEmpty()) {
@@ -1066,16 +1131,17 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             addConnectTableEntry(ShadowStatus.SUCCESS, "Connected starting at token " + token);
         }
     }
-    
+
     /**
      * {@inheritDoc}
      */
+    @Override
     public void connectClosed(String msg)
     {
         if(msg == null || msg.isEmpty()) {
             msg = "Connection closed";
         }
-        
+
         // Save last token on disconnect
         if(lastToken != null && !lastToken.isEmpty()) {
             updateContestInformation();
@@ -1083,24 +1149,38 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         }
         addConnectTableEntry(ShadowStatus.INFO, msg);
     }
-    
+
     /**
      * {@inheritDoc}
      */
+    @Override
     public void errorDisconnect(String errMsg)
     {
         if(errMsg == null || errMsg.isEmpty()) {
             errMsg = "Unexpected disconnect";
         }
         addConnectTableEntry(ShadowStatus.FAILURE, errMsg);
-        
+
         // Save last token on disconnect
         if(lastToken != null && !lastToken.isEmpty()) {
             updateContestInformation();
         }
     }
 
-    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void statusMessage(String status)
+    {
+        if(status == null || status.isEmpty()) {
+            addConnectTableEntry(ShadowStatus.STATUS, "Empty Status");
+        } else {
+            addConnectTableEntry(ShadowStatus.STATUS, status);
+        }
+    }
+
+
     private IRemoteContestAPIAdapter createRemoteContestAPIAdapter(URL url, String login, String password) {
 
         boolean useMockAdapter = StringUtilities.getBooleanValue(IniFile.getValue("shadow.usemockcontestadapter"), false);
@@ -1111,7 +1191,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             return new RemoteContestAPIAdapter(url, login, password);
         }
     }
-    
+
     /**
      * Returns a String containing the URL of the remote version endpoint, or null if the string can not be formed
      * from the supplied remoteURLString
@@ -1124,7 +1204,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private String getRemoteAPIVersionURLString(String remoteURLString)
     {
         String remoteAPIVersionURLString = null;
-    
+
         // API (Version) endpoint is right before /contests/ in the URL, so find that, if it's there
         int iApi = remoteURLString.lastIndexOf("/contests/");
         if(iApi != -1) {
@@ -1136,7 +1216,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         }
         return(remoteAPIVersionURLString);
     }
-    
+
     /**
      * Returns a new IRemoteContestAPIAdapter object suitable for connecting to the VERSION api endpoint of the remote CCS
      * This endpoint is distinctly different from the /contest/xxxx endpoints in that it is the same for all contests
@@ -1148,7 +1228,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private IRemoteContestAPIAdapter createRemoteContestVersionAPIAdapter(String remoteURLString, String login, String password) throws MalformedURLException {
 
         boolean useMockAdapter = StringUtilities.getBooleanValue(IniFile.getValue("shadow.usemockcontestadapter"), false);
-        
+
         String remoteAPIVersionURLString = getRemoteAPIVersionURLString(remoteURLString);
         if(remoteAPIVersionURLString != null) {
             // If we have a valid URL to try, let's do it.
@@ -1176,7 +1256,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
     private String getRemoteAPIVersionInfo(String remoteURLString, String login, String password)
     {
         String infoStr;
-        
+
         try {
             // get the special API adapter for version info
             IRemoteContestAPIAdapter remoteAPI = createRemoteContestVersionAPIAdapter(remoteURLString, login, password);
@@ -1186,9 +1266,9 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                     // ex. {"version":"2022-07","version_url":"https://ccs-specs.icpc.io/2022-07/contest_api","name":"domjudge"}
                     String verstr = (String)map.get("version");
                     String provider = (String)map.get("name");
-                    
+
                     infoStr = "API Version: ";
-                    
+
                     // Try to make an intelligent looking string if stuff is missing
                     if(verstr == null || verstr.isEmpty()) {
                         infoStr += "N/A";
@@ -1202,7 +1282,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                     }
                 } else {
                     // getRemoteAPIVersionURLString will always return non-null here for those wondering, or remoteAPI would be null!
-                    infoStr = "No API version available at " + getRemoteAPIVersionURLString(remoteURLString);                                                   
+                    infoStr = "No API version available at " + getRemoteAPIVersionURLString(remoteURLString);
                 }
             } else {
                 infoStr = "Can not form API Version URL from " + remoteURLString;

--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -1059,17 +1059,21 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             if(lastToken == null || !token.equals(lastToken)) {
                 // TODO: Do we want to save the token to a file here in case we crash?
                 //       Currently, token is only saved when the shadow is "stopped"
-                // TODO: Do we want to "InvokeLater" these (simple) updates to text fields?
                 lastToken = token;
-                lastEventTextfield.setText(lastToken);
-                try {
-                    GregorianCalendar cal = new GregorianCalendar();
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        lastEventTextfield.setText(lastToken);
+                        try {
+                            GregorianCalendar cal = new GregorianCalendar();
 
-                    lastDateFormat.setCalendar(cal);
-                    lastEventTimeTextField.setText(lastDateFormat.format(cal.getTime()));
-                } catch(Exception e) {
-                    // Just ignore any exception from date formatter
-                }
+                            lastDateFormat.setCalendar(cal);
+                            lastEventTimeTextField.setText(lastDateFormat.format(cal.getTime()));
+                        } catch(Exception e) {
+                            // Just ignore any exception from date formatter
+                        }
+                    }
+                });
             }
         }
     }
@@ -1083,10 +1087,14 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         // if the number of records is different from what we last display and it's valid
         // update the instrumentation.
         if(nRec != numRecord && nRec >= 0) {
-            // TODO: Do we want to "InvokeLater" this (simple) update to a text field?
             numRecord = nRec;
-            // Save to file? Send to server contestinfo?
-            lastRecordTextfield.setText(String.valueOf(numRecord));
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    // Save to file? Send to server contestinfo?
+                    lastRecordTextfield.setText(String.valueOf(numRecord));
+                }
+            });
         }
     }
 
@@ -1099,10 +1107,14 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
         // if the number of tossed records is different from what we last display and it's valid
         // update the instrumentation.
         if(nRec != numTossedRecord && nRec >= 0) {
-            // TODO: Do we want to "InvokeLater" this (simple) update to a text field?
             numTossedRecord = nRec;
-            // Save to file? Send to server contestinfo?
-            lastTossedRecordTextfield.setText(String.valueOf(numTossedRecord));
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    // Save to file? Send to server contestinfo?
+                    lastTossedRecordTextfield.setText(String.valueOf(numTossedRecord));
+                }
+            });
         }
     }
 


### PR DESCRIPTION
### Description of what the PR does
Remove restriction that the contest must be started prior to starting shadowing.  The Shadow will wait for CLICS **state** events with the appropriate value for "**started**" then start the contest clock.  Various checks are done so we don't start twice, etc.  Also listen for a valid value in the "**ended**" property to denote the end of the contest at which point the contest is stopped.

Sorry about all the diff's in `RemoteEventFeedMonitor `- @troy2914 made me turn on the option that gets rid of extra space on lines, and, well, apparently, this modules had LOTS of extra space on the ends of lines.  *sigh* :-)

### Issue which the PR addresses
Fixes #815
Fixes #608 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
jdk1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load up a shadow  contest from a primary that is known to send state events on the event feed.  (DOMjudge does this)  Alternately, at the current time, you can use a contest such as [The NAC2024 System Test 1 contest](https://github.com/icpcsysops/NAC2024/tree/main/contests/systest1) and use a URL of: https://icpc.displayadmin.com:50443/contests/nac24systest1 to act as a primary (it's really a replay server, but will provide the necessary state events for **started** and **ended**.  The _user_ and _password_ for the connection can be found in the corresponding `system.pc2.yaml` file for the contest.  If you choose to use the replay server, you can enter "`&speedfactor=50`" in the "**Last Token:**" box to speed up the playback (yes, the `&` is necessary as this is an appended **_QueryParam_** to the replay endpoint).
2) Do not start the contest.
3) Start shadowing from the primary.
4) A lovely dialog appears asking you to make sure you want to start shadowing, even though the contest isn't started.  Answer **Yes** here.
4) Observe the status table list on the shadow pane.  You should see the cyan-colored **state** messages as they are delivered.  Any submissions or judgments made prior to the starting **state** message will be "_tossed_" (there is a new count on the shadow GUI labeled "**Tossed**".  This indicates how many messages were tossed because the contest was not started.  (Appropriate tool-tip on the label).
5) Contest should start when the primary sends a **state** event with the **started** time non-null (PC2 does not care what the value of the time is as long as it's a valid time.  A warning is logged and a message appears in the status table on the GUI if the time supplied does not match the configured contest start time - apparently this is a requirement by the CLICS spec which we ignore.)
6) At the end of the contest, the contest should stop when a **state** event is received with an **ended** property set to a valid time.

Sample screen shot:
![image (2)](https://github.com/pc2ccs/pc2v9/assets/5657363/0b53c414-6ff6-4798-9733-4ceac872fbce)
