### PR TITLE
I992 update to use SubmitSampleRunsPane instead of SubmitSubmissionsPane

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/DevelopmentPane.java
+++ b/src/edu/csus/ecs/pc2/ui/DevelopmentPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -10,7 +10,7 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 
 /**
  * Developer tools pane.
- * 
+ *
  * @author pc2@ecs.csus.edu
  */
 public class DevelopmentPane extends JPanePlugin {
@@ -18,7 +18,7 @@ public class DevelopmentPane extends JPanePlugin {
     private static final long serialVersionUID = -6902750741500529883L;
 
     private PluginPane pluginPane = new PluginPane();
-    
+
     private ContestScheduledStartClockPane contestScheduledStartClockPane = new ContestScheduledStartClockPane();
 
     private ReportPane reportPane = new ReportPane();
@@ -26,15 +26,15 @@ public class DevelopmentPane extends JPanePlugin {
     private OptionsPane optionsPane = new OptionsPane();
 
     private LogSettingsPane logSettingsPane = new LogSettingsPane();
-    
+
     private ContestPreloadPane contestPreloadPane = new ContestPreloadPane();
 
     private ContestClockAllPane contestClockAllPane = new ContestClockAllPane();
-    
-    private SubmitSubmissionsPane submitSubmissionsPane = new SubmitSubmissionsPane();
-    
+
+    private SubmitSampleRunsPane submitSampleRunsPane = new SubmitSampleRunsPane();
+
     private DisplayPermissionsPane displayPermissionsPane = new DisplayPermissionsPane();
-    
+
    public DevelopmentPane() {
         super();
         setLayout(new BorderLayout(0, 0));
@@ -43,23 +43,23 @@ public class DevelopmentPane extends JPanePlugin {
         add(tabbedPane);
 
         tabbedPane.addTab("Plugins", null, pluginPane, null);
-        
-        tabbedPane.addTab("Submitter", null, submitSubmissionsPane, null);
-        
+
+        tabbedPane.addTab("Submit Judge's Submissions", null, submitSampleRunsPane, null);
+
         tabbedPane.addTab("Scheduled Start Countdown", null, contestScheduledStartClockPane, null);
-        
+
         tabbedPane.addTab("All Countdown Timers", null, contestClockAllPane, null);
-        
+
         tabbedPane.addTab("Reports", null, reportPane, null);
-        
+
         tabbedPane.addTab("Sample Contests", null, contestPreloadPane, null);
 
         tabbedPane.addTab("Log Settings", null, logSettingsPane, null);
 
         tabbedPane.addTab("Options", null, optionsPane, null);
-        
+
         tabbedPane.addTab("Check Permissions", null, displayPermissionsPane, null);
-        
+
    }
 
     @Override
@@ -77,9 +77,9 @@ public class DevelopmentPane extends JPanePlugin {
         contestPreloadPane.setContestAndController(inContest, inController);
         contestScheduledStartClockPane.setContestAndController(inContest, inController);
         contestClockAllPane.setContestAndController(inContest, inController);
-        submitSubmissionsPane.setContestAndController(inContest, inController);
+        submitSampleRunsPane.setContestAndController(inContest, inController);
         displayPermissionsPane.setContestAndController(inContest, inController);
     }
-    
+
 
 } // @jve:decl-index=0:visual-constraint="10,10"

--- a/src/edu/csus/ecs/pc2/ui/DisplayPermissionsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/DisplayPermissionsPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -14,13 +14,14 @@ import javax.swing.JPanel;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.security.Permission;
 
 /**
  * A UI that provides a button to display the PC2 {@link Permission}s associated with the currently logged-in account.
- * 
- * 
+ *
+ *
  * @author John Clevenger, PC^2 Development Team (pc2@ecs.csus.edu).
  */
 public class DisplayPermissionsPane extends JPanePlugin {
@@ -54,35 +55,42 @@ public class DisplayPermissionsPane extends JPanePlugin {
 
         //find out who I am
         ClientId clientId = getContest().getClientId();
-        
+
         //get my account
         Account myAccount = getContest().getAccount(clientId);
-        
-        //get the list of permissions granted to my account
-        Permission.Type[] myPermissions = myAccount.getPermissionList().getList();
-        
-        //construct a String listing each permission
-        String msg = "Permissions (" + myPermissions.length + "): \n";
-        
-        if (myPermissions.length==0) {
-            msg += "  <none>\n";
-        } else {
 
-            ArrayList<String> perms = new ArrayList<String>();
-            
-            for (Permission.Type permission : myPermissions) {
-                perms.add(permission.toString());
-            }
-            perms.sort(null);
-            
-            for (String perm : perms) {
-                msg += "  " + perm + "\n";
+        String msg;
+
+        // Since the server does not have an Account, we make a special check here to avoid a null
+        // reference.
+        if(myAccount == null && clientId.getClientType() == ClientType.Type.SERVER) {
+            msg = "The contest server has any permission it needs.";
+        } else {
+            //get the list of permissions granted to my account
+            Permission.Type[] myPermissions = myAccount.getPermissionList().getList();
+
+            //construct a String listing each permission
+            msg = "Permissions (" + myPermissions.length + "): \n";
+
+            if (myPermissions.length==0) {
+                msg += "  <none>\n";
+            } else {
+
+                ArrayList<String> perms = new ArrayList<String>();
+
+                for (Permission.Type permission : myPermissions) {
+                    perms.add(permission.toString());
+                }
+                perms.sort(null);
+
+                for (String perm : perms) {
+                    msg += "  " + perm + "\n";
+                }
             }
         }
-        
         //display the permision list
         JOptionPane.showMessageDialog(this, msg, "Current Permissions", JOptionPane.INFORMATION_MESSAGE);
-        
+
     }
 
     @Override

--- a/src/edu/csus/ecs/pc2/ui/PluginLoadPane.java
+++ b/src/edu/csus/ecs/pc2/ui/PluginLoadPane.java
@@ -18,14 +18,14 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 
 /**
  * Pane to allow user to choose and open/start plugin window or pane.
- * 
+ *
  * @author pc2@ecs.csus.edu
  */
 
 public class PluginLoadPane extends JPanePlugin {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -1303011559658754807L;
 
@@ -47,7 +47,7 @@ public class PluginLoadPane extends JPanePlugin {
 
     /**
      * This method initializes
-     * 
+     *
      */
     public PluginLoadPane() {
         super();
@@ -56,7 +56,7 @@ public class PluginLoadPane extends JPanePlugin {
 
     /**
      * This method initializes this
-     * 
+     *
      */
     private void initialize() {
         this.setLayout(null);
@@ -74,7 +74,7 @@ public class PluginLoadPane extends JPanePlugin {
 
     /**
      * This method initializes pluginComboBox
-     * 
+     *
      * @return javax.swing.JComboBox
      */
     private JComboBox<PluginWrapper> getPluginComboBox() {
@@ -87,7 +87,7 @@ public class PluginLoadPane extends JPanePlugin {
 
     /**
      * This method initializes openNewPluginButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getOpenNewPluginButton() {
@@ -96,6 +96,7 @@ public class PluginLoadPane extends JPanePlugin {
             openNewPluginButton.setBounds(new Rectangle(41, 147, 134, 36));
             openNewPluginButton.setText("Add Tab");
             openNewPluginButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     addNewTab();
                 }
@@ -119,7 +120,7 @@ public class PluginLoadPane extends JPanePlugin {
 
     /**
      * This method initializes addPluginInNewWindow
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getAddPluginInNewWindow() {
@@ -128,6 +129,7 @@ public class PluginLoadPane extends JPanePlugin {
             addPluginInNewWindow.setBounds(new Rectangle(317, 147, 182, 36));
             addPluginInNewWindow.setText("Open in new Window");
             addPluginInNewWindow.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     addNewPluginWindow();
                 }
@@ -144,7 +146,7 @@ public class PluginLoadPane extends JPanePlugin {
     }
 
     /**
-     * 
+     *
      * @author pc2@ecs.csus.edu
      * @version $Id$
      */
@@ -177,7 +179,7 @@ public class PluginLoadPane extends JPanePlugin {
 
     private JPanePlugin[] getPluginList() {
         Vector<JPanePlugin> plugins = new Vector<JPanePlugin>();
-        
+
         plugins.add(new AccountsPane());
         plugins.add(new AccountsTablePane());
         plugins.add(new AutoJudgesPane());
@@ -187,6 +189,7 @@ public class PluginLoadPane extends JPanePlugin {
         plugins.add(new ConnectionsPane());
         plugins.add(new ConnectionsTablePane());
         plugins.add(new ContestClockPane());
+        plugins.add(new ContestInformationPane());
         plugins.add(new ContestScheduledStartClockPane());
         plugins.add(new ContestTimesPane());
         plugins.add(new EventFeedServerPane());
@@ -216,10 +219,10 @@ public class PluginLoadPane extends JPanePlugin {
         plugins.add(new ViewPropertiesPane());
         plugins.add(new NSAStandingsPane());
         plugins.add(new QuickJudgePane());
-        
+
         plugins.add(new ResultsComparePane());
 
-        JPanePlugin[] pluginList = (JPanePlugin[]) plugins.toArray(new JPanePlugin[plugins.size()]);
+        JPanePlugin[] pluginList = plugins.toArray(new JPanePlugin[plugins.size()]);
 
         Arrays.sort(pluginList, new JPluginPaneNameComparator());
 
@@ -229,6 +232,7 @@ public class PluginLoadPane extends JPanePlugin {
     private void loadPluginList() {
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 pluginComboBox.removeAllItems();
                 for (JPanePlugin plugin : getPluginList()) {

--- a/src/edu/csus/ecs/pc2/ui/PluginPane.java
+++ b/src/edu/csus/ecs/pc2/ui/PluginPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -14,7 +14,7 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 
 /**
  * Pane for Plugin Frame (tabbed panes).
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -23,7 +23,7 @@ import edu.csus.ecs.pc2.core.model.IInternalContest;
 public class PluginPane extends JPanePlugin {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 4327701084703859112L;
 
@@ -35,7 +35,7 @@ public class PluginPane extends JPanePlugin {
 
     /**
      * This method initializes
-     * 
+     *
      */
     public PluginPane() {
         super();
@@ -44,7 +44,7 @@ public class PluginPane extends JPanePlugin {
 
     /**
      * This method initializes this
-     * 
+     *
      */
     private void initialize() {
         this.setLayout(new BorderLayout());
@@ -56,13 +56,15 @@ public class PluginPane extends JPanePlugin {
 
     }
 
+    @Override
     public String getPluginTitle() {
         return "Plugin View";
     }
 
+    @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         super.setContestAndController(inContest, inController);
-        
+
         PluginLoadPane pluginLoadPane = new PluginLoadPane();
         pluginLoadPane.setParentFrame(getParentFrame());
         pluginLoadPane.setParentTabbedPane(getPluginTabbedPane());
@@ -72,7 +74,7 @@ public class PluginPane extends JPanePlugin {
 
     /**
      * This method initializes pluginTabbedPane
-     * 
+     *
      * @return javax.swing.JTabbedPane
      */
     private JTabbedPane getPluginTabbedPane() {
@@ -84,13 +86,13 @@ public class PluginPane extends JPanePlugin {
 
     /**
      * This method initializes infoPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getInfoPane() {
         if (infoPane == null) {
             infoLabel = new JLabel();
-            infoLabel.setText("JLabel");
+            infoLabel.setText("Dynamically Load Plugins");
             infoLabel.setHorizontalAlignment(SwingConstants.CENTER);
             infoLabel.setHorizontalTextPosition(SwingConstants.CENTER);
             infoPane = new JPanel();

--- a/src/edu/csus/ecs/pc2/ui/ViewPropertiesPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ViewPropertiesPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -25,7 +25,7 @@ import edu.csus.ecs.pc2.core.security.Permission.Type;
 
 /**
  * View this clients properties.
- *  
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -34,7 +34,7 @@ import edu.csus.ecs.pc2.core.security.Permission.Type;
 public class ViewPropertiesPane extends JPanePlugin {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 2554693130978453347L;
 
@@ -54,9 +54,12 @@ public class ViewPropertiesPane extends JPanePlugin {
 
     private JButton closeButton = null;
 
+    private JPanel permissionSummaryPane = null;
+
+
     /**
      * This method initializes
-     * 
+     *
      */
     public ViewPropertiesPane() {
         super();
@@ -65,11 +68,12 @@ public class ViewPropertiesPane extends JPanePlugin {
 
     /**
      * This method initializes this
-     * 
+     *
      */
     private void initialize() {
         this.setLayout(new BorderLayout());
         this.setSize(new Dimension(396, 208));
+        this.add(getPermissionSummaryPane(), BorderLayout.NORTH);
         this.add(getPermissionsScrollPane(), BorderLayout.CENTER);
         this.add(getButtonPane(), BorderLayout.SOUTH);
 
@@ -82,7 +86,7 @@ public class ViewPropertiesPane extends JPanePlugin {
 
     /**
      * This method initializes permissionsJList
-     * 
+     *
      * @return javax.swing.JList
      */
     private JCheckBoxJList getPermissionsJList() {
@@ -91,6 +95,7 @@ public class ViewPropertiesPane extends JPanePlugin {
             permissionsJList.setModel(defaultListModel);
             // ListSelectionListeners are called before JCheckBoxes get updated
             permissionsJList.addPropertyChangeListener("change", new PropertyChangeListener() {
+                @Override
                 public void propertyChange(PropertyChangeEvent evt) {
                     showPermissionCount(permissionsJList.getSelectedIndices().length + " permissions selected");
                 }
@@ -104,7 +109,7 @@ public class ViewPropertiesPane extends JPanePlugin {
         super.setContestAndController(inContest, inController);
         account = inContest.getAccount(inContest.getClientId());
         populatePermissions(account);
-        
+
         if (getParentFrame() != null){
             getParentFrame().setTitle("Permissions/Abilities for " + inContest.getClientId());
         }
@@ -174,15 +179,16 @@ public class ViewPropertiesPane extends JPanePlugin {
 
     public void showPermissionCount(final String message) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
-                permissionCountLabel.setText(message);
+                getPermissionCountLabel().setText(message);
             }
         });
     }
 
     /**
      * This method initializes permissionsScrollPane
-     * 
+     *
      * @return javax.swing.JScrollPane
      */
     private JScrollPane getPermissionsScrollPane() {
@@ -195,7 +201,7 @@ public class ViewPropertiesPane extends JPanePlugin {
 
     /**
      * This method initializes buttonPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getButtonPane() {
@@ -203,14 +209,17 @@ public class ViewPropertiesPane extends JPanePlugin {
             buttonPane = new JPanel();
             buttonPane.setLayout(new FlowLayout());
             buttonPane.setPreferredSize(new Dimension(35, 35));
-            buttonPane.add(getCloseButton(), null);
+            // do not add close button if in a tabbed control
+            if(getParentFrame() != null) {
+                buttonPane.add(getCloseButton(), null);
+            }
         }
         return buttonPane;
     }
 
     /**
      * This method initializes closeButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getCloseButton() {
@@ -218,6 +227,7 @@ public class ViewPropertiesPane extends JPanePlugin {
             closeButton = new JButton();
             closeButton.setText("Close");
             closeButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     closeWindow();
                 }
@@ -230,6 +240,29 @@ public class ViewPropertiesPane extends JPanePlugin {
         if (getParentFrame() != null) {
             getParentFrame().setVisible(false);
         }
+    }
+
+    /**
+     * The summary pane is used to show things like how many permissions are selected.
+     * it appears at the top of the frame
+     *
+     * @return the pane containing the summary info
+     */
+    private JPanel getPermissionSummaryPane() {
+        if(permissionSummaryPane == null) {
+            permissionSummaryPane = new JPanel();
+            permissionSummaryPane.setLayout(new FlowLayout());
+            permissionSummaryPane.setPreferredSize(new Dimension(25, 25));
+            permissionSummaryPane.add(getPermissionCountLabel(), null);
+        }
+        return(permissionSummaryPane);
+    }
+
+    private JLabel getPermissionCountLabel() {
+        if(permissionCountLabel == null) {
+          permissionCountLabel = new JLabel("No permissions selected");
+        }
+        return(permissionCountLabel);
     }
 
 } // @jve:decl-index=0:visual-constraint="10,10"

--- a/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
+++ b/src/edu/csus/ecs/pc2/ui/admin/AdministratorView.java
@@ -23,6 +23,7 @@ import javax.swing.event.ChangeListener;
 import edu.csus.ecs.pc2.VersionInfo;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.IniFile;
+import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.StaticLog;
@@ -83,6 +84,8 @@ import edu.csus.ecs.pc2.ui.UIPlugin;
 public class AdministratorView extends JFrame implements UIPlugin, ChangeListener {
 
     private static final long serialVersionUID = 1L;
+
+    private static final String SAMPLE_SUBMIT_PANE_KEY = "admin.sampleSubmitPane";
 
     private IInternalContest contest;
 
@@ -333,8 +336,10 @@ public class AdministratorView extends JFrame implements UIPlugin, ChangeListene
                 QuickJudgePane quickJudgePane = new QuickJudgePane();
                 addUIPlugin(getRunContestTabbedPane(), "Judging Utilities", quickJudgePane);
 
-                SubmitSampleRunsPane sampleRunsPane = new SubmitSampleRunsPane();
-                addUIPlugin(getRunContestTabbedPane(), "Submit Samples", sampleRunsPane);
+                if(StringUtilities.getBooleanValue(IniFile.getValue(SAMPLE_SUBMIT_PANE_KEY), false)) {
+                    SubmitSampleRunsPane sampleRunsPane = new SubmitSampleRunsPane();
+                    addUIPlugin(getRunContestTabbedPane(), "Submit Samples", sampleRunsPane);
+                }
 
                 if (!controller.isSuppressLoginsPaneDisplay()) {
                     LoginsTablePane loginsTablePane = new LoginsTablePane();


### PR DESCRIPTION
### Description of what the PR does
Uses the newer, more full-featured, `SubmitSampleRunsPane `instead of the older limited `SubmitSubmissionsPane `to submit judge sample runs on some panes.  Also, add the ability to add the `SubmitSubmissionsPane `to the **Admin** and **Judge** clients by an INI file setting.

A couple CI bug fixes (NPE's) noticed while making the changes above.

### Issue which the PR addresses
Fixes #992

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Add the following to your `pc2v9.ini `file (at the end is a good place):
```
[admin]
sampleSubmitPane=true
```
2) Start up the server
3) Start up an administrator client.
4) Note that the "**Submit Samples**" tab appears.
5) Remove the setting from the `pc2v9.ini `file
6) Restart the administrator client.
7) Note there is no "**Submit Samples**" tab.
8) You can repeat using the judge client with the following added to the `pc2v9.ini `file:
```
[judge]
sampleSubmitPane=true
```


