### PR TITLE
I 960 Generate event-feed.ndjson as part of Results Export Report

### DIFF
--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -12,6 +12,8 @@ public final class Constants {
 
     public final static String SCOREBOARD_JSON_FILENAME = "scoreboard.json";
 
+    public final static String EVENT_FEED_JSON_FILENAME = "event-feed.ndjson";
+
     public static final long HOURS_PER_DAY = 24;
 
     private Constants() {

--- a/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.File;
@@ -17,18 +17,19 @@ import edu.csus.ecs.pc2.core.imports.clics.CLICSAwardUtilities;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
+import edu.csus.ecs.pc2.services.core.EventFeedJSON;
 import edu.csus.ecs.pc2.services.core.ScoreboardJson;
 
 public class ExportFilesUtilities {
 
     /**
      * Write contest results files to directory.
-     * 
+     *
      * Creates contest result files
      * <li>{@link ResultsFile.RESULTS_FILENAME}
      * <li>{@link Constants.SCOREBOARD_JSON_FILENAME}
      * <li>{@link Constants.AWARDS_JSON_FILENAME}
-     * 
+     *
      * @param contest
      * @param outputDirectory
      *            directory to write reports to.
@@ -43,6 +44,8 @@ public class ExportFilesUtilities {
         String scoreboardJsonFilename = outputDirectory + File.separator + Constants.SCOREBOARD_JSON_FILENAME;
 
         String awardsFileName = outputDirectory + File.separator + Constants.AWARDS_JSON_FILENAME;
+
+        String eventfeedJsonFilename = outputDirectory + File.separator + Constants.EVENT_FEED_JSON_FILENAME;
 
         try {
             ResultsFile resultsFile = new ResultsFile();
@@ -85,6 +88,20 @@ public class ExportFilesUtilities {
             ExecuteUtilities.rethrow(e);
         }
 
-        return (String[]) filesCreated.toArray(new String[filesCreated.size()]);
+        try {
+            EventFeedJSON efEventFeedJSON = new EventFeedJSON(contest);
+            String json = efEventFeedJSON.createJSON(contest, null, null);
+            String[] eventfeedJsonLines = { json };
+            FileUtilities.writeFileContents(eventfeedJsonFilename, eventfeedJsonLines);
+
+            filesCreated.add(eventfeedJsonFilename);
+
+        } catch (Exception e) {
+            StaticLog.getLog().log(Level.WARNING, "Problem writing event-feed JSON file", e);
+            Utilities.printStackTrace(System.out, e);
+            ExecuteUtilities.rethrow(e);
+        }
+
+        return filesCreated.toArray(new String[filesCreated.size()]);
     }
 }

--- a/src/edu/csus/ecs/pc2/core/report/ResultsExportReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/ResultsExportReport.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.File;
@@ -24,7 +24,7 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
 
 public class ResultsExportReport implements IReport {
-    
+
     private IInternalContest contest;
 
     private IInternalController controller;
@@ -34,11 +34,11 @@ public class ResultsExportReport implements IReport {
     private Filter filter = new Filter();
 
     private String pc2ResultsDir = null;
-    
+
     private String primaryCCSResultsDir = null;
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -796328654541676730L;
 
@@ -67,7 +67,7 @@ public class ResultsExportReport implements IReport {
 
     @Override
     public void createReportFile(String filename, Filter inFilter) throws IOException {
-        
+
         PrintWriter printWriter = new PrintWriter(new FileOutputStream(filename, false), true);
         filter = inFilter;
 
@@ -85,7 +85,7 @@ public class ResultsExportReport implements IReport {
 
             printWriter.close();
             printWriter = null;
-            
+
         }
 
         catch (RuntimeException rte) {
@@ -98,24 +98,24 @@ public class ResultsExportReport implements IReport {
             printWriter.println("Exception generating report " + rte.getMessage());
             throwable.printStackTrace(printWriter);
         }
-        
+
         catch (Exception e) {
             log.log(Log.INFO, "Exception writing report", e);
             printWriter.println("Exception generating report " + e.getMessage());
         }
     }
 
-    
+
     public String getReportFileName (IReport selectedReport, String extension) {
-       
+
         return getReportBaseFileName(selectedReport, "txt");
     }
-    
+
     public String getAltReportDirname (IReport selectedReport, String extension) {
-        
+
         return getReportBaseFileName(selectedReport, "files");
     }
-    
+
     public String getReportBaseFileName(IReport selectedReport, String extension) {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM.dd.SSS");
         // "yyMMdd HHmmss.SSS");
@@ -124,14 +124,14 @@ public class ResultsExportReport implements IReport {
         while (reportName.indexOf(' ') > -1) {
             reportName = reportName.replace(" ", "_");
         }
-        
+
         if (extension != null &&  extension.length() >= 0) {
             extension = "." + extension;
         }
-            
+
         return "report." + reportName + "." + simpleDateFormat.format(new Date()) + extension;
     }
-    
+
     public String getFileName(IReport selectedReport, String extension) {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM.dd.SSS"); // or maybe? "yyMMdd HHmmss.SSS");
         String reportName = selectedReport.getReportTitle();
@@ -141,30 +141,31 @@ public class ResultsExportReport implements IReport {
         }
         return "report." + reportName + "." + simpleDateFormat.format(new Date()) + "." + extension;
     }
-    
+
     @Override
     public String[] createReport(Filter filter) {
-        
+
     List<String> outList = new ArrayList<String>();
-        
-        
+
+
         String resultsFilename = getPc2ResultsDir() + File.separator + ResultsFile.RESULTS_FILENAME;
         String scoreboardJsonFilename = getPc2ResultsDir() + File.separator + Constants.SCOREBOARD_JSON_FILENAME;
         String awardsFileName = getPc2ResultsDir() + File.separator + Constants.AWARDS_JSON_FILENAME;
-        
+        String eventFeedJsonFileName = getPc2ResultsDir() + File.separator + Constants.EVENT_FEED_JSON_FILENAME;
+
         ExportFilesUtilities.writeResultsFiles(contest, getPc2ResultsDir());
 
         String finalizedStatus = "No.  (Warning - contest is not finalized)";
-        
+
         FinalizeData finalizedDAta = contest.getFinalizeData();
         if (finalizedDAta != null) {
             if ( finalizedDAta.isCertified() ) {
-                
+
                 finalizedStatus = "Yes.  Finalized at "+
                         finalizedDAta.getCertificationDate();
             }
         }
-        
+
         String[] reportLinss = { //
 
                 "pc2 results dir       : " + getPc2ResultsDir(), //
@@ -175,15 +176,16 @@ public class ResultsExportReport implements IReport {
                 resultsFilename, //
                 scoreboardJsonFilename, //
                 awardsFileName, //
+                eventFeedJsonFileName, //
                 "", //
 
         };
-        
+
         outList.addAll(0, Arrays.asList(reportLinss));
-        
-   
-        
-        return (String[]) outList.toArray(new String[outList.size()]);
+
+
+
+        return outList.toArray(new String[outList.size()]);
     }
 
 
@@ -244,7 +246,7 @@ public class ResultsExportReport implements IReport {
         printWriter.println("end report: " + getReportTitle());
 
     }
-    
+
     public String getPc2ResultsDir() {
         if (pc2ResultsDir == null) {
 //            ExecuteUtilities.ensureDirectory(Constants.REPORT_DIRECTORY_NAME);
@@ -266,7 +268,7 @@ public class ResultsExportReport implements IReport {
     public String getPrimaryCCSResultsDir() {
         return primaryCCSResultsDir;
     }
-    
+
     public void setPrimaryCCSResultsDir(String primaryCCSResultsDir) {
         this.primaryCCSResultsDir = primaryCCSResultsDir;
     }


### PR DESCRIPTION
### Description of what the PR does
End of contest procedures require the saving of the `event-feed.ndjson` file in addition to the already saved `results.tsv`, `scoreboard.json` and `awards.json`.  The changes here arrange for `event-feed.ndjson` to be saved as part of the Results Export Report.


### Issue which the PR addresses
Fixes #960 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load up any contest 
2) From the `pc2server`, go to the **Reports** tab.
3) Choose the **Results Export Files** report
4) Press "**Export Report Contents**"
5) Notice that `event-feed.ndjson `is now generated as part of the report.
<img width="414" alt="image" src="https://github.com/pc2ccs/pc2v9/assets/5657363/853f1dc2-c67a-4c46-b4e9-029b639a1000">
