### PR TITLE
i_943 Fix Group tab on Edit Problem

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ProblemGroupPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ProblemGroupPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.Color;

--- a/src/edu/csus/ecs/pc2/ui/ProblemGroupPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ProblemGroupPane.java
@@ -113,28 +113,6 @@ public class ProblemGroupPane extends JPanePlugin {
             getGroupListBox().setForeground(Color.BLACK);
         }
         getGroupListBox().setEnabled(enable);
-
-        // This loop is wrong and does not do what you think it does.
-        // Apparently, enabling/disabling a checkbox within a JCheckboxJList has no effect (it appears to always be enabled
-        // if the JCheckboxJList is enabled.)
-        // Instead you disable the entire JCheckboxJList component as we do above.  Leaving
-        // this here for code review, but should be removed.
-        // If this code is enabled, it causes lots and lots of re-reads of the problem data files
-        // since it would trigger a checkbox changed listener for each setEnabled().  This causes
-        // the check for the update button to be done which checks every data file and takes quite
-        // some time on huge data files and/or large numbers of files.
-//        ListModel<Object> list = getGroupListBox().getModel();
-//
-//        for (int i = 0; i < list.getSize(); i++) {
-//            Object ele = list.getElementAt(i);
-//            if (ele instanceof WrapperJCheckBox) {
-//                WrapperJCheckBox box = (WrapperJCheckBox) ele;
-//
-//                box.setEnabled(enable);
-//
-//            }
-//
-//        }
     }
 
     @Override
@@ -163,12 +141,8 @@ public class ProblemGroupPane extends JPanePlugin {
             selectGroupsRadioButton.setSelected(true);
         }
 
-        // I don't know what this is for and why it's here - This list is always empty at this point - JB 3/20/2024
-        // Why always enable the checkboxes?  Makes no sense.
-        // enableGroupCheckBoxes(true);
 
-        // This makes more sense - to color the background of the list box depending on whether "all groups" can view the problem
-        // and enable/disable the container of the checkboxes (JCheckBoxJList)
+        // Enable/Disable the checkbox list box depending on whether "all groups" can view the problem
         enableGroupCheckBoxes(!allGroupsSelected);
 
         Group[] groups = getContest().getGroups();


### PR DESCRIPTION
### Description of what the PR does
Do not enable/disable individual group check boxes. This causes excesseive overhad when checking for the **Update** button.
Instead, enable/disable the entire `JCheckBoxJList `control which CONTAINS the checkboxes. This appears to be the original author's intent.

Left some commented-out code with new comments to help in code review. Will be removed prior to merging after approved.

### Issue which the PR addresses
Fixes #943 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
jdk1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Part 1:

1. Load a contest that has some groups defined
2. Go to the **Problems** tab
3. Add a problem (or edit an existing one)
4. Go to the **Groups** tab
5. Select the **Show to all groups** radio button
6. Attempt to check some of the groups in the group box check list
7. Note you can not change the state of the check boxes
8. Select the Show to only these groups radio.
9. Attempt to check some of the groups in the group box check list
10. Note you can now change the state of the check boxes

Part 2 (slowness loading):

1. Load a contest (such as `wfluxor/contests/wf47/systest1`) that has lots of groups defined (>20) and problems with lots of test cases and/or big test case files.
2. Attempt to edit one of these problems (note that that the performance is now reasonable)