### PR TITLE
i_954,955 Fix awards.json compare and results.tsv generation

### DIFF
--- a/src/edu/csus/ecs/pc2/core/report/FileComparisonUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/FileComparisonUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.File;
@@ -248,7 +248,7 @@ public class FileComparisonUtilities {
 
                     fieldName = "team_ids";
                     valueOne = formatTeamList(firstAward.getTeam_ids());
-                    valueTwo = formatTeamList(firstAward.getTeam_ids());
+                    valueTwo = formatTeamList(clicsAward.getTeam_ids());
                     fieldCompareRecord = new FieldCompareRecord(fieldName, valueOne, valueTwo, null, key);
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
                     

--- a/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
@@ -106,9 +106,15 @@ public class ResultsFile {
 
         int median = getMedian(standingsRecords);
 
+        // if not finalized, make up "best guess" data.
+        // There should be constants somewhere that give the "current" gold/silver/bronze ranks; note that
+        // FinalizePane hard codes 4, 8, 12 in the text fields *ARGH*
+        // Should also be able to read the defaults at startup from the config files
+        // Here we just cobble together some half-assed finalized data
         if (finalizeData == null) {
-            String [] badbad = {"Contest not finalized cannot create awards"};
-            return badbad;
+            finalizeData = GenDefaultFinalizeData();
+//            String [] badbad = {"Contest not finalized cannot create awards"};
+//            return badbad;
         }
 
         // TODO finalizeData really needs a B instead of getBronzeRank
@@ -210,7 +216,7 @@ public class ResultsFile {
     }
 
     /**
-     * Create CCS restuls.tsv file contents.
+     * Create CCS results.tsv file contents.
      *
      * @param contest
      * @param resultFileTitleFieldName override title anem {@value #DEFAULT_RESULT_FIELD_NAME}.
@@ -249,8 +255,9 @@ public class ResultsFile {
         int median = getMedian(standingsRecords);
 
         if (finalizeData == null) {
-            String [] badbad = {"Contest not finalized cannot create awards"};
-            return badbad;
+            finalizeData = GenDefaultFinalizeData();
+//            String [] badbad = {"Contest not finalized cannot create awards"};
+//            return badbad;
         }
 
         // TODO finalizeData really needs a B instead of getBronzeRank
@@ -377,4 +384,18 @@ public class ResultsFile {
         return XMLUtilities.transformToArray(xmlString, xsltFileName);
     }
 
+    /**
+     * Generate some default finalize data so we can make a results.tsv before the contest is finalized.
+     * @return FinalizeData object
+     */
+    private FinalizeData GenDefaultFinalizeData()
+    {
+        finalizeData = new FinalizeData();
+        finalizeData.setGoldRank(4);
+        finalizeData.setSilverRank(8);
+        finalizeData.setBronzeRank(12);
+        finalizeData.setCertified(false);
+        finalizeData.setComment("Preliminary Results - Contest not Finalized");
+        return(finalizeData);
+    }
 }


### PR DESCRIPTION
### Description of what the PR does
Fix bug in `FileComparisionUtilities `where the  same value was being compared to itself for team ID lists. Create dummy `FinalizeData `object if contest is not yet finalized.

### Issue which the PR addresses
Fixes #954 #955 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
jdk1.8.0_351

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Use the folders in `testdata\FileComparisonUtilitiesTest\resultscompwork\results` and the `awards.json` file under **domjudge** and **pc2**.
2. Change the team id list in one of the `awards.json` files for one or more citations.
3. Run the **Results Compare** from an administrator.

Note that the the comparison on` awards.json `now fails as expected.

On an unfinalized contest, attempt to generate a` results.tsv` report from an administrator or server.
The file is now generated.