### PR TITLE
i995, i968, i975 Scoreboard JSON file always shows 0 for the time of a solved problem

### DIFF
--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboard.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboard.java
@@ -130,10 +130,9 @@ public class CLICSScoreboard {
                 
                 scoreRow.setTime(toInt(psi.getSolutionTime()));
                 
-                String problemIdNumber = psi.getProblemId();
-                // TODO FIX must get shortname from Problem rather than using id
-                String problemShortName = "Id = " + problemIdNumber;
-                scoreRow.setProblem_id(problemShortName); // problem short name
+                String problemShortName = psi.getShortName();
+                
+                scoreRow.setProblem_id(problemShortName);
 
                 scoreRow.setNum_pending(toInt(psi.getIsPending()));
 

--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboard.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSScoreboard.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 
 package edu.csus.ecs.pc2.core.imports.clics;
 
@@ -123,9 +123,13 @@ public class CLICSScoreboard {
                 ProblemScoreRow scoreRow = new ProblemScoreRow();
 
                 //  <problem attempts="50" bestSolutionTime="13" id="3" lastSolutionTime="87" numberSolved="35" title="Careful Ascent"/>
-
+                   
+                scoreRow.setSolved(toBool(psi.getIsSolved(), false));
+                
                 scoreRow.setNum_judged(toInt(psi.getAttempts()));
-
+                
+                scoreRow.setTime(toInt(psi.getSolutionTime()));
+                
                 String problemIdNumber = psi.getProblemId();
                 // TODO FIX must get shortname from Problem rather than using id
                 String problemShortName = "Id = " + problemIdNumber;
@@ -133,7 +137,7 @@ public class CLICSScoreboard {
 
                 scoreRow.setNum_pending(toInt(psi.getIsPending()));
 
-                scoreRow.setSolved(toBool(psi.getIsSolved(), false));
+                
 
                 problemList.add(scoreRow);
             }

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -793,6 +793,7 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
                     IMemento psiMemento = standingsRecordMemento.createChild("problemSummaryInfo");
                     psiMemento.putInteger("index", problemsIndexHash.get(psi.getProblemId()));
                     psiMemento.putString("problemId", psi.getProblemId().toString());
+                    psiMemento.putString("shortName", problems[problemsIndexHash.get(psi.getProblemId())-1].getShortName());
                     psiMemento.putInteger("attempts", psi.getNumberSubmitted());
                     psiMemento.putInteger("points", psi.getPenaltyPoints());
                     psiMemento.putLong("solutionTime", psi.getSolutionTime());

--- a/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
@@ -782,6 +782,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         IMemento summaryInfoMemento = mementoRoot.createChild("problemSummaryInfo");
         summaryInfoMemento.putInteger("index", index);
         summaryInfoMemento.putString("problemId", summaryInfo.getProblemId().toString());
+        summaryInfoMemento.putString("shortName", summaryInfo.getShortName());
         summaryInfoMemento.putInteger("attempts", summaryInfo.getNumberSubmitted());
         summaryInfoMemento.putInteger("points", summaryInfo.getPenaltyPoints());
         summaryInfoMemento.putLong("solutionTime", summaryInfo.getSolutionTime());
@@ -801,6 +802,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         summaryInfo.setUnJudgedRuns(false);
         summaryInfo.setSolved(problemScoreRecord.isSolved());
         summaryInfo.setProblemId(problem.getElementId());
+        summaryInfo.setShortName(problem.getShortName());
 
         return summaryInfo;
     }

--- a/src/edu/csus/ecs/pc2/core/scoring/ProblemSummaryInfo.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/ProblemSummaryInfo.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.scoring;
 
 import java.io.Serializable;
@@ -35,6 +35,8 @@ public class ProblemSummaryInfo implements Serializable {
     private int judgedRunCount = 0;
 
     private ElementId problemId = null;
+    
+    private String shortName = "";
 
     /**
      * @return Returns the problemId.
@@ -49,6 +51,14 @@ public class ProblemSummaryInfo implements Serializable {
      */
     public void setProblemId(edu.csus.ecs.pc2.core.model.ElementId problemId) {
         this.problemId = problemId;
+    }
+    
+    public String getShortName() {
+        return shortName;
+    }
+    
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/standings/ContestStandings.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ContestStandings.java
@@ -2,6 +2,7 @@
 package edu.csus.ecs.pc2.core.standings;
 
 import java.util.List;
+import java.util.logging.Level;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -12,6 +13,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.log.StaticLog;
 
 /**
  * This class encapsulates a collection of data representing the current contest standings.  
@@ -62,7 +66,8 @@ public class ContestStandings {
         try {
             retStr = mapper.writeValueAsString(this);
         } catch (JsonProcessingException e) {
-            // TODO pass a log into this class so we can do proper logging
+            Log log = StaticLog.getLog();
+            log.log(Level.WARNING, "Contest Standings (teamStanding) was unable to be turned into a JSON", e);
             e.printStackTrace();
         }
         

--- a/src/edu/csus/ecs/pc2/core/standings/GroupList.java
+++ b/src/edu/csus/ecs/pc2/core/standings/GroupList.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings;
 
 import java.util.List;
@@ -7,6 +7,11 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * scoreboard XML group element.
@@ -19,7 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class GroupList {
 
     //    <groupList>
-    //    <group externalId="18475" id="4" title="ICPC North America South Division Championship"/>
+    //    <group externalId="18475" id="4" included = "1" title="ICPC North America South Division Championship"/>
     //    </groupList>
 
     public List<ScoringGroup> getGroups() {
@@ -31,6 +36,23 @@ public class GroupList {
     }
 
     @XmlElement(name = "group")
+    @JacksonXmlProperty(localName = "group")
+    @JacksonXmlElementWrapper(useWrapping = false)
     private List<ScoringGroup> groups = null;
-
+    
+    @Override
+    public String toString() {
+        
+        String retStr = "Undefined";
+        ObjectMapper mapper = new ObjectMapper();
+        
+        try {
+            retStr = mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            // TODO pass a log into this class so we can do proper logging
+            e.printStackTrace();
+        }
+        
+        return retStr;
+    }
 }

--- a/src/edu/csus/ecs/pc2/core/standings/GroupList.java
+++ b/src/edu/csus/ecs/pc2/core/standings/GroupList.java
@@ -2,6 +2,7 @@
 package edu.csus.ecs.pc2.core.standings;
 
 import java.util.List;
+import java.util.logging.Level;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -12,6 +13,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.log.StaticLog;
 
 /**
  * scoreboard XML group element.
@@ -49,7 +53,8 @@ public class GroupList {
         try {
             retStr = mapper.writeValueAsString(this);
         } catch (JsonProcessingException e) {
-            // TODO pass a log into this class so we can do proper logging
+            Log log = StaticLog.getLog();
+            log.log(Level.WARNING, "GroupList was unable to be turned into a JSON", e);
             e.printStackTrace();
         }
         

--- a/src/edu/csus/ecs/pc2/core/standings/ProblemSummaryInfo.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ProblemSummaryInfo.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -18,7 +18,7 @@ public class ProblemSummaryInfo {
 
     // <problemSummaryInfo attempts="0" index="12" isPending="false"
     // isSolved="false" points="0" problemId="sodaslurper--6927480297132897573"
-    // solutionTime="0"/>
+    // shortName ="sodaslurper" solutionTime="0"/>
 
     @XmlAttribute
     private String attempts;
@@ -37,6 +37,9 @@ public class ProblemSummaryInfo {
 
     @XmlAttribute
     private String problemId;
+    
+    @XmlAttribute
+    private String shortName;
 
     @XmlAttribute
     private String solutionTime;
@@ -87,6 +90,14 @@ public class ProblemSummaryInfo {
 
     public void setProblemId(String problemId) {
         this.problemId = problemId;
+    }
+    
+    public String getShortName() {
+        return shortName;
+    }
+
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
     }
 
     public String getSolutionTime() {

--- a/src/edu/csus/ecs/pc2/core/standings/ScoringGroup.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ScoringGroup.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -6,17 +6,20 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
-@XmlRootElement(name = "scoringGroup")
+@XmlRootElement(name = "group")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ScoringGroup {
 
-    // <group externalId="18474" id="1" title="ICPC North America East Division Championship"/>
+    // <group externalId="18474" id="1" included="1" title="ICPC North America East Division Championship"/>
 
     @XmlAttribute
     private String externalId;
 
     @XmlAttribute
     private String id;
+    
+    @XmlAttribute
+    private String included; //TODO could be boolean
 
     @XmlAttribute
     private String title;
@@ -35,6 +38,14 @@ public class ScoringGroup {
 
     public void setId(String id) {
         this.id = id;
+    }
+    
+    public String getIncluded() {
+        return included;
+    }
+
+    public void setIncluded(String included) {
+        this.included = included;
     }
 
     public String getTitle() {

--- a/src/edu/csus/ecs/pc2/core/standings/ScoringProblem.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ScoringProblem.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -12,7 +12,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @author Douglas A. Lane <pc2@ecs.csus.edu>
  *
  */
-@XmlRootElement(name = "scoringGroup")
+@XmlRootElement(name = "problem")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ScoringProblem {
 

--- a/src/edu/csus/ecs/pc2/core/standings/StandingsHeader.java
+++ b/src/edu/csus/ecs/pc2/core/standings/StandingsHeader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings;
 
 import java.io.Serializable;
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -13,6 +14,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * This class defines the header which appears at the top of a {@link ContestStandings} object.  
@@ -90,10 +93,18 @@ public class StandingsHeader implements Serializable {
     @XmlAttribute
     private String totalSolved;
     
+    @XmlAnyElement(lax = true)
+    private List<Object> otherElements;
+
+    
     @XmlElement(name = "groupList")
+    @JacksonXmlProperty(localName = "groupList")
+    @JacksonXmlElementWrapper(useWrapping = false)
     private GroupList grouplist = null;
 
     @XmlElement(name = "problem")
+    @JacksonXmlProperty(localName = "problem")
+    @JacksonXmlElementWrapper(useWrapping = false)
     private List<ScoringProblem> problems = null;
 
     public String getGeneratorId() {

--- a/src/edu/csus/ecs/pc2/core/standings/json/ProblemScoreRow.java
+++ b/src/edu/csus/ecs/pc2/core/standings/json/ProblemScoreRow.java
@@ -1,9 +1,15 @@
-// Copyright (C) 1989-2021 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.standings.json;
+
+import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * 
@@ -12,9 +18,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
  *
  */
 
-//The following annotation tells the Jackson ObjectMapper not to include "type information" when it serializes
+//The annotation one after @JsonSerialize tells the Jackson ObjectMapper not to include "type information" when it serializes
 //objects of this class (the default is to include the fully-qualified class name as an additional JSON element).
 //(Note that exclusion of such type information means that generated JSON cannot subsequently be accurately DESERIALIZED...)
+@JsonSerialize(using = ProblemScoreRowSerializer.class)
 @JsonTypeInfo(use=Id.NONE)
 public class ProblemScoreRow {
     
@@ -69,5 +76,27 @@ public class ProblemScoreRow {
         this.num_pending = num_pending;
     }
     
+}
+
+/**
+ * This custom JsonSerialer for ProblemScoreRow class adds time field to Json based on the condition of whether the problem is marked as solved or not. 
+ * If it is the boolean for solved is marked true Json will have time field. If not Json will not have the time field.
+ *
+ */
+class ProblemScoreRowSerializer extends JsonSerializer<ProblemScoreRow> {
+    @Override
+    public void serialize(ProblemScoreRow problemScoreRow, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+        gen.writeBooleanField("solved", problemScoreRow.isSolved());
+        gen.writeNumberField("num_judged", problemScoreRow.getNum_judged());
+
+        if (problemScoreRow.isSolved()) {
+            gen.writeNumberField("time", problemScoreRow.getTime());
+        } 
+        gen.writeStringField("problem_id", problemScoreRow.getProblem_id());
+        gen.writeNumberField("num_pending", problemScoreRow.getNum_pending());
+
+        gen.writeEndObject();
+    }
 }
 

--- a/src/edu/csus/ecs/pc2/ui/ReportPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ReportPane.java
@@ -628,7 +628,7 @@ public class ReportPane extends JPanePlugin {
 
             selectedReport.setContestAndController(getContest(), getController());
 
-            // SOMEDAY insure that each report createReportFile sets the filter too
+            // SOMEDAY ensure that each report createReportFile sets the filter too
             /**
              * Using setFilter because createReportFile may not set the filter
              */


### PR DESCRIPTION
Before submitting your Pull Request, please make sure you have read the [Guidelines for Submitting Pull Requests](https://github.com/pc2ccs/pc2v9/wiki/Guidelines-for-Submitting-Pull-Requests).  Then please provide the following information:

### Description of what the PR does
Fixes the three issue that will be mentioned below. shortName info is added to standing XML's by the scoring algorithms so that shortName can be displayed in ScoreboardJSON. 

ScoreboardJSON report no longer shows 0 for time of solved problems. 

Grouplist and problems are no longer null. They have the correct values. This is a intermediate XML file and it is not used so this can't be seen in UI.

### Issue which the PR addresses
fixes #968 and fixes #995 and fixes #975

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12 R, JDK 8u381 (1.8)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
For #968 open admin or server. Then select reports. Select Scoreboard JSON from reports. Then export report contents. Save the pop up. Check the file download. Observe that time for solved problems are not 0 anymore. 

For #995 Before the method createContestStandings(String xmlString) .......core/standings/ScoreboardUtilities.java returns ContestStandings object. Compare the object and xml string. Information on groups and problems that were not there is there. That point of the code can be reached by attempting to export Scoreboard JSON report from admin or server.

For #975 open admin or server. Then select reports. Select Scoreboard JSON from reports. Then export report contents. Save the pop up. Check the file download. Observe that problem_id's value is shortName. 