### PR TITLE
i_942 Fix entry points with periods

### DIFF
--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -1,15 +1,15 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 /**
  * Constants for pc2.
- * 
+ *
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
 public final class Constants {
-    
+
     public static final String AWARDS_JSON_FILENAME = "awards.json";
-    
+
     public final static String SCOREBOARD_JSON_FILENAME = "scoreboard.json";
 
     public static final long HOURS_PER_DAY = 24;
@@ -19,7 +19,7 @@ public final class Constants {
     }
 
     // SerializedFile constants.
-    
+
     public static final int FILETYPE_BINARY = 1;
 
     public static final String FILETYPE_BINARY_TEXT = "Binary";
@@ -71,22 +71,22 @@ public final class Constants {
      * number of seconds in an hour.
      */
     public static final long SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
-    
+
     public static final long SECONDS_PER_DAY = 86400;
 
     /**
      * Default contest length.
      */
     public static final long DEFAULT_CONTEST_LENGTH_SECONDS = 18000; // 5 * 60 * 60
-    
-    
+
+
     public static final int DEFAULT_MAX_OUTPUT_SIZE_K = 512;
 
     /**
      * PC<sup>2</sup> Validator Program Name.
      */
     public static final String PC2_VALIDATOR_NAME = "edu.csus.ecs.pc2.validator.pc2Validator.PC2Validator";
-    
+
     /**
      * CLICS Validator Program Name.
      */
@@ -96,18 +96,23 @@ public final class Constants {
      * The Default PC2 Validator Command Line
      */
     public static final String DEFAULT_PC2_VALIDATOR_COMMAND = "{:validator} {:infile} {:outfile} {:ansfile} {:resfile} ";
-    
+
     /**
      * The Default CLICS Validator Command Line
      */
     public static final String DEFAULT_CLICS_VALIDATOR_COMMAND = "{:validator} {:infile} {:ansfile} {:feedbackdir} ";
-    
-    
+
+
     /**
      * Command substitution variable for name of thing to execute (basename of source file)
      */
     public static final String CMDSUB_BASENAME_VARNAME = "{:basename}";
-    
+
+    /**
+     * Command substitution variable for all files submitted. Note the missing ':' - legacy.
+     */
+    public static final String CMSSUB_FILES_VARNAME = "{files}";
+
     /**
      * Command substitution variable for conditional suffix
      * This can be used for languages (such as Kotlin), that has a different main class name than the basename of
@@ -118,12 +123,12 @@ public final class Constants {
      * Use of this is not just restricted to executables or basename; it can be used anywhere in the string.
      */
     public static final String CMDSUB_COND_SUFFIX = "{:ensuresuffix=}";
-    
+
     /**
      * Default file name for judgement ini file.
      */
     public static final String JUDGEMENT_INIT_FILENAME = "reject.ini";
-    
+
 
     /**
      * Minimum java major version value.
@@ -137,13 +142,13 @@ public final class Constants {
 
     /**
      * Default port that a pc2 server listens on.
-     * 
+     *
      */
     public static final int DEFAULT_PC2_PORT = 50002;
-    
-    
+
+
     // Column names for load/save accounts
-    
+
     public static final String SITE_COLUMN_NAME = "site";
 
     public static final String ACCOUNT_COLUMN_NAME = "account";
@@ -169,11 +174,11 @@ public final class Constants {
     public static final String SHORTSCHOOLNAME_COLUMN_NAME = "shortschoolname";
 
     public static final String TEAMNAME_COLUMN_NAME = "teamname";
-    
+
     public static final String COUNTRY_CODE_COLUMN_NAME = "countrycode";
 
     public static final String SCORING_ADJUSTMENT_COLUMN_NAME = "scoreadjustment";
-    
+
     public static final String INST_CODE_COLUMN_NAME = "institution";
 
     public static final String DEFAULT_INSTITUTIONNAME = "undefined";
@@ -183,25 +188,25 @@ public final class Constants {
     public static final String DEFAULT_COUNTRY_CODE = "XXX";
 
     public static final String DEFAULT_INSTITUTIONCODE = "undefined";
-    
+
     public static final int INPUT_VALIDATOR_SUCCESS_EXIT_CODE = 42;
-    
+
     public static final int INPUT_VALIDATOR_FAILED_EXIT_CODE = 43;
-    
+
     public static final int INPUT_VALIDATOR_EXECUTION_ERROR_CODE = -39;
-    
+
     public static final String ACCOUNTS_LOAD_FILENAME = "accounts_load.tsv";
 
     public static final int BYTES_PER_KIBIBYTE = 1024;
-    
+
     public static final int KIBIBYTE_PER_MEBIBYTE = 1024;
-    
+
     /**
      * Directory where scripts go that PC2 executes for sandbox and interactive submissions.
      * This folder is in the PC2 home folder (install folder).
      */
     public static final String PC2_SCRIPT_DIRECTORY = "scripts";
-    
+
     /**
      * Command line to run submission in a sandbox
      */
@@ -211,42 +216,42 @@ public final class Constants {
      * File name of script to run submission in sandbox ({:sandboxprogramname} if non-interactive)
      */
     public static final String PC2_INTERNAL_SANDBOX_PROGRAM_NAME = "pc2sandbox.sh";
-    
+
     /**
      * Filename of the script to run submission for an interactive problem in a sandbox ({:sandboxprogramname} if interactive)
      */
     public static final String PC2_INTERNAL_SANDBOX_INTERACTIVE_NAME = "pc2sandbox_interactive.sh";
-    
+
     /**
      *  Command to execute to run an interactive problem in a sandbox
      */
     public static final String PC2_INTERNAL_SANDBOX_INTERACTIVE_COMMAND_LINE = "./{:sandboxprogramname} {:memlimit} {:timelimit} {:validator} {:infilename} {:ansfilename} {:testcase}";
-    
+
     /**
      *  Filename of the script to run for an interactive problem when not using a sandbox
      */
     public static final String PC2_INTERACTIVE_NAME = "pc2_interactive.sh";
-    
+
     /**
      *  Command to execute to run an interactive problem when not using a sandbox
      */
     public static final String PC2_INTERACTIVE_COMMAND_LINE = "./pc2_interactive.sh {:validator} {:infilename} {:ansfilename} {:testcase}";
-    
+
     /**
      *  Filename of the script to run during the validate phase AFTER the interactive validator has completed
      */
     public static final String PC2_INTERACTIVE_VALIDATOR_NAME = "pc2validate_interactive.sh";
-    
+
     /**
      *  Command to execute to validate results of an interactive run AFTER the interactive validator has completed
      */
     public static final String PC2_INTERACIVE_VALIDATE_COMMAND = "./" + PC2_INTERACTIVE_VALIDATOR_NAME + " {:resfile} {:feedbackdir} {:testcase}";
-    
+
     /**
      * Execution info for entire run (all testcases)
      */
     public static final String PC2_EXECUTION_RESULTS_NAME_SUFFIX = "executeinfo.ndjson";
-    
+
     /**
      * OS Compatibility constants
      */
@@ -260,17 +265,17 @@ public final class Constants {
     public static final String VALIDATION_DEFAULT = "default";
     public static final String VALIDATION_INTERACTIVE = "interactive";
     public static final String VALIDATION_SCORE = "score";
-    
+
     /**
      * Prefix for deleted runs.
      */
     public static final String DEL_RUN_PREFIX = "DEL ";
-    
+
     /**
      * output directory for reports.
      */
     public static final String REPORT_DIRECTORY_NAME = "reports";
-    
+
     /**
      * default results directory for CDP.
      */

--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -111,7 +111,7 @@ public final class Constants {
     /**
      * Command substitution variable for all files submitted. Note the missing ':' - legacy.
      */
-    public static final String CMSSUB_FILES_VARNAME = "{files}";
+    public static final String CMDSUB_FILES_VARNAME = "{files}";
 
     /**
      * Command substitution variable for conditional suffix

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2696,6 +2696,8 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
                 // create the name of the expected compilation result
                 programName = replaceString(language.getExecutableIdentifierMask(), Constants.CMDSUB_BASENAME_VARNAME, programName);
+                // perform any other substitutions
+                programName = substituteAllStrings(run, programName);
             } else {
 
                 // This used to just replace the {:basename}, but there is no reason not to run it

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1981,7 +1981,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 // (overrides :mainfile, :files, :basename)
                 if(language.getID().equals(Language.CLICS_LANGID_PYTHON3)) {
                     // Python ONLY takes one file, and if there's an entrypoint it overrides everything
-                    cmdline = replaceString(cmdline, Constants.CMSSUB_FILES_VARNAME, entryPointName);
+                    cmdline = replaceString(cmdline, Constants.CMDSUB_FILES_VARNAME, entryPointName);
                     // This next one is dubious.  BASENAME implies no extension, but the entryPointName for python, has one.
                     cmdline = replaceString(cmdline, Constants.CMDSUB_BASENAME_VARNAME, entryPointName);
                 } else {
@@ -3021,7 +3021,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 return origString;
             }
             newString = replaceString(origString, "{:mainfile}", runFiles.getMainFile().getName());
-            newString = replaceString(newString, Constants.CMSSUB_FILES_VARNAME, ExecuteUtilities.getAllSubmittedFilenames(runFiles));
+            newString = replaceString(newString, Constants.CMDSUB_FILES_VARNAME, ExecuteUtilities.getAllSubmittedFilenames(runFiles));
             newString = replaceString(newString, Constants.CMDSUB_BASENAME_VARNAME, removeExtension(runFiles.getMainFile().getName()));
             newString = replaceString(newString, "{:package}", packageName);
 

--- a/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.File;
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Plugin;
 import edu.csus.ecs.pc2.core.Utilities;
@@ -26,20 +27,20 @@ import edu.csus.ecs.pc2.core.model.RunFiles;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 
 /**
- * 
- * 
+ *
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
 
 // $HeadURL$
 public class ExecuteUtilities extends Plugin {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -9167576117688387694L;
-    
+
     /**
      * Regular Expression to match include file names.
      */
@@ -51,51 +52,51 @@ public class ExecuteUtilities extends Plugin {
     private static Pattern includeRePattern = Pattern.compile(INCLUDE_RE);
 
     private Run run;
-    
+
     private RunFiles runFiles;
-    
+
     private Problem problem;
-    
+
     private Language language;
-    
+
     private ProblemDataFiles problemDataFiles;
-    
+
     private Log log;
-    
+
     private ExecutionData executionData;
-    
+
     private String resultsFileName;
 
     private static String debugMessage = null;
-    
+
     public static final String DEFAULT_PC2_JAR_PATH = "./build/prod";
-    
+
     public static final String PC2_JAR_FILENAME = "pc2.jar";
-    
+
     public ExecuteUtilities(IInternalContest contest, IInternalController controller, Run run, RunFiles runFiles, Problem problem, Language language) {
         super();
-        
+
         setContestAndController(contest, controller);
-        
+
         this.run = run;
         this.runFiles = runFiles;
         this.problem = problem;
         this.language = language;
-        
+
         log = getController().getLog();
-        
+
         if (run == null) {
             throw new IllegalArgumentException("Run is null");
         }
-        
+
         resultsFileName = createResultsFileName(run);
     }
 
     /**
      * Replace all instances of beforeString with afterString.
-     * 
+     *
      * If before string is not found, then returns original string.
-     * 
+     *
      * @param origString
      *            string to be modified
      * @param beforeString
@@ -106,7 +107,7 @@ public class ExecuteUtilities extends Plugin {
      */
     public static String replaceString(String origString, String beforeString, String afterString) {
         debugMessage = null;
-        
+
         if (origString == null) {
             return origString;
         }
@@ -126,12 +127,12 @@ public class ExecuteUtilities extends Plugin {
 
         return buf.toString();
     }
-    
+
     /**
      * Replace beforeString with int.
-     * 
+     *
      * For details see {@link #replaceString(String, String, String)}
-     * 
+     *
      * @param origString
      *            string to be modified
      * @param beforeString
@@ -141,7 +142,7 @@ public class ExecuteUtilities extends Plugin {
      * @return string after replacement.
      */
     public static String replaceString(String origString, String beforeString, int afterInt) {
-        
+
         debugMessage = null;
 
         String afterString = new Integer(afterInt).toString();
@@ -152,7 +153,7 @@ public class ExecuteUtilities extends Plugin {
      * Return string minus last extension. <br>
      * Finds last . (period) in input string, strips that period and all other characters after that last period. If no period is found in string, will return a copy of the original string. <br>
      * Unlike the Unix basename program, no extension is supplied.
-     * 
+     *
      * @param original
      *            the input string
      * @return a string with all text after last . removed
@@ -170,11 +171,11 @@ public class ExecuteUtilities extends Plugin {
         return outString;
 
     }
-    
-    
+
+
     /**
      * Match string to RE.
-     * 
+     *
      * @param str
      * @param reString
      * @return true if str matches regular expression reString
@@ -183,28 +184,28 @@ public class ExecuteUtilities extends Plugin {
         Pattern p = Pattern.compile(reString);
         Matcher m = p.matcher(str);
         return m.find();
-        
+
     }
-    
+
     /**
      * Match String to {@link #INCLUDE_RE}.
-     * 
+     *
      * @param str
      * @return true if string matches {{@link #INCLUDE_RE}.
      */
     public static boolean matchIncludeRe(String str) {
         return includeRePattern.matcher(str).find();
     }
-    
+
     /**
      * Return all compilable submitted file names.
-     * 
+     *
      * @param files
      * @return main file and any additional filenames that end in: .c, .cpp or .C
      */
     public static String getAllSubmittedFilenames(RunFiles files){
         String filelist = files.getMainFile().getName();
-        
+
         if (files.getOtherFiles() != null && files.getOtherFiles().length > 0){
             for (SerializedFile file : files.getOtherFiles()) {
                 if (! matchIncludeRe(file.getName())) {
@@ -214,12 +215,12 @@ public class ExecuteUtilities extends Plugin {
         }
         return filelist;
     }
-    
+
     /**
      * return string with all field variables filled with values.
-     * 
+     *
      * Each variable will be filled in with values.
-     * 
+     *
      * <pre>
      *             valid fields are:
      *              {:mainfile} - submitted file (hello.java)
@@ -234,13 +235,13 @@ public class ExecuteUtilities extends Plugin {
      *              {:ansfile}
      *              {:pc2home}
      * </pre>
-     * 
+     *
      * @param origString -
      *            original string to be substituted.
      * @return a new String with all occurrences of substitution variables replaced by the corresponding values
      */
     public String substituteAllStrings(String origString) {
-        
+
         String newString = "";
         String nullArgument = "-"; /* this needs to change */
 
@@ -252,24 +253,24 @@ public class ExecuteUtilities extends Plugin {
             return origString;
         }
         newString = replaceString(origString, "{:mainfile}", runFiles.getMainFile().getName());
-        newString = replaceString(newString, "{files}", getAllSubmittedFilenames(runFiles));
-        newString = replaceString(newString, "{:basename}", removeExtension(runFiles.getMainFile().getName()));
+        newString = replaceString(newString, Constants.CMSSUB_FILES_VARNAME, getAllSubmittedFilenames(runFiles));
+        newString = replaceString(newString, Constants.CMDSUB_BASENAME_VARNAME, removeExtension(runFiles.getMainFile().getName()));
 
         if (problem != null){
-            
+
             String validatorCommand = null;
 
             if (problem.getOutputValidatorProgramName() != null) {
                 validatorCommand = problem.getOutputValidatorProgramName();
             }
-            
+
             if (problemDataFiles != null) {
                 SerializedFile validatorFile = problemDataFiles.getOutputValidatorFile();
                 if (validatorFile != null) {
                     validatorCommand = validatorFile.getName(); // validator
                 }
             }
-            
+
             if (validatorCommand != null) {
                 newString = replaceString(newString, "{:validator}", validatorCommand);
             }
@@ -299,8 +300,8 @@ public class ExecuteUtilities extends Plugin {
                 debugLog("No language defined for "+run.getLanguageId());
             }
         }
-        
-        
+
+
         if (run.getProblemId() != null) {
             Problem[] problems = getContest().getProblems();
             int index = 0;
@@ -317,7 +318,7 @@ public class ExecuteUtilities extends Plugin {
                 debugLog("No problem defined for "+run.getProblemId());
             }
         }
-        
+
         if (run.getSubmitter() != null) {
             newString = replaceString(newString, "{:teamid}", run.getSubmitter().getClientNumber());
             newString = replaceString(newString, "{:siteid}", run.getSubmitter().getSiteNumber());
@@ -348,12 +349,12 @@ public class ExecuteUtilities extends Plugin {
             newString = replaceString(newString, "{:exitvalue}", Integer.toString(executionData.getExecuteExitValue()));
             newString = replaceString(newString, "{:executetime}", Long.toString(executionData.getExecuteTimeMS()));
         }
-        
+
         String pc2home = getPC2Home();
         if (pc2home != null && pc2home.length() > 0) {
             newString = replaceString(newString, "{:pc2home}", pc2home);
         }
-        
+
         if (resultsFileName != null) {
             newString = replaceString(newString, "{:resfile}", resultsFileName);
         }
@@ -363,31 +364,31 @@ public class ExecuteUtilities extends Plugin {
 
     /**
      * Perform conditional substitutions
-     * 
+     *
      * @param origString
      * @param condVar
      * @return - possibly modified string
      */
     public static String replaceStringConditional(String origString, String condVar) {
-        
+
         int subStartIdx, endIdx, suffLen;
         String suffString;
-        
+
         if (origString == null || condVar == null) {
             return origString;
         }
         // if substitute variable has an = sign, we try to match the substring up to and including the
         // equals sign, eg: {:ensuresuffix=Kt}, we want to match: {:ensuresuffix=
         int subIdx = condVar.indexOf('=');
-        
+
         // Need at least two chars to left of =
         if(subIdx < 2) {
             return origString;
-        }       
+        }
 
         // don't care about anything after the =
         String subMatch = condVar.substring(0, subIdx+1);
-        
+
         int startIdx = origString.lastIndexOf(subMatch);
 
         if (startIdx == -1) {
@@ -399,16 +400,16 @@ public class ExecuteUtilities extends Plugin {
         while (startIdx != -1) {
             subStartIdx = startIdx + subMatch.length();
             endIdx = origString.indexOf('}', subStartIdx);
-            
+
             // Missing closing } for substitute variable?
             if(endIdx == -1) {
                 break;
             }
-            
+
             // this is the string we may have to add, but first see if it's there already
             suffString = origString.substring(subStartIdx, endIdx);
             suffLen = suffString.length();
-            
+
             // if there are not enough chars before the substitute var to compare, or, the trailing characters
             // don't match, then we have to replace the substitute var with the new suffix string, otherwise, we
             // we just delete the substitute var altogether
@@ -418,13 +419,13 @@ public class ExecuteUtilities extends Plugin {
             } else {
                 buf.delete(startIdx,  endIdx+1);
             }
-            
+
             startIdx = origString.lastIndexOf(subMatch, startIdx - 1);
         }
 
         return buf.toString();
     }
-    
+
     public static String getPC2Home() {
         String pc2home = new VersionInfo().locateHome();
         return pc2home;
@@ -432,9 +433,9 @@ public class ExecuteUtilities extends Plugin {
 
 
     private void debugLog(String string) {
-        
+
         debugMessage = string;
-        
+
         Exception ex = new Exception("ERROR "+string);
         if (log != null){
             log. log(Log.DEBUG, ex.getMessage(),  ex);
@@ -442,15 +443,15 @@ public class ExecuteUtilities extends Plugin {
             ex.printStackTrace(System.err);
         }
     }
-    
+
     /**
      * Create a unique results file.
      */
     public static String createResultsFileName (Run run){
         return createResultsFileName(run.getNumber());
     }
-    
-    
+
+
     /**
      * Create a unique results file.
      */
@@ -499,15 +500,15 @@ public class ExecuteUtilities extends Plugin {
     public void setExecutionData(ExecutionData executionData) {
         this.executionData = executionData;
     }
-    
+
     public Language getLanguage() {
         return language;
     }
-    
+
     public void setLanguage(Language language) {
         this.language = language;
     }
-    
+
     public static String getDebugMessage() {
         return debugMessage;
     }
@@ -520,14 +521,14 @@ public class ExecuteUtilities extends Plugin {
     public String getResultsFileName() {
         return resultsFileName;
     }
-    
+
     public void setResultsFileName(String resultsFileName) {
         this.resultsFileName = resultsFileName;
     }
 
     /**
      * Remove all files from specified directory, including subdirectories.
-     * 
+     *
      * @param dirName
      *            directory to be cleared.
      * @return true if directory was cleared.
@@ -548,50 +549,50 @@ public class ExecuteUtilities extends Plugin {
         }
         return (result);
     }
-    
+
     /**
      * Removes the specified directory (folder) from the file system, including first recursively removing
      * all files and all sub-directories (and their contents).
-     * 
+     *
      * @param dirName the name of the directory to be removed
-     * 
-     * @return true if the directory was successfully cleared and removed; false if the 
-     *      specified directory is null or the empty string, does not exist, 
+     *
+     * @return true if the directory was successfully cleared and removed; false if the
+     *      specified directory is null or the empty string, does not exist,
      *      could not be cleared, could not be removed, or if the specified name is not a directory
      */
     public static boolean removeDirectory(String dirName) {
-        
+
         if (dirName==null || dirName.equals("")) {
             return false;
         }
-        
+
         File dir = new File(dirName);
         if (!dir.isDirectory()) {
             return false;
         }
-        
+
         boolean success = clearDirectory(dirName);
         if (!success) {
             return false;
-        } 
-        
+        }
+
         success = dir.delete();
-        
+
         return success;
     }
-    
-    
+
+
     @Override
     public void dispose() {
-        
+
         // nothing to dispose
     }
 
     /**
      * Ensures directory.
-     * 
+     *
      * If directory cannot be created then returns false.
-     * 
+     *
      * @param directoryName
      * @return true if directory exists or was created, false otherwise.
      */
@@ -606,7 +607,7 @@ public class ExecuteUtilities extends Plugin {
 
     /**
      * Find the pc2.jar file path.
-     * 
+     *
      */
     public static String findPC2JarPath() {
 
@@ -619,7 +620,7 @@ public class ExecuteUtilities extends Plugin {
             }
             jarDir = defaultPath;
             String cp = System.getProperty("java.class.path");
-            
+
             String[] dirlist = cp.split(":");
             for (String token : dirlist) {
 
@@ -631,12 +632,12 @@ public class ExecuteUtilities extends Plugin {
             }
 
             if (DEFAULT_PC2_JAR_PATH.equals(jarDir)) {
-                
+
                 File dir = new File("dist/" + PC2_JAR_FILENAME);
                 if (dir.isFile()) {
                     jarDir = new File(dir.getParent()).getCanonicalPath() + File.separator;
                 } else {
-                    
+
                     dir = new File(PC2_JAR_FILENAME);
                     if (dir.isFile()) {
                         jarDir = new File(dir.getParent()).getCanonicalPath() + File.separator;
@@ -670,37 +671,37 @@ public class ExecuteUtilities extends Plugin {
             return false;
         }
     }
-    
+
     /**
      * Did the team's run solve the problem ?.
-     * 
+     *
      * @param executionData  the ExecutionData object which was produced by running the team's program
      * @return true if validation returned accepted
      */
     public static boolean didTeamSolveProblem(ExecutionData executionData) {
-        
+
         if (!executionData.isCompileSuccess() || !executionData.isExecuteSucess()){
             return false;
         }
-        
+
         if (executionData.isRunTimeLimitExceeded()){
             return false;
         }
 
-        // validator program failed to run 
+        // validator program failed to run
         if (! executionData.isValidationSuccess()){
             return false;
         }
 
-        
+
         if (executionData.getExecutionException() != null){
             return false;
         }
-        
+
         if (executionData.getValidationResults() != null){
-            
+
             String results = executionData.getValidationResults();
-            
+
             // bug 280 ICPC Validator Interface Standard calls for "accepted" in any case.
             if (results.trim().equalsIgnoreCase("accepted")) {
                 return true;
@@ -708,7 +709,7 @@ public class ExecuteUtilities extends Plugin {
         }
         return false;
     }
-    
+
     public static String toString(ExecutionData executionData) {
 
         return " compileSuccess=" + executionData.isCompileSuccess() + //
@@ -719,7 +720,7 @@ public class ExecuteUtilities extends Plugin {
                 ", validationResults=" + executionData.getValidationResults() //
         ;
     }
-    
+
     public static void dump(ExecutionData executionData) {
 
         System.out.println( " compileSuccess=" + executionData.isCompileSuccess() + //
@@ -730,13 +731,13 @@ public class ExecuteUtilities extends Plugin {
                 ", validationResults=" + executionData.getValidationResults() //
                 )
         ;
-        
+
         if (executionData.getExecutionException() != null){
             executionData.getExecutionException().printStackTrace();
         }
     }
-    
-        
+
+
 
     /**
      * Write String Array to file.
@@ -767,8 +768,8 @@ public class ExecuteUtilities extends Plugin {
         writer.close();
         writer = null;
     }
-    
-    
+
+
     /**
      * Cast a CheckedException as an unchecked one.
      *
@@ -781,5 +782,5 @@ public class ExecuteUtilities extends Plugin {
     public static <T extends Throwable> RuntimeException rethrow(Throwable throwable) throws T {
         throw (T) throwable;
     }
-    
+
 }

--- a/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ExecuteUtilities.java
@@ -253,7 +253,7 @@ public class ExecuteUtilities extends Plugin {
             return origString;
         }
         newString = replaceString(origString, "{:mainfile}", runFiles.getMainFile().getName());
-        newString = replaceString(newString, Constants.CMSSUB_FILES_VARNAME, getAllSubmittedFilenames(runFiles));
+        newString = replaceString(newString, Constants.CMDSUB_FILES_VARNAME, getAllSubmittedFilenames(runFiles));
         newString = replaceString(newString, Constants.CMDSUB_BASENAME_VARNAME, removeExtension(runFiles.getMainFile().getName()));
 
         if (problem != null){

--- a/src/edu/csus/ecs/pc2/core/model/Language.java
+++ b/src/edu/csus/ecs/pc2/core/model/Language.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import edu.csus.ecs.pc2.core.StringUtilities;
@@ -7,16 +7,30 @@ import edu.csus.ecs.pc2.core.log.StaticLog;
 
 /**
  * Single Language Definition.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
 // $HeadURL$
 public class Language implements IElementObject {
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 7782777481422759344L;
+
+    /**
+     * Well-known CLICS language ids
+     * TODO: We have to find a better way to deal with language-specific things inside PC2.
+     *       Languages require specific processing for things like "entry_point".  It's non-trivial
+     *       to make this "dynamic" and have PC2 be language agnostic. This has to be discussed.
+     *       For now, we will use the somewhat "well-known" CLICS "unofficial" language Identifiers for
+     *       ICPC contests.  JB 03/20/2024
+     */
+    public static final String CLICS_LANGID_JAVA = "java";
+    public static final String CLICS_LANGID_KOTLIN = "kotlin";
+    public static final String CLICS_LANGID_PYTHON3 = "python3";
+    public static final String CLICS_LANGID_C = "c";
+    public static final String CLICS_LANGID_CPP = "cpp";
 
     /**
      * Title for the Language.
@@ -32,37 +46,37 @@ public class Language implements IElementObject {
 
     /**
      * Compiler/Language command line.
-     * 
+     *
      * Command line with field substitution to compile source.
      */
     private String compileCommandLine;
-    
+
     /**
      * Executable Identifier Mask.
-     * 
+     *
      */
     private String executableIdentifierMask;
 
-    
+
     /**
      * Judge program command line.
-     * 
+     *
      * Command line for judges to execute the program created using compileCommandLine.
      */
     private String judgeProgramExecuteCommandLine;
-    
+
     /**
      * Flag to indicate whether using judge execut command line.
      */
     private boolean usingJudgeProgramExecuteCommandLine = false;
-    
+
     /**
      * Execute program command line.
-     * 
+     *
      * Command line to execute the program created using compileCommandLine.
      */
     private String programExecuteCommandLine;
-    
+
     private boolean interpreted = false;
 
     private String id = "";
@@ -137,6 +151,7 @@ public class Language implements IElementObject {
     /**
      * @see Object#equals(java.lang.Object).
      */
+    @Override
     public boolean equals(Object obj) {
         if (obj == null) {
             return false;
@@ -150,6 +165,7 @@ public class Language implements IElementObject {
         }
     }
 
+    @Override
     public String toString() {
         return displayName;
     }
@@ -157,25 +173,29 @@ public class Language implements IElementObject {
     /**
      * @return Returns the elementId.
      */
+    @Override
     public ElementId getElementId() {
         return elementId;
     }
 
+    @Override
     public int versionNumber() {
         return elementId.getVersionNumber();
     }
 
+    @Override
     public int getSiteNumber() {
         return elementId.getSiteNumber();
     }
 
+    @Override
     public void setSiteNumber(int siteNumber) {
         elementId.setSiteNumber(siteNumber);
     }
 
     public boolean isSameAs(Language language) {
         try {
-            
+
             if (! StringUtilities.stringSame(displayName, language.getDisplayName())) {
                 return false;
             }
@@ -223,11 +243,11 @@ public class Language implements IElementObject {
     public void setExecutableIdentifierMask(String executableIdentifierMask) {
         this.executableIdentifierMask = executableIdentifierMask;
     }
-    
+
     public void setInterpreted(boolean interpreted) {
         this.interpreted = interpreted;
     }
-    
+
     public boolean isInterpreted() {
         return interpreted;
     }
@@ -239,15 +259,15 @@ public class Language implements IElementObject {
             return getProgramExecuteCommandLine();
         }
     }
-    
+
     public void setJudgeProgramExecuteCommandLine(String judgeProgramExecuteCommandLine) {
         this.judgeProgramExecuteCommandLine = judgeProgramExecuteCommandLine;
     }
-    
+
     public void setUsingJudgeProgramExecuteCommandLine(boolean usingJudgeProgramExecuteCommandLine) {
         this.usingJudgeProgramExecuteCommandLine = usingJudgeProgramExecuteCommandLine;
     }
-    
+
     public boolean isUsingJudgeProgramExecuteCommandLine() {
         return usingJudgeProgramExecuteCommandLine;
     }
@@ -255,7 +275,7 @@ public class Language implements IElementObject {
     public void setID(String newId) {
         this.id = newId;
     }
-    
+
     public String getID() {
         return id;
     }

--- a/src/edu/csus/ecs/pc2/core/model/Run.java
+++ b/src/edu/csus/ecs/pc2/core/model/Run.java
@@ -1,16 +1,14 @@
-// Copyright (C) 1989-2020 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.util.Arrays;
 import java.util.Vector;
 
-import edu.csus.ecs.pc2.core.Utilities;
-
 /**
  * Submitted Run info.
- * 
+ *
  * Contains the submitter, problem, language, files and other data for a run.
- * 
+ *
  * @author pc2@ecs.csus.edu
  */
 
@@ -20,7 +18,7 @@ import edu.csus.ecs.pc2.core.Utilities;
 public class Run extends Submission {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 4643865629642121895L;
 
@@ -45,14 +43,14 @@ public class Run extends Submission {
 
         /**
          * Run is being judged.
-         * 
+         *
          * If a run must be judged by more than one judge, then when at least one judge has judged the run this state is set.
          */
         BEING_JUDGED,
 
         /**
          * Run is being re-judged.
-         * 
+         *
          * A run was previously judged.
          */
         BEING_RE_JUDGED,
@@ -167,7 +165,7 @@ public class Run extends Submission {
 
     /**
      * Returns true if judged (or is being re-judged, or Manual_review.
-     * 
+     *
      * @return true if judged.
      */
     public boolean isJudged() {
@@ -176,7 +174,7 @@ public class Run extends Submission {
 
     /**
      * Get the current judgement.
-     * 
+     *
      * @return return null if not judged else the judgement
      */
     public JudgementRecord getJudgementRecord() {
@@ -201,7 +199,7 @@ public class Run extends Submission {
     }
 
     /**
-     * 
+     *
      * @return true if team given a Yes.
      */
     public boolean isSolved() {
@@ -215,18 +213,18 @@ public class Run extends Submission {
 
     /**
      * Return list of all JudgementRecords.
-     * 
+     *
      * @return JudgementRecord[] - list of all active and inactive JudgementRecord
      */
     public JudgementRecord[] getAllJudgementRecords() {
-        return (JudgementRecord[]) judgementList.toArray(new JudgementRecord[judgementList.size()]);
+        return judgementList.toArray(new JudgementRecord[judgementList.size()]);
     }
 
     /**
      * Add new judgement.
-     * 
+     *
      * This will disable previous judgements and
-     * 
+     *
      * @param judgement
      *            new judgement to add.
      */
@@ -252,7 +250,7 @@ public class Run extends Submission {
     }
 
     /**
-     * 
+     *
      * @return null if no judgement found, else the judgement
      */
     public JudgementRecord getComputerJudgementRecord() {
@@ -281,7 +279,7 @@ public class Run extends Submission {
     }
 
     /**
-     * 
+     *
      * @return 0 if not judged, else number of minutes to judge run.
      */
     public long getJudgedMinutes() {
@@ -307,7 +305,7 @@ public class Run extends Submission {
     }
 
     /**
-     * 
+     *
      * @return empty string if no judgement, else comment
      */
     public String getCommentsForJudge() {
@@ -325,7 +323,7 @@ public class Run extends Submission {
 
     /**
      * Show this judgement to teams ?
-     * 
+     *
      * @return true if the judgement can be shown to the team, else false
      */
     public boolean isSendToTeams() {
@@ -344,6 +342,7 @@ public class Run extends Submission {
         return systemOS;
     }
 
+    @Override
     public String toString() {
         return "Run " + getNumber() + " " + getStatus() + " " + getElapsedMins() + " min " + getElapsedMS() + "ms from " + getSubmitter() + " id " + getElementId().toString() + " problem "
                 + getProblemId() + " lang " + getLanguageId();
@@ -351,9 +350,9 @@ public class Run extends Submission {
 
     /**
      * The elapsed time when this run was added.
-     * 
+     *
      * This is always the actual server submission time. The submission time can be 'overridden' using {@link #setElapsedMS(long)} and that elapsed MS will be used for scoring, esp. in CCS Test Mode.
-     * 
+     *
      * @return the server timestamp for this submission
      */
     public long getOriginalElapsedMS() {
@@ -376,9 +375,9 @@ public class Run extends Submission {
 
     /**
      * Set an override time for the elapsed time.
-     * 
+     *
      * When {@link #setElapsedMS(long)} is invoked will save that elapsed time (fetched by {@link #getOverRideElapsedTimeMS()}) and set the elapsed time to this override time.
-     * 
+     *
      * @param overRideElapsedTimeMS
      */
     public void setOverRideElapsedTimeMS(long overRideElapsedTimeMS) {
@@ -430,7 +429,7 @@ public class Run extends Submission {
 
     /**
      * The run id assigned by a server.
-     * 
+     *
      * @return
      */
     public int internalRunId() {
@@ -440,17 +439,17 @@ public class Run extends Submission {
     public void setOverRideNumber(int number) {
         overrideNumber = number;
     }
-    
+
     public int getOverrideNumber() {
         return overrideNumber;
     }
 
     /**
-     * 
+     *
      * @return a list of the testcase results
      */
     public RunTestCase[] getRunTestCases() {
-        return (RunTestCase[]) testcases.toArray(new RunTestCase[testcases.size()]);
+        return testcases.toArray(new RunTestCase[testcases.size()]);
     }
 
     public void addTestCase(RunTestCase runTestCaseResult) {
@@ -463,20 +462,17 @@ public class Run extends Submission {
 
     /**
      * Set entry point (main file name).
-     * 
+     *
      * Strips path and strips extension.
-     * 
+     *
      * @param name
      */
     public void setEntryPoint(String name) {
         if(name != null) {
-            name = Utilities.getFileBaseName(name);
-            if (name != null){
-                entryPoint = name.toCharArray();
-            }
+            entryPoint = name.toCharArray();
         }
     }
-    
+
     /**
      * Get the entry point, main file, for the submitted source(s).
      * @return
@@ -485,7 +481,7 @@ public class Run extends Submission {
         if (entryPoint != null){
             return new String(entryPoint);
         }
-        
+
         return null;
     }
 }

--- a/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/ExecutableTest.java
@@ -40,7 +40,7 @@ import edu.csus.ecs.pc2.validator.pc2Validator.PC2ValidatorSettings;
 
 /**
  * Test Executable class.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -65,29 +65,30 @@ public class ExecutableTest extends AbstractTestCase {
 
     //a Sumit problem which reads data from stdin
     private Problem iSumitProblem;
-    
-    //a Sumit problem which reads data from stdin and produces floating point output 
+
+    //a Sumit problem which reads data from stdin and produces floating point output
     private Problem iSumitFloatOutputProblem;
-    
+
     // SOMEDAY add test for hello
     private Problem helloWorldProblem = null;
 
     private Language javaLanguage = null;
 
     private String pc2YesJudgement = PC2Validator.JUDGEMENT_YES;
-    
+
     private String pc2NoJudgement = PC2Validator.JUDGEMENT_NO_WRONG_ANSWER;
-    
+
     private String clicsYesJudgement = ClicsValidator.CLICS_CORRECT_ANSWER_MSG;
-    
+
     private String clicsNoJudgement = ClicsValidator.CLICS_WRONG_ANSWER_MSG;
-    
+
     private String clicsWrongOutputSpacingJudgement = ClicsValidator.CLICS_INCORRECT_OUTPUT_FORMAT_MSG;
 
     public ExecutableTest(String string) {
         super(string);
     }
 
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
 
@@ -122,7 +123,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Returns number of failed data sets.
-     * 
+     *
      * @param run
      * @return
      */
@@ -139,7 +140,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Returns number of failed data sets.
-     * 
+     *
      * @param run
      * @return
      */
@@ -156,7 +157,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Create a language using {@link LanguageAutoFill}.
-     * 
+     *
      * @param autoFillLanguageTitle
      *            title for language from {@link LanguageAutoFill}.
      * @return
@@ -172,6 +173,8 @@ public class ExecutableTest extends AbstractTestCase {
         language.setExecutableIdentifierMask(values[2]);
         // programExecutionCommandLineTextField.setText(values[3]);
         language.setProgramExecuteCommandLine(values[3]);
+        language.setInterpreted(LanguageAutoFill.INTERPRETER_VALUE.equals(values[5]));
+        language.setID(values[6]);
 
         return language;
     }
@@ -205,13 +208,13 @@ public class ExecutableTest extends AbstractTestCase {
 
         problem.setPC2ValidatorSettings(settings);
     }
-    
+
     protected void setupMockPC2Validator(Problem problem) {
 
         problem.setValidatorType(VALIDATOR_TYPE.CUSTOMVALIDATOR);
         assertFalse("Not Expecting using pc2 validator", problem.isUsingPC2Validator());
         String mockValidatorCommandLine = "java {:validator} {:infile} {:outfile} {:ansfile} {:resfile} ";
-        problem.setOutputValidatorCommandLine(mockValidatorCommandLine + " -pc2 " + problem.getPC2ValidatorSettings().getWhichPC2Validator() 
+        problem.setOutputValidatorCommandLine(mockValidatorCommandLine + " -pc2 " + problem.getPC2ValidatorSettings().getWhichPC2Validator()
                 + " " + problem.getPC2ValidatorSettings().isIgnoreCaseOnValidation());
         problem.setOutputValidatorProgramName(MOCK_VALIDATOR_NAME);
     }
@@ -219,7 +222,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Create sample Hello world problem with validator add to contest.
-     * 
+     *
      * @param contest2
      * @return
      * @throws FileNotFoundException
@@ -246,7 +249,7 @@ public class ExecutableTest extends AbstractTestCase {
     }
 
     /**
-     * 
+     *
      * @param contest2
      * @return
      * @see #createISumitProblem(IInternalContest)
@@ -287,10 +290,10 @@ public class ExecutableTest extends AbstractTestCase {
      * The difference between this method and method createSumitProblem() is that the Problem created
      * by this method uses the "ISumit" program, which reads its data from stdin (the Problem
      * created by method createSumitProblem() is configured to read data from a file).
-     * 
+     *
      * @param contest2 - the contest to which the Problem will be added
      * @return a new Problem (which has been added to the specified contest)
-     * @throws FileNotFoundException if either the input data file "sumit.in" or the judge's 
+     * @throws FileNotFoundException if either the input data file "sumit.in" or the judge's
      *          answer file "sumit.ans" cannot be found
      * @see #createISumitFloatOutputProblem(IInternalContest)
      */
@@ -304,7 +307,7 @@ public class ExecutableTest extends AbstractTestCase {
         problem.setTimeOutInSeconds(10);
 
         setupUsingPC2Validator(problem);
-        
+
         problem.setReadInputDataFromSTDIN(true);
 
         ProblemDataFiles problemDataFiles = new ProblemDataFiles(problem);
@@ -329,7 +332,7 @@ public class ExecutableTest extends AbstractTestCase {
      * Produces a new file in the Test Output directory which has the same name as the specified
      * file but where the End-of-Line characters in the new file have been converted to the form
      * of the host OS.
-     * 
+     *
      * @param originalFileName the original data file
      * @return the name of a new file with EOL converted
      */
@@ -346,13 +349,13 @@ public class ExecutableTest extends AbstractTestCase {
             }
             br.close();
             bw.close();
-            
+
         } catch (IOException e) {
             System.err.println ("IOException while converting input file '"+ originalFileName + "'");
             e.printStackTrace();
         }
-        
-        
+
+
         return newFilename;
     }
 
@@ -361,10 +364,10 @@ public class ExecutableTest extends AbstractTestCase {
      * The newly-created problem is configured to use the PC2Validator.
      * The difference between this method and method createISumitProblem() is that the Problem created
      * by this method is configured to expect floating-point output.
-     * 
+     *
      * @param contest2 - the contest to which the Problem will be added
      * @return a new Problem (which has been added to the specified contest)
-     * @throws FileNotFoundException if either the input data file "sumit.in" or the judge's 
+     * @throws FileNotFoundException if either the input data file "sumit.in" or the judge's
      *          answer file "sumitFloatOutput.ans" cannot be found
      */
     private Problem createISumitFloatOutputProblem(IInternalContest contest2) throws FileNotFoundException {
@@ -377,7 +380,7 @@ public class ExecutableTest extends AbstractTestCase {
         problem.setTimeOutInSeconds(10);
 
         setupUsingPC2Validator(problem);
-        
+
         problem.setReadInputDataFromSTDIN(true);
 
         ProblemDataFiles problemDataFiles = new ProblemDataFiles(problem);
@@ -399,7 +402,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Create sample LargeOutput problem and add to contest.
-     * 
+     *
      * @param contest2
      * @return
      * @throws FileNotFoundException
@@ -435,7 +438,7 @@ public class ExecutableTest extends AbstractTestCase {
     }
 
     /**
-     * 
+     *
      * @param contest2
      * @return
      * @throws FileNotFoundException
@@ -535,54 +538,54 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, false, pc2YesJudgement);
     }
-    
+
     /**
      * Verifies that the PC2 Validator returns the correct results for all combinations
      * of the "ignoreCase" flag.  The combinations are:  a program which produces the
-     * CORRECT case output, both with ignoreCase=true and ignoreCase=false  (both should succeed); 
+     * CORRECT case output, both with ignoreCase=true and ignoreCase=false  (both should succeed);
      * and a program which produces INCORRECT case output, both with ignoreCase=true (should succeed)
-     * and with ignoreCase=false (should fail). 
-     * 
+     * and with ignoreCase=false (should fail).
+     *
      * @throws Exception if an Exception occurs during the execution of the program (i.e., during invocation of Executable.execute())
      */
     public void testPC2ValidatorIgnoreCaseOption() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
-        
+
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
 
         //set the problem to ignore case and use straight "diff" on validation
         iSumitProblem.getPC2ValidatorSettings().setIgnoreCaseOnValidation(true);
         iSumitProblem.getPC2ValidatorSettings().setWhichPC2Validator(1);
-        
+
         //submit ISumit, which should succeed
         Run run = createRun(submitter, javaLanguage, iSumitProblem, 42, 120);
         RunFiles runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, pc2YesJudgement);
-        
+
         //set the problem to require case sensitivity and use straight "diff" on validation
         iSumitProblem.getPC2ValidatorSettings().setIgnoreCaseOnValidation(false);
         iSumitProblem.getPC2ValidatorSettings().setWhichPC2Validator(1);
-        
+
         //submit ISumit, which should succeed
         run = createRun(submitter, javaLanguage, iSumitProblem, 43, 121);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, pc2YesJudgement);
-        
+
         //submit ISumitWrongCase, which should fail
         run = createRun(submitter, javaLanguage, iSumitProblem, 44, 122);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputCase.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, false, pc2NoJudgement );
-        
+
         //set the problem to ignore case sensitivity and use straight "diff" on validation
         iSumitProblem.getPC2ValidatorSettings().setIgnoreCaseOnValidation(true);
         iSumitProblem.getPC2ValidatorSettings().setWhichPC2Validator(1);
-        
+
         //submit ISumitWrongCase, which should succeed (because case is being ignored)
         run = createRun(submitter, javaLanguage, iSumitProblem, 45, 123);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputCase.java"));
@@ -592,13 +595,13 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Verifies that the PC2 Validator returns the correct results for all combinations
-     * of the "ignore whitespace" option (that is, PC2Validator option 4).  
+     * of the "ignore whitespace" option (that is, PC2Validator option 4).
      * The combinations are:  a program which produces the
      * CORRECT spacing in its output, both with option 1 (require exact spacing, i.e. use "diff" (option 1))
-     * and with option 4 (ignore whitespace in output)  (both should succeed); 
+     * and with option 4 (ignore whitespace in output)  (both should succeed);
      * and a program which produces INCORRECT output spacing, both with option 1 (should fail)
-     * and with option 4 (should succeed). 
-     * 
+     * and with option 4 (should succeed).
+     *
      * @throws Exception if an Exception occurs during the execution of the program (i.e., during invocation of Executable.execute())
      */
     public void testPC2ValidatorIgnoreWhitespaceOption() throws Exception {
@@ -613,185 +616,185 @@ public class ExecutableTest extends AbstractTestCase {
         iSumitProblem.setValidatorType(VALIDATOR_TYPE.PC2VALIDATOR);
         iSumitProblem.getPC2ValidatorSettings().setIgnoreCaseOnValidation(true);
         iSumitProblem.getPC2ValidatorSettings().setWhichPC2Validator(1);
-        
+
         //submit ISumit, which should succeed
         Run run = createRun(submitter, javaLanguage, iSumitProblem, 52, 130);
         RunFiles runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, pc2YesJudgement);
-        
+
         //set the problem to ignore whitespace
         iSumitProblem.getPC2ValidatorSettings().setWhichPC2Validator(4);
-        
+
         //submit ISumit, which should succeed
         run = createRun(submitter, javaLanguage, iSumitProblem, 53, 132);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, pc2YesJudgement);
-        
+
         //submit ISumitWrongOutputSpacing, which should succeed
         run = createRun(submitter, javaLanguage, iSumitProblem, 54, 133);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputSpacing.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, pc2YesJudgement );
-        
-        //set the problem to require whitespace to match 
+
+        //set the problem to require whitespace to match
         iSumitProblem.getPC2ValidatorSettings().setWhichPC2Validator(1);
-        
+
         //submit ISumitWrongOutputSpacing, which should fail (because spacing match is being required)
         run = createRun(submitter, javaLanguage, iSumitProblem, 55, 134);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputSpacing.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, false, pc2NoJudgement );
     }
-    
+
     /**
      * Verifies that the Clics Validator returns the correct results for all combinations
-     * of the "case_sensitive" option.  
+     * of the "case_sensitive" option.
      * The combinations are:  a program which produces the
      * CORRECT case in its output, both with case-sensitivity off and on (both should succeed)
      * and a program which produces INCORRECT case in its output, both with case-sensitivity
      * off (should succeed) and with case-sensitivity on (should fail).
-     * 
+     *
      * @throws Exception if an Exception occurs during the execution of the program (i.e., during invocation of Executable.execute())
      */
     public void testClicsValidatorCaseSensitiveOption() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
-        
+
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
 
         //set the problem to ignore case
         iSumitProblem.setValidatorType(VALIDATOR_TYPE.CLICSVALIDATOR);
         iSumitProblem.getClicsValidatorSettings().setCaseSensitive(false);
-        
+
         //submit ISumit, which should succeed
         Run run = createRun(submitter, javaLanguage, iSumitProblem, 62, 140);
         RunFiles runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         //set the problem to require case match
         iSumitProblem.getClicsValidatorSettings().setCaseSensitive(true);
-        
+
         //submit ISumit, which should succeed
         run = createRun(submitter, javaLanguage, iSumitProblem, 63, 141);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         //submit ISumitWrongOutputCase, which should fail
         run = createRun(submitter, javaLanguage, iSumitProblem, 64, 142);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputCase.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, false, clicsNoJudgement );
-        
-        //set the problem to ignore case 
+
+        //set the problem to ignore case
         iSumitProblem.getClicsValidatorSettings().setCaseSensitive(false);
-        
+
         //submit ISumitWrongOutputCase, which should succeed (because case is being ignored)
         run = createRun(submitter, javaLanguage, iSumitProblem, 65, 143);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputCase.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, clicsYesJudgement );
     }
-    
+
     /**
      * Verifies that the Clics Validator returns the correct results for all combinations
-     * of the "space_sensitive" option.  
+     * of the "space_sensitive" option.
      * The combinations are:  a program which produces the
      * CORRECT spacing in its output, both with space-sensitivity off and on (both should succeed)
      * and a program which produces INCORRECT spacing in its output, both with space-sensitivity
      * off (should succeed) and with case-sensitivity on (should fail).
-     * 
+     *
      * @throws Exception if an Exception occurs during the execution of the program (i.e., during invocation of Executable.execute())
      */
     public void testClicsValidatorSpaceSensitiveOption() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
-        
+
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
 
         //set the problem to ignore spacing
         iSumitProblem.setValidatorType(VALIDATOR_TYPE.CLICSVALIDATOR);
         iSumitProblem.getClicsValidatorSettings().setSpaceSensitive(false);
-        
+
         //submit ISumit, which should succeed
         Run run = createRun(submitter, javaLanguage, iSumitProblem, 62, 140);
         RunFiles runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         //set the problem to require spacing match
         iSumitProblem.getClicsValidatorSettings().setSpaceSensitive(true);
-        
+
         //submit ISumit, which should succeed
         run = createRun(submitter, javaLanguage, iSumitProblem, 63, 141);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumit.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         //submit ISumitWrongOutputSpacing, which should fail
         run = createRun(submitter, javaLanguage, iSumitProblem, 64, 142);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputSpacing.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, false, clicsWrongOutputSpacingJudgement );
-        
-        //set the problem to ignore spacing 
+
+        //set the problem to ignore spacing
         iSumitProblem.getClicsValidatorSettings().setSpaceSensitive(false);
-        
+
         //submit ISumitWrongOutputSpacing, which should succeed (because spacing is being ignored)
         run = createRun(submitter, javaLanguage, iSumitProblem, 65, 143);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitWrongOutputSpacing.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
         runExecutableTest(run, runFiles, true, clicsYesJudgement );
     }
-    
+
     /**
      * Verifies that the Clics Validator returns the correct results for all combinations
-     * of the "Relative Tolerance" option. The combinations are:  
+     * of the "Relative Tolerance" option. The combinations are:
      * - a program that produces a floating-point output value that matches exactly the judge's answer when relative tolerance is disabled (should succeed)
      * - a program that produces a floating point value that doesn't match exactly the judge's answer when relative tolerance is disabled (should fail)
      * - a program that produces a floating-point value that matches exactly the judge's answer with relative tolerance enabled (should succeed regardless of tolerance value)
      * - a program that produces a floating-point value within the specified relative tolerance of the judge's answer (should succeed)
      * - a program that produces a floating-point value outside the specified relative tolerance of the judge's answer (should fail)
-     * 
+     *
      * @throws Exception if an Exception occurs during the execution of the program (i.e., during invocation of Executable.execute())
      */
     public void testClicsValidatorRelativeToleranceOption() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
-        
+
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
 
         //set the problem state to ignore tolerances
         iSumitFloatOutputProblem.setValidatorType(VALIDATOR_TYPE.CLICSVALIDATOR);
         iSumitFloatOutputProblem.getClicsValidatorSettings().disableFloatRelativeTolerance();
         iSumitFloatOutputProblem.getClicsValidatorSettings().disableFloatAbsoluteTolerance();
-        
-        // submit a program that produces a floating-point output value that matches exactly the judge's answer 
+
+        // submit a program that produces a floating-point output value that matches exactly the judge's answer
         // when relative tolerance is disabled (should succeed)
         Run run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 71, 171);
         RunFiles runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitFloatOutput.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutput with relative tolerance disabled (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
-        // submit a program that produces a floating point value that doesn't match exactly the judge's answer 
+
+        // submit a program that produces a floating point value that doesn't match exactly the judge's answer
         // when relative tolerance is disabled (should fail)
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 72, 172);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitFloatOutputTenUnitsOff.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutputTenUnitsOff with relative tolerance disabled (should fail)");
         runExecutableTest(run, runFiles, false, clicsNoJudgement);
-        
-        // submit a program that produces a floating-point value that matches exactly the judge's answer 
+
+        // submit a program that produces a floating-point value that matches exactly the judge's answer
         // with relative tolerance enabled (should succeed regardless of tolerance value)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatRelativeTolerance(0.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 73, 173);
@@ -799,7 +802,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutput with relative tolerance of zero (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // try the same thing with a wildly different relative tolerance value (should succeed)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatRelativeTolerance(10000.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 74, 174);
@@ -807,7 +810,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutput with relative tolerance of 10000 (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // try the same thing with another wildly different relative tolerance value (should succeed)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatRelativeTolerance(-10000.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 75, 175);
@@ -815,7 +818,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutput with relative tolerance of -10000 (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // submit a program that produces a floating-point value within the specified tolerance of the judge's answer (should succeed)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatRelativeTolerance(0.15);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 76, 176);
@@ -823,7 +826,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutputTenPercentOff with relative tolerance of 15% (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // submit a program that produces a floating-point value outside the specified tolerance of the judge's answer (should fail)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatRelativeTolerance(0.05);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 77, 177);
@@ -831,50 +834,50 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorRelativeToleranceOption(): ISumitFloatOutputTenPercentOff with relative tolerance of 5% (should fail)");
         runExecutableTest(run, runFiles, false, clicsNoJudgement);
-        
+
     }
-    
+
     /**
      * Verifies that the Clics Validator returns the correct results for all combinations
-     * of the "Absolute Tolerance" option. The combinations are:  
+     * of the "Absolute Tolerance" option. The combinations are:
      * - a program that produces a floating-point output value that matches exactly the judge's answer when absolute tolerance is disabled (should succeed)
      * - a program that produces a floating point value that doesn't match exactly the judge's answer when absolute tolerance is disabled (should fail)
      * - a program that produces a floating-point value that matches exactly the judge's answer with absolute tolerance enabled (should succeed regardless of tolerance value)
      * - a program that produces a floating-point value within the specified absolute tolerance of the judge's answer (should succeed)
      * - a program that produces a floating-point value outside the specified absolute tolerance of the judge's answer (should fail)
-     * 
+     *
      * @throws Exception if an Exception occurs during the execution of the program (i.e., during invocation of Executable.execute())
      */
     public void testClicsValidatorAbsoluteToleranceOption() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
-        
+
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
 
         //set the problem state to ignore tolerances
         iSumitFloatOutputProblem.setValidatorType(VALIDATOR_TYPE.CLICSVALIDATOR);
         iSumitFloatOutputProblem.getClicsValidatorSettings().disableFloatAbsoluteTolerance();
         iSumitFloatOutputProblem.getClicsValidatorSettings().disableFloatRelativeTolerance();
-        
-        // submit a program that produces a floating-point output value that matches exactly the judge's answer 
+
+        // submit a program that produces a floating-point output value that matches exactly the judge's answer
         // when absolute tolerance is disabled (should succeed)
         Run run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 81, 181);
         RunFiles runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitFloatOutput.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutput with absolute tolerance disabled (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
-        // submit a program that produces a floating point value that doesn't match exactly the judge's answer 
+
+        // submit a program that produces a floating point value that doesn't match exactly the judge's answer
         // when absolute tolerance is disabled (should fail)
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 82, 182);
         runFiles = new RunFiles(run, getSamplesSourceFilename("ISumitFloatOutputTenUnitsOff.java"));
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutputTenUnitsOff with absolute tolerance disabled (should fail)");
         runExecutableTest(run, runFiles, false, clicsNoJudgement);
-        
-        // submit a program that produces a floating-point value that matches exactly the judge's answer 
+
+        // submit a program that produces a floating-point value that matches exactly the judge's answer
         // with absolute tolerance enabled (should succeed regardless of tolerance value)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatAbsoluteTolerance(0.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 83, 183);
@@ -882,7 +885,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutput with absolute tolerance of zero (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // try the same thing with a wildly different absolute tolerance value (should succeed)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatAbsoluteTolerance(10000.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 84, 184);
@@ -890,7 +893,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutput with absolute tolerance of 10000 (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // try the same thing with another wildly different absolute tolerance value (should succeed)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatAbsoluteTolerance(-10000.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 85, 185);
@@ -898,7 +901,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutput with absolute tolerance of -10000 (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // submit a program that produces a floating-point value within the specified absolute tolerance of the judge's answer (should succeed)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatAbsoluteTolerance(15.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 86, 186);
@@ -906,7 +909,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutputTenUnitsOff with absolute tolerance of 15 (should succeed)");
         runExecutableTest(run, runFiles, true, clicsYesJudgement);
-        
+
         // submit a program that produces a floating-point value outside the specified tolerance of the judge's answer (should fail)
         iSumitFloatOutputProblem.getClicsValidatorSettings().setFloatAbsoluteTolerance(5.0);
         run = createRun(submitter, javaLanguage, iSumitFloatOutputProblem, 87, 187);
@@ -914,7 +917,7 @@ public class ExecutableTest extends AbstractTestCase {
         contest.setClientId(getLastAccount(Type.JUDGE).getClientId());
 //        System.out.println ("Running testClicsValidatorAbsoluteToleranceOption(): ISumitFloatOutputTenUnitsOff with absolute tolerance of 5 (should fail)");
         runExecutableTest(run, runFiles, false, clicsNoJudgement);
-        
+
     }
 
     protected Executable runExecutableTest(Run run, RunFiles runFiles, boolean solved, String expectedJudgement) throws Exception {
@@ -923,7 +926,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Invoke a executable test.
-     * 
+     *
      * @param run
      * @param runFiles
      * @param solved
@@ -944,7 +947,7 @@ public class ExecutableTest extends AbstractTestCase {
         executable.execute();
 
         ExecutionData executionData = executable.getExecutionData();
-        
+
         // TODO 917  dumpRunTestCases(run);
 
         // System.out.println("expectedJudgement  = " + expectedJudgement);
@@ -1038,7 +1041,7 @@ public class ExecutableTest extends AbstractTestCase {
             count++;
         }
         System.out.println("There are " + runTestCases.length + " test cases ");
-        
+
     }
 
     private Account getFirstJudge() {
@@ -1088,15 +1091,16 @@ public class ExecutableTest extends AbstractTestCase {
 
     }
 
+    @Override
     protected void tearDown() throws Exception {
         super.tearDown();
     }
 
     /**
      * Executable class with override for executable directory.
-     * 
+     *
      * Executable creates a directory based on execute site and client id, this class allows for an override of that execute directory, especially for testing purposes with multi-threaded tests.
-     * 
+     *
      * @author pc2@ecs.csus.edu
      * @version $Id$
      */
@@ -1105,7 +1109,7 @@ public class ExecutableTest extends AbstractTestCase {
     class ExecutableOverride extends Executable {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = -6045865627706850495L;
 
@@ -1121,6 +1125,7 @@ public class ExecutableTest extends AbstractTestCase {
             return executeDirectoryName;
         }
 
+        @Override
         public void setExecuteDirectoryName(String directory) {
             this.executeDirectoryName = directory;
         }
@@ -1168,70 +1173,70 @@ public class ExecutableTest extends AbstractTestCase {
         String actual = executeUtilities.substituteAllStrings(origString);
         assertEquals(expected, actual);
     }
-    
+
     /**
      * test {files} substitution.
-     * 
+     *
      * Bug 1244.
-     * 
+     *
      * @throws Exception
      */
     public void testSubstituteFiles() throws Exception {
-        
+
         String executeDirectoryName = getOutputDataDirectory(getName());
         ensureDirectory(executeDirectoryName);
-        
+
         String sumitFilename = getSamplesSourceFilename("ISumit.java");
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
         Problem problem = createHelloProblemNoJudgesData(contest);
-        
+
         Run run = createRun(submitter, javaLanguage, problem, 2, 2);
         assertFileExists(sumitFilename);
-        
+
         RunFiles runFiles = new RunFiles(run, sumitFilename);
-        
+
         Executable executable = new Executable(contest, controller, run, runFiles);
         executable.setExecuteDirectoryName(executeDirectoryName);
         executable.setUsingGUI(false);
-        
+
         String actual = executable.substituteAllStrings(run, "foo {files}");
-        
+
         assertEquals("Expected substitution", "foo ISumit.java", actual);
     }
-    
+
     /**
      * test {:ensuresuffix=xxx} substitution.
-     * 
+     *
      * @throws Exception
      */
     public void testCondSuffixSubstitute() throws Exception {
-        
+
         String executeDirectoryName = getOutputDataDirectory(getName());
         ensureDirectory(executeDirectoryName);
-        
+
         String sumitFilename = getSamplesSourceFilename("ISumit.java");
         ClientId submitter = contest.getAccounts(Type.TEAM).lastElement().getClientId();
         Problem problem = createHelloProblemNoJudgesData(contest);
-        
+
         Run run = createRun(submitter, javaLanguage, problem, 2, 2);
         assertFileExists(sumitFilename);
-        
+
         RunFiles runFiles = new RunFiles(run, sumitFilename);
-        
+
         Executable executable = new Executable(contest, controller, run, runFiles);
         executable.setExecuteDirectoryName(executeDirectoryName);
         executable.setUsingGUI(false);
-        
+
         String actual = executable.substituteAllStrings(run, "foo {:basename}{:ensuresuffix=it}");
-        
+
         assertEquals("Expected substitution", "foo ISumit", actual);
-        
+
         actual = executable.substituteAllStrings(run, "{:basename}{:ensuresuffix=Kt}");
-        
+
         assertEquals("Expected substitution", "ISumitKt", actual);
-        
+
         actual = executable.substituteAllStrings(run, "kotlin {:basename}{:ensuresuffix=Kt}{:ensuresuffix=Kt} {:basename}{:ensuresuffix=ISumit}{:ensuresuffix=Kt}");
-        
+
         assertEquals("Expected substitution", "kotlin ISumitKtKt ISumitKt", actual);
     }
 
@@ -1264,7 +1269,7 @@ public class ExecutableTest extends AbstractTestCase {
     }
 
     /**
-     * 
+     *
      * @param contest2
      * @return
      * @throws FileNotFoundException
@@ -1299,7 +1304,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Bug TODO - no judge data file specified
-     * 
+     *
      * @throws Exception
      */
     public void testValidateMissingJudgesDataFile() throws Exception {
@@ -1324,7 +1329,7 @@ public class ExecutableTest extends AbstractTestCase {
         Map<String, String> map = System.getenv();
 
         Set<String> keys = map.keySet();
-        String[] names = (String[]) keys.toArray(new String[keys.size()]);
+        String[] names = keys.toArray(new String[keys.size()]);
         Arrays.sort(names);
 
         for (String name : names) {
@@ -1471,7 +1476,7 @@ public class ExecutableTest extends AbstractTestCase {
     }
 
     public void testMultipleTestCaseExternalFile() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
@@ -1507,7 +1512,7 @@ public class ExecutableTest extends AbstractTestCase {
     }
 
     public void testMultipleTestCaseInternalFile() throws Exception {
-        
+
         if (isFastJUnitTesting()){
             return;
         }
@@ -1703,7 +1708,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Create a multiple test case sumit problem.
-     * 
+     *
      * @param contest2
      * @param externalFiles
      * @return
@@ -1779,7 +1784,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Load problemdatafiles from directory
-     * 
+     *
      * @param problem
      * @param problemDataFiles
      * @param dataFilesDirectory
@@ -1818,7 +1823,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Submit hello world program for sumit problem.
-     * 
+     *
      * @throws Exception
      */
     public void testValidationFailure() throws Exception {
@@ -1834,7 +1839,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Test validation results for runs that fail validation.
-     * 
+     *
      * @param run
      * @param executable
      * @param expectedPassingTestCases
@@ -1859,7 +1864,7 @@ public class ExecutableTest extends AbstractTestCase {
 
     /**
      * Test where all test cases are tried/tested.
-     * 
+     *
      * @throws Exception
      */
     public void testMiddleFailure() throws Exception {
@@ -1891,8 +1896,8 @@ public class ExecutableTest extends AbstractTestCase {
 
         assertValidationFailure(run, executable, 1, 6, noJudgement);
     }
-    
-    
+
+
     /**
      * Test where on first failed test case, does not test the remaining tests.
      * @throws Exception
@@ -1931,7 +1936,7 @@ public class ExecutableTest extends AbstractTestCase {
 
         assertValidationFailure(run, executable, 0, 1, noJudgement);
     }
-    
+
     public void testsubstituteFiles() throws Exception {
         SampleContest sampleContest = new SampleContest();
         IInternalContest contest = sampleContest.createContest(2, 2, 12, 12, true);
@@ -1971,5 +1976,5 @@ public class ExecutableTest extends AbstractTestCase {
         assertEquals("Expected file list ", expected, filelist);
 
     }
-    
+
 }


### PR DESCRIPTION
### Description of what the PR does
If an `entry_point `was specified in a "**submissions**" event on the event-feed that contained a package (for Java) or an explicit file (for Python3), the run would fail (_compile error_ for Java and _Run time Exception_ for Python3). Add code to handle the special cases for each language that can specify an entry point. Code works the same as before if no `entry_point `specified.
Remove pruning of `entry_point `when it is set in the **Run**.   This was removing important information for Java entry points with package information specified and extensions on Python files.

CI: Add constant for {files} command substitution string and change in places it's used.
NOTE: This may relate to issue #869 in that the {files} substitution variable is mistyped in the code perhaps.  It should be {:files} probably.  That change is not part of this code, but it is now easier to fix that, should we decide to do it.  It's unclear if if {files} is a type or legacy nomenclature.

### Issue which the PR addresses
Fixes #942 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Java jdk1.8.0_321

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Refer to the issue #942.  This is very difficult to test without a shadow system, and the procedure described there is lengthy and involved.

A good thorough code review is probably a good first step.

