### PR TITLE
i_1003 Use CLICSScoreboard instead of ScoreboardJson 

### DIFF
--- a/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
@@ -14,11 +14,13 @@ import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.ExecuteUtilities;
 import edu.csus.ecs.pc2.core.imports.clics.CLICSAward;
 import edu.csus.ecs.pc2.core.imports.clics.CLICSAwardUtilities;
+import edu.csus.ecs.pc2.core.imports.clics.CLICSScoreboard;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.standings.ContestStandings;
+import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
 import edu.csus.ecs.pc2.services.core.EventFeedJSON;
-import edu.csus.ecs.pc2.services.core.ScoreboardJson;
 
 public class ExportFilesUtilities {
 
@@ -61,13 +63,13 @@ public class ExportFilesUtilities {
         }
 
         try {
-            ScoreboardJson scoreboardJson = new ScoreboardJson();
-            String json = scoreboardJson.createJSON(contest);
-            String[] scoreboardJsonLines = { json };
-            FileUtilities.writeFileContents(scoreboardJsonFilename, scoreboardJsonLines);
+            ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
+            CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contestStandings);
+            String json = clicsScoreboard.toString();
+            String[] sa = { json };
+            FileUtilities.writeFileContents(scoreboardJsonFilename, sa);
 
             filesCreated.add(scoreboardJsonFilename);
-
         } catch (Exception e) {
             StaticLog.getLog().log(Level.WARNING, "Problem writing scorebord file", e);
             Utilities.printStackTrace(System.out, e);


### PR DESCRIPTION
### Description of what the PR does
For the **Results Export Files** report, use the newer `CLICSScoreboardJson `class which includes the correct `time `property for each problem, as well as the correct `shortname `(instead of the element id).
### Issue which the PR addresses
Fixes #1003 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) On a completed contest, generate the "**Results Export Files**" report.
2) View the `scoreboard.json` file.
3) Look for the correct short name for a team's problems as well as a non-zero `time `property, if the problem was solved.