### PR TITLE
i_988 Fix NPE in SubmitSampleRunspane

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/SubmitSampleRunsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/SubmitSampleRunsPane.java
@@ -1263,38 +1263,40 @@ public class SubmitSampleRunsPane extends JPanePlugin {
 
     public void reloadRunList() {
 
-        if (filter.isFilterOn()){
-            getFilterButton().setForeground(Color.BLUE);
-            getFilterButton().setToolTipText("Edit filter - filter ON");
-            rowCountLabel.setForeground(Color.BLUE);
-        } else {
-            getFilterButton().setForeground(Color.BLACK);
-            getFilterButton().setToolTipText("Edit filter");
-            rowCountLabel.setForeground(Color.BLACK);
-        }
+        if(submissionList != null) {
+            if (filter.isFilterOn()){
+                getFilterButton().setForeground(Color.BLUE);
+                getFilterButton().setToolTipText("Edit filter - filter ON");
+                rowCountLabel.setForeground(Color.BLUE);
+            } else {
+                getFilterButton().setForeground(Color.BLACK);
+                getFilterButton().setToolTipText("Edit filter");
+                rowCountLabel.setForeground(Color.BLACK);
+            }
 
-        for (SubmissionSample sub : submissionList) {
-            ClientId clientId = null;
+            for (SubmissionSample sub : submissionList) {
+                ClientId clientId = null;
 
-            Run run = sub.getRun();
-            if(run != null) {
-                RunStates runStates = run.getStatus();
-                if (!(runStates.equals(RunStates.NEW) || run.isDeleted())) {
-                    JudgementRecord judgementRecord = run.getJudgementRecord();
-                    if (judgementRecord != null) {
-                        clientId = judgementRecord.getJudgerClientId();
+                Run run = sub.getRun();
+                if(run != null) {
+                    RunStates runStates = run.getStatus();
+                    if (!(runStates.equals(RunStates.NEW) || run.isDeleted())) {
+                        JudgementRecord judgementRecord = run.getJudgementRecord();
+                        if (judgementRecord != null) {
+                            clientId = judgementRecord.getJudgerClientId();
+                        }
                     }
                 }
+                updateRunRow(sub, clientId, false);
             }
-            updateRunRow(sub, clientId, false);
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    updateRowCount();
+                    resizeColumnWidth(runTable);
+                }
+            });
         }
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                updateRowCount();
-                resizeColumnWidth(runTable);
-            }
-        });
     }
     /**
      * Run Listener
@@ -1370,16 +1372,18 @@ public class SubmitSampleRunsPane extends JPanePlugin {
 
         private SubmissionSample getSubmission(RunEvent event)
         {
-            Run run = event.getRun();
+            if(submissionList != null) {
+                Run run = event.getRun();
 
-            // We are only interested in runs we submitted
-            if(run.getSubmitter().equals(getContest().getClientId())) {
-                for(SubmissionSample sub : submissionList) {
-                    Run subRun = sub.getRun();
-                    // Check run numbers if this submission has a run
-                    if(subRun != null && subRun.getNumber() == run.getNumber()) {
-                        sub.setRun(run);
-                        return(sub);
+                // We are only interested in runs we submitted
+                if(run.getSubmitter().equals(getContest().getClientId())) {
+                    for(SubmissionSample sub : submissionList) {
+                        Run subRun = sub.getRun();
+                        // Check run numbers if this submission has a run
+                        if(subRun != null && subRun.getNumber() == run.getNumber()) {
+                            sub.setRun(run);
+                            return(sub);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description of what the PR does
If the `SubmitSampleRunsPane `was never used, and a run changed, an NPE would result when the `IRunListener `methods were called.   Fixed to simply check the value of offending member, `submissionList` before referencing.  Currently, this only happens for administrator accounts.

### Issue which the PR addresses
Fixes #988 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11 and Ubuntu 22.04.1 (contest image)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load a contest
2) From an administrator account, judge a run
3) From the administrator account, edit the run and change its status to NEW
4) From the administrator account, judge the run again and note the `RunsTablePane ` now updates - previously, it did not.