### PR TITLE
i_980 Fix sorting bug for results.tsv medalists

### DIFF
--- a/src/edu/csus/ecs/pc2/core/scoring/FinalsStandingsRecordComparator.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/FinalsStandingsRecordComparator.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.scoring;
 
 import java.io.Serializable;
@@ -22,13 +22,13 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
      *
      */
     private static final long serialVersionUID = 2417425534254224622L;
-    
+
     private AccountNameComparator accountNameComparator = new AccountNameComparator();
 
     private AccountList cachedAccountList;
-    
+
     private int median = -1;
-    
+
     private int lastRank = -1;
 
     /**
@@ -59,6 +59,7 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
      * @throws ClassCastException
      *             if the arguments' types prevent them from being compared by this Comparator.
      */
+    @Override
     public int compare(StandingsRecord o1, StandingsRecord o2) {
         int status = 0;
         long a1, b1;
@@ -69,8 +70,8 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
         int nameComparison;
         int a0, b0;
 
-        StandingsRecord teamA = (StandingsRecord) o1;
-        StandingsRecord teamB = (StandingsRecord) o2;
+        StandingsRecord teamA = o1;
+        StandingsRecord teamB = o2;
         a0 = teamA.getRankNumber();
         a1 = teamA.getNumberSolved();
         a2 = teamA.getPenaltyPoints();
@@ -88,7 +89,7 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
 //        nameComparison = nameA.toLowerCase().compareTo(nameB.toLowerCase());
         nameComparison = accountNameComparator.compare(nameA, nameB);
 
-        // 
+        //
         // Primary Sort = number of solved problems (high to low)
         // Secondary Sort = score (low to high)
         // Tertiary Sort = earliest submittal of last submission (low to high)
@@ -114,10 +115,10 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
             }
         } else if (a0 > getLastRank()) {
             return 1;
-        } else if (b1 > getLastRank()) {
+        } else if (b0 > getLastRank()) {
             return -1;
         }
-        
+
         if ((b1 == a1) && (b2 == a2) && (b3 == a3) && (nameComparison == 0)
                 && (b5 == a5)) {
             status = 0; // elements equal, this shouldn't happen...


### PR DESCRIPTION
### Description of what the PR does
The wrong value was being used to compare the ranks of one team.  The # of problems solved instead of the rank was used in some cases.  This has been fixed.
Eclipse made a few other cosmetic changes to the code (removing white space on lines and superfluous casting).

### Issue which the PR addresses
Fixes #980 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load the pc2zip NAC2024 (from S3)
2) Generate a results.tsv.  Note the medalists are not sorted properly (see the sample in Issue #980)
3) Apply the change in this PR.
4) Re-generate the `results.tsv`, or, simply skip step 2 and compare to the file attached in Issue #980) ([results-fixed.txt](https://github.com/user-attachments/files/15959478/results-fixed.txt))
5) Note the medalists are correctly sorted.

