### PR TITLE
I948 Fixes to Finalize tab and WF vs regional rankings

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/FinalizeData.java
+++ b/src/edu/csus/ecs/pc2/core/model/FinalizeData.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.Serializable;

--- a/src/edu/csus/ecs/pc2/core/model/FinalizeData.java
+++ b/src/edu/csus/ecs/pc2/core/model/FinalizeData.java
@@ -6,18 +6,18 @@ import java.util.Date;
 
 /**
  * CCS Finalization Data.
- * 
+ *
  * When a contest is finalized it is "certified" and a result is that
  * the contest data is locked down, no changes that would change
  * score results will be allowed.  This condition can be checked
  * using the {@link #isCertified()} method.
- * 
+ *
  * <br><br>
- * 
+ *
  * This data contains information about which ranks (teams) get
  * medals, and provides information for the CCS Event Feed XML
  * finalized element.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -34,10 +34,12 @@ public class FinalizeData implements Serializable {
     private int bronzeRank;
 
     private String comment;
-    
+
     private boolean certified = false;
-    
+
     private Date certificationDate = null;
+
+    private boolean useWFGroupRanking = true;
 
     /**
      * @return last rank for gold.
@@ -82,7 +84,7 @@ public class FinalizeData implements Serializable {
 
     /**
      * Is contest certified?.
-     * 
+     *
      * @param certified true certifies, false un-certifies.
      */
     public void setCertified(boolean certified) {
@@ -92,12 +94,12 @@ public class FinalizeData implements Serializable {
         } else {
             certificationDate = null;
         }
-        
+
     }
 
     /**
      * Has is the contest been finalized/certified?.
-     * 
+     *
      * @return true if certified/finalized.
      */
     public boolean isCertified() {
@@ -106,10 +108,29 @@ public class FinalizeData implements Serializable {
 
     /**
      * Date when certified.
-     * 
+     *
      * @return
      */
     public Date getCertificationDate() {
         return certificationDate;
+    }
+
+    /**
+     * Set whether or not to show rankings in results files as groups based on # of problems
+     * solved, after the medal ranks.
+     *
+     * @param useWFGroupRanking
+     */
+    public void setUseWFGroupRanking(boolean useWFGroupRanking) {
+        this.useWFGroupRanking = useWFGroupRanking;
+    }
+
+    /**
+     * Return whether or not WF group rankings (based on # problems solved) should be used for results files
+     *
+     * @return true if WF group rankings are to be used
+     */
+    public boolean isUseWFGroupRanking() {
+        return useWFGroupRanking;
     }
 }

--- a/src/edu/csus/ecs/pc2/core/report/FileComparisonUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/FileComparisonUtilities.java
@@ -494,7 +494,7 @@ public class FileComparisonUtilities {
         @Override
         public String getKey(Object object) {
             CLICSAward clicsAward = (CLICSAward) object;
-            return clicsAward.getCitation();
+            return clicsAward.getId();
         }
     }
     

--- a/src/edu/csus/ecs/pc2/core/report/FinalizeReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/FinalizeReport.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.FileOutputStream;
@@ -15,7 +15,7 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 
 /**
  * Print Finalize Report.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -24,12 +24,12 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 public class FinalizeReport implements IReport {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7306522824265732770L;
 
     /**
-     * 
+     *
      */
 
     private IInternalContest contest;
@@ -40,6 +40,7 @@ public class FinalizeReport implements IReport {
 
     private Filter filter;
 
+    @Override
     public void writeReport(PrintWriter printWriter) {
         printFinalizeData(printWriter);
     }
@@ -60,6 +61,7 @@ public class FinalizeReport implements IReport {
             printWriter.println("  silver rank : " + data.getSilverRank());
             printWriter.println("  bronze rank : " + data.getBronzeRank());
             printWriter.println("  comment     : " + data.getComment());
+            printWriter.println("  WF Rankings : " + data.isUseWFGroupRanking());
         } else {
             printWriter.println("  certified   : false");
             printWriter.println("   ** no data ** ");
@@ -67,6 +69,7 @@ public class FinalizeReport implements IReport {
         }
     }
 
+    @Override
     public void printHeader(PrintWriter printWriter) {
         printWriter.println(new VersionInfo().getSystemName());
         printWriter.println("Date: " + Utilities.getL10nDateTime());
@@ -75,11 +78,13 @@ public class FinalizeReport implements IReport {
         printWriter.println(getReportTitle() + " Report");
     }
 
+    @Override
     public void printFooter(PrintWriter printWriter) {
         printWriter.println();
         printWriter.println("end report");
     }
 
+    @Override
     public void createReportFile(String filename, Filter inFilter) throws IOException {
 
         PrintWriter printWriter = new PrintWriter(new FileOutputStream(filename, false), true);
@@ -105,32 +110,39 @@ public class FinalizeReport implements IReport {
         }
     }
 
+    @Override
     public String[] createReport(Filter inFilter) {
         throw new SecurityException("Not implemented");
     }
 
+    @Override
     public String createReportXML(Filter inFilter) throws IOException {
         return Reports.notImplementedXML(this);
     }
 
+    @Override
     public String getReportTitle() {
         return "Finalize-Certify";
     }
 
+    @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         this.contest = inContest;
         this.controller = inController;
         log = controller.getLog();
     }
 
+    @Override
     public String getPluginTitle() {
         return "Finalize-Certify Report";
     }
 
+    @Override
     public Filter getFilter() {
         return filter;
     }
 
+    @Override
     public void setFilter(Filter filter) {
         this.filter = filter;
     }

--- a/src/edu/csus/ecs/pc2/core/scoring/FinalsStandingsRecordComparator.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/FinalsStandingsRecordComparator.java
@@ -31,6 +31,8 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
 
     private int lastRank = -1;
 
+    private boolean useWFGroupRanking = true;
+
     /**
      * Compares its two arguments for order. Returns a negative integer, zero, or a positive integer as the first argument is less
      * than, equal to, or greater than the second.
@@ -102,21 +104,23 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
             return 1;
         } else if (b1 < getMedian()) {
             return -1;
-        } else if( a0 > getLastRank() && b0 > getLastRank() ) {
-            // compare only number of solved and name
-            if (b1 == a1) {
-                return(nameComparison);
-            } else {
-                if (b1 < a1) {
-                    return (-1);
+        } else if(isUseWFGroupRanking()) {
+            if( a0 > getLastRank() && b0 > getLastRank() ) {
+                // compare only number of solved and name
+                if (b1 == a1) {
+                    return(nameComparison);
                 } else {
-                    return (1);
+                    if (b1 < a1) {
+                        return (-1);
+                    } else {
+                        return (1);
+                    }
                 }
+            } else if (a0 > getLastRank()) {
+                return 1;
+            } else if (b0 > getLastRank()) {
+                return -1;
             }
-        } else if (a0 > getLastRank()) {
-            return 1;
-        } else if (b0 > getLastRank()) {
-            return -1;
         }
 
         if ((b1 == a1) && (b2 == a2) && (b3 == a3) && (nameComparison == 0)
@@ -159,5 +163,13 @@ public class FinalsStandingsRecordComparator implements Serializable, Comparator
 
     public void setLastRank(int lastRank) {
         this.lastRank = lastRank;
+    }
+
+    public boolean isUseWFGroupRanking() {
+        return useWFGroupRanking;
+    }
+
+    public void setUseWFGroupRanking(boolean useGroupRank) {
+        useWFGroupRanking = useGroupRank;
     }
 }

--- a/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
@@ -224,6 +224,9 @@ public class ResultsFile {
      */
     public String[] createTSVFileLines(IInternalContest contest, Group group, String resultFileTitleFieldName)  {
 
+        // TODO JB
+        boolean wfGroupRanking = false;
+        
         Vector<String> lines = new Vector<String>();
 
         finalizeData = contest.getFinalizeData();
@@ -299,12 +302,14 @@ public class ResultsFile {
             String award = getAwardMedal(record.getRankNumber(), finalizeData, ranked);
             String rank = "";
             if (!"honorable".equalsIgnoreCase(award)) {
-                if (realRank > lastMedalRank && (lastSolvedNum != record.getNumberSolved())) {
-                    lastSolvedNum = record.getNumberSolved();
-                    rankNumber = realRank;
-                    record.setRankNumber(realRank);
-                } else if (realRank > lastMedalRank && lastSolvedNum == record.getNumberSolved() && lastSolvedNum > 0) {
-                    record.setRankNumber(rankNumber);
+                if(wfGroupRanking) {
+                    if (realRank > lastMedalRank && (lastSolvedNum != record.getNumberSolved())) {
+                        lastSolvedNum = record.getNumberSolved();
+                        rankNumber = realRank;
+                        record.setRankNumber(realRank);
+                    } else if (realRank > lastMedalRank && lastSolvedNum == record.getNumberSolved() && lastSolvedNum > 0) {
+                        record.setRankNumber(rankNumber);
+                    }
                 }
                 rank = Integer.toString(record.getRankNumber());
             }
@@ -391,9 +396,9 @@ public class ResultsFile {
     private FinalizeData GenDefaultFinalizeData()
     {
         finalizeData = new FinalizeData();
-        finalizeData.setGoldRank(4);
-        finalizeData.setSilverRank(8);
-        finalizeData.setBronzeRank(12);
+        finalizeData.setGoldRank(1);
+        finalizeData.setSilverRank(3);
+        finalizeData.setBronzeRank(6);
         finalizeData.setCertified(false);
         finalizeData.setComment("Preliminary Results - Contest not Finalized");
         return(finalizeData);

--- a/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
@@ -113,8 +113,6 @@ public class ResultsFile {
         // Here we just cobble together some half-assed finalized data
         if (finalizeData == null) {
             finalizeData = GenDefaultFinalizeData();
-//            String [] badbad = {"Contest not finalized cannot create awards"};
-//            return badbad;
         }
 
         // TODO finalizeData really needs a B instead of getBronzeRank
@@ -134,6 +132,7 @@ public class ResultsFile {
         comparator.setCachedAccountList(accountList);
         comparator.setLastRank(lastMedalRank);
         comparator.setMedian(median);
+        comparator.setUseWFGroupRanking(finalizeData.isUseWFGroupRanking());
         Arrays.sort(standingsRecords, comparator);
 */
 
@@ -159,16 +158,18 @@ public class ResultsFile {
             String award = getAwardMedal(record.getRankNumber(), finalizeData, ranked);
             String rank = "";
             if (!"honorable".equalsIgnoreCase(award)) {
-                if (realRank > lastMedalRank && (lastSolvedNum != record.getNumberSolved())) {
-                    lastSolvedNum = record.getNumberSolved();
-                    rankNumber = realRank;
-                    record.setRankNumber(realRank);
-                } else if (realRank > lastMedalRank && lastSolvedNum == record.getNumberSolved() && lastSolvedNum > 0) {
-                    lastSolvedNum = record.getNumberSolved();
-                    rankNumber = realRank;
-                    record.setRankNumber(realRank);
-                } else if (realRank > lastMedalRank && lastSolvedNum == record.getNumberSolved() && lastSolvedNum > 0) {
-                    record.setRankNumber(rankNumber);
+                if(finalizeData.isUseWFGroupRanking()) {
+                    if (realRank > lastMedalRank && (lastSolvedNum != record.getNumberSolved())) {
+                        lastSolvedNum = record.getNumberSolved();
+                        rankNumber = realRank;
+                        record.setRankNumber(realRank);
+                    } else if (realRank > lastMedalRank && lastSolvedNum == record.getNumberSolved() && lastSolvedNum > 0) {
+                        lastSolvedNum = record.getNumberSolved();
+                        rankNumber = realRank;
+                        record.setRankNumber(realRank);
+                    } else if (realRank > lastMedalRank && lastSolvedNum == record.getNumberSolved() && lastSolvedNum > 0) {
+                        record.setRankNumber(rankNumber);
+                    }
                 }
                 rank = Integer.toString(record.getRankNumber());
             }
@@ -224,9 +225,6 @@ public class ResultsFile {
      */
     public String[] createTSVFileLines(IInternalContest contest, Group group, String resultFileTitleFieldName)  {
 
-        // TODO JB
-        boolean wfGroupRanking = false;
-        
         Vector<String> lines = new Vector<String>();
 
         finalizeData = contest.getFinalizeData();
@@ -259,8 +257,6 @@ public class ResultsFile {
 
         if (finalizeData == null) {
             finalizeData = GenDefaultFinalizeData();
-//            String [] badbad = {"Contest not finalized cannot create awards"};
-//            return badbad;
         }
 
         // TODO finalizeData really needs a B instead of getBronzeRank
@@ -278,6 +274,7 @@ public class ResultsFile {
         comparator.setCachedAccountList(accountList);
         comparator.setLastRank(lastMedalRank);
         comparator.setMedian(median);
+        comparator.setUseWFGroupRanking(finalizeData.isUseWFGroupRanking());
         Arrays.sort(standingsRecords, comparator);
 
         int realRank = 0;
@@ -302,7 +299,7 @@ public class ResultsFile {
             String award = getAwardMedal(record.getRankNumber(), finalizeData, ranked);
             String rank = "";
             if (!"honorable".equalsIgnoreCase(award)) {
-                if(wfGroupRanking) {
+                if(finalizeData.isUseWFGroupRanking()) {
                     if (realRank > lastMedalRank && (lastSolvedNum != record.getNumberSolved())) {
                         lastSolvedNum = record.getNumberSolved();
                         rankNumber = realRank;
@@ -396,11 +393,12 @@ public class ResultsFile {
     private FinalizeData GenDefaultFinalizeData()
     {
         finalizeData = new FinalizeData();
-        finalizeData.setGoldRank(1);
-        finalizeData.setSilverRank(3);
-        finalizeData.setBronzeRank(6);
+        finalizeData.setGoldRank(4);
+        finalizeData.setSilverRank(8);
+        finalizeData.setBronzeRank(12);
         finalizeData.setCertified(false);
         finalizeData.setComment("Preliminary Results - Contest not Finalized");
+        finalizeData.setUseWFGroupRanking(true);
         return(finalizeData);
     }
 }

--- a/src/edu/csus/ecs/pc2/ui/FinalizePane.java
+++ b/src/edu/csus/ecs/pc2/ui/FinalizePane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -50,6 +50,8 @@ public class FinalizePane extends JPanePlugin {
     private JPanel buttonPane = null;
 
     private JButton finalizeButton = null;
+    
+    private JButton updateButton = null;
 
     private JPanel centerPane = null;
 
@@ -117,7 +119,8 @@ public class FinalizePane extends JPanePlugin {
             flowLayout.setHgap(45);
             buttonPane = new JPanel();
             buttonPane.setLayout(flowLayout);
-            buttonPane.setPreferredSize(new Dimension(35, 35));
+            buttonPane.setPreferredSize(new Dimension(52, 35));
+            buttonPane.add(getUpdateButton(), null);
             buttonPane.add(getFinalizeButton(), null);
             buttonPane.add(getReportButton(), null);
         }
@@ -218,6 +221,60 @@ public class FinalizePane extends JPanePlugin {
             });
         }
         return finalizeButton;
+    }
+
+    /**
+     * This method initializes updateButton
+     * 
+     * @return javax.swing.JButton
+     */
+    private JButton getUpdateButton() {
+        if (updateButton == null) {
+            updateButton = new JButton();
+            updateButton.setText("Update");
+            updateButton.setMnemonic(KeyEvent.VK_U);
+            updateButton.setToolTipText("Update medal counts");
+            updateButton.addActionListener(new java.awt.event.ActionListener() {
+                public void actionPerformed(java.awt.event.ActionEvent e) {
+                    updateMedalCounts();
+                }
+            });
+        }
+        return updateButton;
+    }
+
+    protected void updateMedalCounts() {
+
+        FinalizeData data = getFromFields();
+        FinalizeData currentData = getContest().getFinalizeData();
+        
+        try {
+            if(currentData != null && currentData.isCertified()) {
+                throw new InvalidFieldValue("You can not change the medal counts on a certfied contest");                
+            }
+            if (data.getGoldRank() <= 0) {
+                throw new InvalidFieldValue("Gold rank must be greater than zero");                
+            }
+            if (data.getSilverRank() <= 0) {
+                throw new InvalidFieldValue("Silver rank must be greater than zero");                
+            }
+            if (data.getBronzeRank() <= 0) {
+                throw new InvalidFieldValue("Bronze rank must be greater than zero");
+            }
+            if(data.getGoldRank() >= data.getSilverRank()) {
+                throw new InvalidFieldValue("Gold rank must not be greater than silver rank");
+            }
+            if(data.getSilverRank() >= data.getBronzeRank()) {
+                throw new InvalidFieldValue("Silver rank must not be greater than bronze rank");
+            }
+
+        } catch (InvalidFieldValue e) {
+            showMessage(e.getMessage());
+            return;
+        }
+
+        data.setCertified(false);
+        getController().updateFinalizeData(data);
     }
 
     protected void certifyContest() {


### PR DESCRIPTION
### Description of what the PR does
Allow the user to specify medal counts instead of ending rank (#948, #969 and #777)
Add an option to not rank by _World Finals groupings_, rather, rank every team individually, even after medals. (#777)
Allow updating of medal counts prior to finalizing (#948)
Allow generation of `results.tsv` from the **Finalize** tab all the time.
Fix the finalize report to show the status of the WF Group ranking flag (#777)

### Issue which the PR addresses
Fixes #948
Fixes #969
Fixes #777

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Many of the changes are GUI related.  The underlying data structures have not changed, for example, to support the way the number of medals are selected.  Internally it is still done by rank.  I have included some screenshots below of the new GUI.

Default Finalize tab (4G, 4S, 4B + WF style group ranking):

![image](https://github.com/pc2ccs/pc2v9/assets/5657363/ca01a20a-2961-4f36-ae14-0ab3adaa99e0)

[Sample results.tsv file generated from the above settings](https://github.com/user-attachments/files/15959850/wfresults_4g4s4b.txt)

Change medal counts to 1G, 2S, 3B and do regional style ranking:

![image](https://github.com/pc2ccs/pc2v9/assets/5657363/2b949cdf-46e2-4562-ab7b-e0652c06605a)

[Sample regional results.tsv file generated from the above settings](https://github.com/user-attachments/files/15959832/results_1g2s3b-regional.txt)

1. To test, you'll need a completed. but not finalized, contest's pc2zip file - _WF46 Luxor finals_ is a good one - you can get the archive from the Sysops Amazon S3 drive (s3://icpc-sysops-pastcontests/finals/finals2023/shadow/wf46/202404181512-pc2archive-wf46-prefinalize-finals.zip), or, use one of your own completed, but not finalized, contests.
2. Bring up the **pc2server** and a **pc2admin**.
3. On the admin, go to the **Run->Finalize** tab as shown in the screen shots above.
4. Make the desired changes to the medal counts and check or uncheck the "**Use World Finals group rankings for results**" check box, depending on what you want to see.
5. Press the "**View**" button to generate a `results.tsv` file and view it.  Note the rankings should correspond to the settings.
6. Note that the label says: "_Unofficial Results file ..._"  since the contest has not been finalized.  After the contest is finalized, you can not change medal counts. (N.B. do we really want to prohibit the medal counts from changing after finalization?  Changing medal counts does not affect scoring, only ranking.  And, it may be desirable (or necessary) to change the ranking method/medal counts after the contest is finalized.)



