### PR TITLE
I963: scoreboard and compare runs frame are only restricted to one instance.

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsFrame.java
@@ -2,8 +2,6 @@
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.Dimension;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
 
@@ -18,25 +16,17 @@ import edu.csus.ecs.pc2.shadow.ShadowController;
 public class ShadowCompareRunsFrame extends JFrame {
 
     private static final long serialVersionUID = 1L;
-    
-    private boolean isOpen = true;
-    
     public ShadowCompareRunsFrame(ShadowController shadowController) {
         setMinimumSize(new Dimension(750, 900));
         Dimension size = new Dimension(750,750);
         this.setPreferredSize(size);
 //        this.setMinimumSize(size);
-        
+
         ShadowCompareRunsPane runsPane = new ShadowCompareRunsPane(shadowController);
         runsPane.setMinimumSize(new Dimension(750, 900));
         runsPane.setPreferredSize(new Dimension(750, 900));
-        
-        addWindowListener(new WindowAdapter() {
-            public void windowClosed(WindowEvent e) {
-                // This will be called after the window has closed
-                isOpen = false;
-            }
-        });
+
+
 //        runsPane.setContestAndController(shadowController.getLocalContest(), shadowController.getLocalController());
         //the above statement was moved into the ShadowCompareRunsPane() constructor, as follows:
         //   this.setContestAndController(shadowController.getLocalContest(), shadowController.getLocalController());
@@ -47,9 +37,6 @@ public class ShadowCompareRunsFrame extends JFrame {
 
         this.getContentPane().add(runsPane);
     }
-    
-    public boolean isOpen() {
-        return isOpen;
-    }
+
 
 }

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsFrame.java
@@ -1,7 +1,9 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.Dimension;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
 
@@ -17,6 +19,8 @@ public class ShadowCompareRunsFrame extends JFrame {
 
     private static final long serialVersionUID = 1L;
     
+    private boolean isOpen = true;
+    
     public ShadowCompareRunsFrame(ShadowController shadowController) {
         setMinimumSize(new Dimension(750, 900));
         Dimension size = new Dimension(750,750);
@@ -27,6 +31,12 @@ public class ShadowCompareRunsFrame extends JFrame {
         runsPane.setMinimumSize(new Dimension(750, 900));
         runsPane.setPreferredSize(new Dimension(750, 900));
         
+        addWindowListener(new WindowAdapter() {
+            public void windowClosed(WindowEvent e) {
+                // This will be called after the window has closed
+                isOpen = false;
+            }
+        });
 //        runsPane.setContestAndController(shadowController.getLocalContest(), shadowController.getLocalController());
         //the above statement was moved into the ShadowCompareRunsPane() constructor, as follows:
         //   this.setContestAndController(shadowController.getLocalContest(), shadowController.getLocalController());
@@ -36,6 +46,10 @@ public class ShadowCompareRunsFrame extends JFrame {
         // in an invalid state -- existing but having no contest or controller with which to work.)
 
         this.getContentPane().add(runsPane);
+    }
+    
+    public boolean isOpen() {
+        return isOpen;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -77,16 +77,16 @@ import edu.csus.ecs.pc2.shadow.ShadowJudgementPair;
 public class ShadowCompareRunsPane extends JPanePlugin {
 
     private static final long serialVersionUID = 1L;
-    
+
     private static final int RUN_UPDATE_REQUEST_SERVER_TIMEOUT_MILLIS = 30000;
-    
+
     private static final String DEFAULT_REFRESH_INTERVAL = "5";
-    
+
     private ShadowController shadowController = null ;
-    
+
     //the current judgement information from the shadow controller
     private Map<String, ShadowJudgementInfo> currentJudgementMap = null;
-    
+
     private Map<String, ShadowJudgementInfo> filteredJudgementMap = null;
     
     //the table displaying the current results
@@ -102,16 +102,16 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     private Run runWeRequestedServerToUpdate;
 
     private boolean serverHasUpdatedOurRun;
-    
+
     private JPanel dynamicallyRefreshPanel;
-        
+ 
     private JCheckBox mismatchCheckBox;
 
     @Override
     public String getPluginTitle() {
         return "Shadow_Compare_Pane";
     }
-    
+
     /**
      * This GUI class accepts a reference to a {@link ShadowController}, from which it obtains (by calling 
      * {@link ShadowController#getJudgementComparisonInfo()}) a
@@ -127,11 +127,11 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         Dimension size = new Dimension(700,700);
         this.setPreferredSize(size);
         this.setMinimumSize(size);
-        
+
         this.shadowController = shadowController ;
-        
+
         this.log = shadowController.getLog();
-        
+
         this.setContestAndController(shadowController.getLocalContest(), shadowController.getLocalController());
 
         //add a run listener so we can be notified when run edits which we invoke (during the "Resolve Run" operation) are completed
@@ -141,13 +141,13 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         JLabel header = new JLabel("Comparison of PC2 vs. Remote Judgements");
         header.setAlignmentX(Component.CENTER_ALIGNMENT);
         this.add(header);
-        
+
         //get the framework for the table which will be used to display comparison results
         resultsTable = getResultsTable();
         
         //put the current comparison results into the table model
         resultsTable.setModel(getUpdatedResultsTableModel());
-        
+
         //support sorting the table by clicking on the column headers
         TableRowSorter<TableModel> sorter = new TableRowSorter<TableModel>(resultsTable.getModel());
         resultsTable.setRowSorter(sorter);
@@ -156,13 +156,18 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         //put the results table in a scrollpane on the GUI
         JScrollPane scrollPane = new JScrollPane(resultsTable, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                     ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+        shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
+
         this.add(scrollPane);
 
         this.add(getSummaryPanel());
-        
+
         this.add(getdynamicallyRefreshPanel());
-        
+
         this.add(getButtonPanel());
+
+
     }
         
     /**
@@ -179,7 +184,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
 
         JTable resultsTable = new JTable() {
             private static final long serialVersionUID = 1L;
-            
+
             private Border outside = new MatteBorder(1, 0, 1, 0, Color.RED);
             private Border inside = new EmptyBorder(0, 1, 0, 1);
             private Border highlight = new CompoundBorder(outside, inside);
@@ -207,7 +212,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
                      (remoteJudgement != null && remoteJudgement.toLowerCase().contains("pending"))) {
                     c.setBackground(new Color(255, 255, 153));
                 }
-                
+
                 // update font to bold & italic if row is selected
                 if (isRowSelected(row)) {
                     c.setFont(new Font("Arial Bold", Font.ITALIC, 14));
@@ -216,7 +221,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
 
                 return c;
             }
-            
+
             //we don't want any of the results cells to be editable
             public boolean isCellEditable(int nRow, int nCol) {
                 return false;
@@ -228,7 +233,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         centerRenderer.setHorizontalAlignment(SwingConstants.CENTER);
         resultsTable.setDefaultRenderer(String.class, centerRenderer);
         resultsTable.setDefaultRenderer(Integer.class, centerRenderer);
-        
+
         resultsTable.setRowSelectionAllowed(true);
         resultsTable.setColumnSelectionAllowed(false);
         resultsTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -455,6 +460,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
             
             dynamicallyRefreshPanel.add(getmismatchCheckBox());
         }
+        
         return dynamicallyRefreshPanel;
     }
     

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -126,7 +126,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     public ShadowCompareRunsPane(ShadowController shadowController) {
         Dimension size = new Dimension(700,700);
         this.setPreferredSize(size);
-        this.setMinimumSize(size);shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
+        this.setMinimumSize(size);
         this.shadowController = shadowController ;
 
         this.log = shadowController.getLog();
@@ -141,7 +141,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         header.setAlignmentX(Component.CENTER_ALIGNMENT);
         this.add(header);
  
-        this.setMinimumSize(size);shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
+        shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
         //get the framework for the table which will be used to display comparison results
         resultsTable = getResultsTable();
  

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareRunsPane.java
@@ -126,8 +126,7 @@ public class ShadowCompareRunsPane extends JPanePlugin {
     public ShadowCompareRunsPane(ShadowController shadowController) {
         Dimension size = new Dimension(700,700);
         this.setPreferredSize(size);
-        this.setMinimumSize(size);
-
+        this.setMinimumSize(size);shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
         this.shadowController = shadowController ;
 
         this.log = shadowController.getLog();
@@ -141,10 +140,11 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         JLabel header = new JLabel("Comparison of PC2 vs. Remote Judgements");
         header.setAlignmentX(Component.CENTER_ALIGNMENT);
         this.add(header);
-
+ 
+        this.setMinimumSize(size);shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
         //get the framework for the table which will be used to display comparison results
         resultsTable = getResultsTable();
-        
+ 
         //put the current comparison results into the table model
         resultsTable.setModel(getUpdatedResultsTableModel());
 
@@ -152,12 +152,11 @@ public class ShadowCompareRunsPane extends JPanePlugin {
         TableRowSorter<TableModel> sorter = new TableRowSorter<TableModel>(resultsTable.getModel());
         resultsTable.setRowSorter(sorter);
         resultsTable.setAutoCreateRowSorter(true); //necessary to allow updated model to display and sort correctly
-                
+ 
         //put the results table in a scrollpane on the GUI
         JScrollPane scrollPane = new JScrollPane(resultsTable, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                     ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 
-        shadowController.setFilter(FILTERS.NONE);//Required to reset the state of the filter
 
         this.add(scrollPane);
 

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareScoreboardFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareScoreboardFrame.java
@@ -1,7 +1,9 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.Dimension;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
 
@@ -17,11 +19,23 @@ public class ShadowCompareScoreboardFrame extends JFrame {
 
     private static final long serialVersionUID = 1L;
     
+    private boolean isOpen = true;
+    
     public ShadowCompareScoreboardFrame(ShadowController shadowController) {
         Dimension size = new Dimension(1200,900);
         this.setPreferredSize(size);
         this.setMinimumSize(size);
+        addWindowListener(new WindowAdapter() {
+            public void windowClosed(WindowEvent e) {
+                // This will be called after the window has closed
+                isOpen = false;
+            }
+        });
         this.getContentPane().add(new ShadowCompareScoreboardPane(shadowController));
+    }
+    
+    public boolean isOpen() {
+        return isOpen;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/ui/ShadowCompareScoreboardFrame.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowCompareScoreboardFrame.java
@@ -2,8 +2,6 @@
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.Dimension;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
 
@@ -19,23 +17,14 @@ public class ShadowCompareScoreboardFrame extends JFrame {
 
     private static final long serialVersionUID = 1L;
     
-    private boolean isOpen = true;
-    
     public ShadowCompareScoreboardFrame(ShadowController shadowController) {
         Dimension size = new Dimension(1200,900);
         this.setPreferredSize(size);
         this.setMinimumSize(size);
-        addWindowListener(new WindowAdapter() {
-            public void windowClosed(WindowEvent e) {
-                // This will be called after the window has closed
-                isOpen = false;
-            }
-        });
+        
         this.getContentPane().add(new ShadowCompareScoreboardPane(shadowController));
     }
     
-    public boolean isOpen() {
-        return isOpen;
-    }
+
 
 }

--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -931,6 +931,11 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                 showErrorMessage("Cannot compare scoreboard, shadow not running","Shadow not running");
                             } else if (shadowCompareScoreboardFrame != null && shadowCompareScoreboardFrame.isVisible()) {
                                 showErrorMessage("Compare Scoreboards already open", "Compare Scoreboards Already Open");
+                                shadowCompareScoreboardFrame.setState(JFrame.NORMAL); //If the frame was minimized this brings it back.
+                                shadowCompareScoreboardFrame.setVisible(false);  // This was recommended to make it work for MacOS
+                                shadowCompareScoreboardFrame.setVisible(true);   
+                                shadowCompareScoreboardFrame.toFront();          
+                                shadowCompareScoreboardFrame.requestFocus();
                             }
                             else {
                                 shadowCompareScoreboardFrame = new ShadowCompareScoreboardFrame(shadowController);

--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -886,8 +886,13 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                         showErrorMessage("No shadow controller available; cannot show runs comparison", "Missing Controller");
                     } else if (!ShadowController.SHADOW_CONTROLLER_STATUS.SC_RUNNING.equals(shadowController.getStatus())) {
                         showErrorMessage("Cannot compare runs, shadow not running","Shadow not running");
-                    } else if (shadowCompareRunsFrame != null && shadowCompareRunsFrame.isOpen()) {
+                    } else if (shadowCompareRunsFrame != null && shadowCompareRunsFrame.isVisible()) {
                         showErrorMessage("Compare Runs already open", "Compare Runs Already Open");
+                        shadowCompareRunsFrame.setState(JFrame.NORMAL); //If the frame was minimized this brings it back.
+                        shadowCompareRunsFrame.setVisible(false);  // This was recommended to make it work for MacOS
+                        shadowCompareRunsFrame.setVisible(true);   
+                        shadowCompareRunsFrame.toFront();          
+                        shadowCompareRunsFrame.requestFocus();     
                     }else {
                         shadowCompareRunsFrame = new ShadowCompareRunsFrame(shadowController);
                         shadowCompareRunsFrame.setSize(600,700);
@@ -924,7 +929,7 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                 showErrorMessage("No shadow controller available; cannot show scoreboard comparison", "Missing Controller");
                             } else if (!ShadowController.SHADOW_CONTROLLER_STATUS.SC_RUNNING.equals(shadowController.getStatus())) {
                                 showErrorMessage("Cannot compare scoreboard, shadow not running","Shadow not running");
-                            } else if (shadowCompareScoreboardFrame != null && shadowCompareScoreboardFrame.isOpen()) {
+                            } else if (shadowCompareScoreboardFrame != null && shadowCompareScoreboardFrame.isVisible()) {
                                 showErrorMessage("Compare Scoreboards already open", "Compare Scoreboards Already Open");
                             }
                             else {

--- a/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ShadowControlPane.java
@@ -144,6 +144,8 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
             "CLICS <b><i>state</i></b> message with a non-null <b>started</b> property is received." +
             "<p><p>Do you wish to continue and start shadowing anyway?</html>";
 
+    private ShadowCompareRunsFrame shadowCompareRunsFrame;
+    private ShadowCompareScoreboardFrame shadowCompareScoreboardFrame;
     // Status column for JTable notifications
     enum ShadowStatus {
         SUCCESS,
@@ -884,13 +886,16 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                         showErrorMessage("No shadow controller available; cannot show runs comparison", "Missing Controller");
                     } else if (!ShadowController.SHADOW_CONTROLLER_STATUS.SC_RUNNING.equals(shadowController.getStatus())) {
                         showErrorMessage("Cannot compare runs, shadow not running","Shadow not running");
-                    } else {
-                        JFrame shadowCompareRunsFrame = new ShadowCompareRunsFrame(shadowController);
+                    } else if (shadowCompareRunsFrame != null && shadowCompareRunsFrame.isOpen()) {
+                        showErrorMessage("Compare Runs already open", "Compare Runs Already Open");
+                    }else {
+                        shadowCompareRunsFrame = new ShadowCompareRunsFrame(shadowController);
                         shadowCompareRunsFrame.setSize(600,700);
                         shadowCompareRunsFrame.setLocationRelativeTo(null); // centers frame
                         shadowCompareRunsFrame.setTitle("Shadow Run Comparison");
                         shadowCompareRunsFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                         shadowCompareRunsFrame.setVisible(true);
+                        
                     }
 
                 }
@@ -919,8 +924,11 @@ public class ShadowControlPane extends JPanePlugin implements IShadowMonitorStat
                                 showErrorMessage("No shadow controller available; cannot show scoreboard comparison", "Missing Controller");
                             } else if (!ShadowController.SHADOW_CONTROLLER_STATUS.SC_RUNNING.equals(shadowController.getStatus())) {
                                 showErrorMessage("Cannot compare scoreboard, shadow not running","Shadow not running");
-                            } else {
-                                JFrame shadowCompareScoreboardFrame = new ShadowCompareScoreboardFrame(shadowController);
+                            } else if (shadowCompareScoreboardFrame != null && shadowCompareScoreboardFrame.isOpen()) {
+                                showErrorMessage("Compare Scoreboards already open", "Compare Scoreboards Already Open");
+                            }
+                            else {
+                                shadowCompareScoreboardFrame = new ShadowCompareScoreboardFrame(shadowController);
                                 shadowCompareScoreboardFrame.setSize(600,700);
                                 shadowCompareScoreboardFrame.setLocationRelativeTo(null); // centers frame
                                 shadowCompareScoreboardFrame.setTitle("Shadow Scoreboard Comparison");


### PR DESCRIPTION
Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
scoreboard and compare runs frame are only restricted to one instance. If user attempts to open the same frame one more time user is warned and the action is not completed.

### Issue which the PR addresses
fixes #963 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
open feeder. Once connected to ccs api, attempt to open compare scoreboard and compare runs. Try to open them again without closing them. User should be warned by the system it is not possible and there is already compare scoreboard or compare runs. Also notice that the old compares will come to front if it is behind other stuff or will get unminimized if it was minimized. Notice that problem stated below does not exist anymore.