### PR TITLE
I 423, I 765 dynamically update shadow compare runs table, show only missmatched runs

### DIFF
--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -1052,7 +1052,8 @@ public class ShadowController {
             for (String key : currentJudgementMap.keySet()) {
 
                 ShadowJudgementPair pair = currentJudgementMap.get(key).getShadowJudgementPair();
-                if (! pair.getPc2Judgement().equals(pair.getRemoteCCSJudgement())) {
+                if ((! pair.getPc2Judgement().equals(pair.getRemoteCCSJudgement())) && 
+                        ! pair.getPc2Judgement().equals("<pending>") &&  !pair.getRemoteCCSJudgement().equals("<pending>") ){//When one of the judgement is pending it will be filtered out
                     newJudgementMap.put(key,currentJudgementMap.get(key));
                 }
             }

--- a/src/edu/csus/ecs/pc2/shadow/ShadowController.java
+++ b/src/edu/csus/ecs/pc2/shadow/ShadowController.java
@@ -97,7 +97,7 @@ public class ShadowController {
     }
     public enum FILTERS {
         NONE,
-        ONLY_MISSMATCH
+        ONLY_MISMATCH
     }
     
     private SHADOW_CONTROLLER_STATUS controllerStatus = null ;
@@ -1047,7 +1047,7 @@ public class ShadowController {
      * @return currentJudgementMap but judgements that shouldnt be shown is removed.
      */
     public Map<String, ShadowJudgementInfo> filterJudgmenentMap(Map<String, ShadowJudgementInfo> currentJudgementMap) {
-        if (getFilter().equals(FILTERS.ONLY_MISSMATCH)) {
+        if (getFilter().equals(FILTERS.ONLY_MISMATCH)) {
             Map<String, ShadowJudgementInfo> newJudgementMap = new HashMap<String, ShadowJudgementInfo>();
             for (String key : currentJudgementMap.keySet()) {
 

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -340,7 +340,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     }
     
     /**
-     * Initialized dynamically refresh panel that contains checkbox,textfield and label for auto refreshing.
+     * Initialized dynamically refresh panel that contains checkbox, textfield and label for auto refreshing.
      * @return
      */
     private JPanel getdynamicallyRefreshPanel() {
@@ -370,6 +370,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
                             Toolkit.getDefaultToolkit().beep();
                         }
                     } catch (NumberFormatException e) {
+                        //catch if user tries to enter non numeric chars.
                         Toolkit.getDefaultToolkit().beep();
                     }
                     
@@ -386,31 +387,30 @@ public class ShadowCompareRunsPane extends JPanePlugin {
                     
                     if (e.getStateChange() == ItemEvent.SELECTED) {
                         if (textField.getText().isEmpty()) {
-                            JOptionPane.showMessageDialog(null, "Please enter a value to textField", "Error", JOptionPane.ERROR_MESSAGE);
+                            JOptionPane.showMessageDialog(null, "Please specify the number of seconds between refreshes (1-60)", "Error", JOptionPane.ERROR_MESSAGE);
                             return;
                         }
-                        int time;
+                        int duration;
                         try {
-                            time = Integer.parseInt(textField.getText());
-                            if (time < 1) {
-                                log.log(Log.WARNING, "dynamicallyRefreshPanel received time less than 1"+ textField.getText());
-                                throw new IllegalArgumentException("Time value cannot be less than 1, time is : " + time);
+                            duration = Integer.parseInt(textField.getText());
+                            if (duration < 1) {
+                                log.log(Log.WARNING, "dynamicallyRefreshPanel received duration less than 1. It received: "+ textField.getText());
+                                throw new IllegalArgumentException("Duration value cannot be less than 1, time is : " + duration);
                             }
-                            if (time > 60) {
-                                log.log(Log.WARNING, "dynamicallyRefreshPanel received time more than 60"+ textField.getText());
-                                throw new IllegalArgumentException("Time value cannot be more than 60, time is:  " + time);
+                            if (duration > 60) {
+                                log.log(Log.WARNING, "dynamicallyRefreshPanel received duration more than 60. It received: "+ textField.getText());
+                                throw new IllegalArgumentException("Duration value cannot be more than 60, time is: " + duration);
                             }
                         } catch (NumberFormatException a) {
-                            // Handle the case where the text cannot be parsed as an integer
-                            log.log(Log.WARNING, "dynamicallyRefreshPanel did not receive an integer for time. It received"+ textField.getText());
-                            throw new NumberFormatException("dynamicallyRefreshPanel did not receive an integer for time. It received: " + textField.getText());
+                            log.log(Log.WARNING, "dynamicallyRefreshPanel did not receive an integer for duration. It received: "+ textField.getText());
+                            throw new NumberFormatException("dynamicallyRefreshPanel did not receive an integer for duration. It received: " + textField.getText());
                         }
                         SwingUtilities.invokeLater(new Runnable() {
                             public void run() {
                                 refreshResultsTable();
                             }
                         });
-                        timer = new Timer(time * 1000, new ActionListener() {
+                        timer = new Timer(duration * 1000, new ActionListener() {
                             @Override
                             public void actionPerformed(ActionEvent e) {
                                 
@@ -423,7 +423,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
                             }
                         });
                         textField.setEnabled(false);
-                        log.log(Log.INFO, "Shadow table will be dynamically refreshed every " + time + " seconds.");  
+                        log.log(Log.INFO, "Shadow table will be dynamically refreshed every " + duration + " seconds.");  
                         timer.start();
                     } 
                     else {

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -339,6 +339,10 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         
     }
     
+    /**
+     * Initialized dynamically refresh panel that contains checkbox,textfield and label for auto refreshing.
+     * @return
+     */
     private JPanel getdynamicallyRefreshPanel() {
         
         if (dynamicallyRefreshPanel == null) {

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -85,6 +85,8 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     //the current judgement information from the shadow controller
     private Map<String, ShadowJudgementInfo> currentJudgementMap = null;
     
+    private Map<String, ShadowJudgementInfo> filteredJudgementMap = null;
+    
     //the table displaying the current results
     private JTable resultsTable = null ;
     
@@ -102,6 +104,8 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     private JPanel dynamicallyRefreshPanel;
     
     private String defaultDuration = "5";
+    
+    private JCheckBox mismatchCheckBox;
 
     @Override
     public String getPluginTitle() {
@@ -242,18 +246,18 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         
         //get the current judgement information from the shadow controller
         currentJudgementMap = shadowController.getJudgementComparisonInfo();
-        currentJudgementMap = shadowController.filterJudgmenentMap(currentJudgementMap);
+        filteredJudgementMap = shadowController.filterJudgmenentMap(currentJudgementMap);  //We don't want summaryPanel to count only mismatches for the summary. This prevents it.
         //define the columns for the table
         String[] columnNames = { "Team", "Problem", "Language", "Submission ID", "PC2 Shadow", "Remote CCS", "Match?", "Overridden?" };
         
         //an array to hold the table data
-        Object[][] data = new Object[currentJudgementMap.size()][8];
+        Object[][] data = new Object[filteredJudgementMap.size()][8];
         
         //fill in each data row with info from the shadow controller's judgement map
         int row = 0;
-        for (String key : currentJudgementMap.keySet()) {
+        for (String key : filteredJudgementMap.keySet()) {
             
-            ShadowJudgementInfo curJudgementInfo = currentJudgementMap.get(key);
+            ShadowJudgementInfo curJudgementInfo = filteredJudgementMap.get(key);
             data[row][0] = new Integer(Utilities.nullSafeToInt(curJudgementInfo.getTeamID(), 0));
             data[row][1] = curJudgementInfo.getProblemID();
             data[row][2] = curJudgementInfo.getLanguageID();
@@ -446,7 +450,15 @@ public class ShadowCompareRunsPane extends JPanePlugin {
             Component horizontalStrut2 = Box.createHorizontalStrut(40);
             dynamicallyRefreshPanel.add(horizontalStrut2);
             
-            JCheckBox mismatchCheckBox = new JCheckBox("Only Mismatched");
+            
+            dynamicallyRefreshPanel.add(getmismatchCheckBox());
+        }
+        return dynamicallyRefreshPanel;
+    }
+    
+    private JCheckBox getmismatchCheckBox() {
+        if (mismatchCheckBox == null) {
+            mismatchCheckBox = new JCheckBox("Only Mismatched");
             mismatchCheckBox.setToolTipText("When toggled, table will only display when pc2 and remote ccs' judgements do not match");
             
             mismatchCheckBox.addItemListener(new ItemListener() {
@@ -472,11 +484,9 @@ public class ShadowCompareRunsPane extends JPanePlugin {
                     }
                 }
             });
-            dynamicallyRefreshPanel.add(mismatchCheckBox);
         }
-        return dynamicallyRefreshPanel;
+        return mismatchCheckBox;
     }
-    
     private JComponent getButtonPanel() {
         
         JPanel buttonPanel = new JPanel();

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -80,6 +80,8 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     
     private static final int RUN_UPDATE_REQUEST_SERVER_TIMEOUT_MILLIS = 30000;
     
+    private static final String DEFAULT_REFRESH_INTERVAL = "5";
+    
     private ShadowController shadowController = null ;
     
     //the current judgement information from the shadow controller
@@ -102,9 +104,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     private boolean serverHasUpdatedOurRun;
     
     private JPanel dynamicallyRefreshPanel;
-    
-    private String defaultDuration = "5";
-    
+        
     private JCheckBox mismatchCheckBox;
 
     @Override
@@ -244,9 +244,11 @@ public class ShadowCompareRunsPane extends JPanePlugin {
      */
     private TableModel getUpdatedResultsTableModel() {
         
-        //get the current judgement information from the shadow controller
+        //get the current judgment information from the shadow controller
         currentJudgementMap = shadowController.getJudgementComparisonInfo();
-        filteredJudgementMap = shadowController.filterJudgmenentMap(currentJudgementMap);  //We don't want summaryPanel to count only mismatches for the summary. This prevents it.
+        
+        //We don't want summaryPanel to count only mismatches for the summary. Below prevents it.
+        filteredJudgementMap = shadowController.filterJudgmenentMap(currentJudgementMap);
         //define the columns for the table
         String[] columnNames = { "Team", "Problem", "Language", "Submission ID", "PC2 Shadow", "Remote CCS", "Match?", "Overridden?" };
         
@@ -362,7 +364,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
             dynamicallyRefreshPanel.add(checkbox);
             
             
-            JTextField textField = new JTextField(defaultDuration,2);
+            JTextField textField = new JTextField(DEFAULT_REFRESH_INTERVAL,2);
             ((AbstractDocument) textField.getDocument()).setDocumentFilter(new DocumentFilter() { //Makes the textfield so that user is not allowed to enter illegal numbers.
                 @Override
                 public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.Box;
-//import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -101,6 +100,8 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     private boolean serverHasUpdatedOurRun;
     
     private JPanel dynamicallyRefreshPanel;
+    
+    private String defaultDuration = "5";
 
     @Override
     public String getPluginTitle() {
@@ -357,7 +358,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
             dynamicallyRefreshPanel.add(checkbox);
             
             
-            JTextField textField = new JTextField("5",2);
+            JTextField textField = new JTextField(defaultDuration,2);
             ((AbstractDocument) textField.getDocument()).setDocumentFilter(new DocumentFilter() { //Makes the textfield so that user is not allowed to enter illegal numbers.
                 @Override
                 public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {
@@ -445,21 +446,33 @@ public class ShadowCompareRunsPane extends JPanePlugin {
             Component horizontalStrut2 = Box.createHorizontalStrut(40);
             dynamicallyRefreshPanel.add(horizontalStrut2);
             
-            JCheckBox missMatchCheckBox = new JCheckBox("Only Missmatched");
-            missMatchCheckBox.setToolTipText("When toggled, table will only display when pc2 and remote ccs' judgements do not match");
+            JCheckBox mismatchCheckBox = new JCheckBox("Only Mismatched");
+            mismatchCheckBox.setToolTipText("When toggled, table will only display when pc2 and remote ccs' judgements do not match");
             
-            missMatchCheckBox.addItemListener(new ItemListener() {
+            mismatchCheckBox.addItemListener(new ItemListener() {
                 @Override
                 public void itemStateChanged(ItemEvent e) {
                     if (e.getStateChange() == ItemEvent.SELECTED) {
-                        shadowController.setFilter(FILTERS.ONLY_MISSMATCH);
+                        
+                        shadowController.setFilter(FILTERS.ONLY_MISMATCH);
+                        SwingUtilities.invokeLater(new Runnable() {
+                            public void run() {
+                                refreshResultsTable();
+                            }
+                        });
                     }
                     else {
+                        
                         shadowController.setFilter(FILTERS.NONE);
+                        SwingUtilities.invokeLater(new Runnable() {
+                            public void run() {
+                                refreshResultsTable();
+                            }
+                        });
                     }
                 }
             });
-            dynamicallyRefreshPanel.add(missMatchCheckBox);
+            dynamicallyRefreshPanel.add(mismatchCheckBox);
         }
         return dynamicallyRefreshPanel;
     }


### PR DESCRIPTION
### Description of what the PR does
adds dynamically refresh panel that contains text field for user to enter time. Table will refresh every given time. Checks for disallowing user to enter illegal values to text field has been implemented as well.

### Issue which the PR addresses
fixes #423 
fixes #765 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
From event feeder select shadow mode. Start the contest (from admin) and press start shadowing. Click compare run. Observe there is a new checkbox and text field at bottom left corner. Try entering illegal values. Notice it will not allow or throw an JOptionPane warning. Click the checkbox to activate auto refresh after inputting time. Observe table auto refreshes. 