### PR TITLE
I1008 Fix null date for Event Feed JSON Report generation

### DIFF
--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -242,7 +242,7 @@ public class JSONTool {
             
             // Only get date if the contest is, in fact, certified
             if (finalizedData != null && finalizedData.isCertified()) {
-                finalizedDate = Utilities.getIso8601formatterWithMS().format(model.getFinalizeData().getCertificationDate());
+                finalizedDate = Utilities.getIso8601formatterWithMS().format(finalizedData.getCertificationDate());
             }
             if (finalizedDate != null) {
                 element.put("finalized", finalizedDate);

--- a/src/edu/csus/ecs/pc2/core/util/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/core/util/JSONTool.java
@@ -26,6 +26,7 @@ import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.model.ContestInformation;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.FinalizeData;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Judgement;
@@ -237,7 +238,10 @@ public class JSONTool {
             }
             // FIXME this should only be showed if the contest is thawed for public users
             String finalizedDate = null;
-            if (model.getFinalizeData() != null) {
+            FinalizeData finalizedData = model.getFinalizeData();
+            
+            // Only get date if the contest is, in fact, certified
+            if (finalizedData != null && finalizedData.isCertified()) {
                 finalizedDate = Utilities.getIso8601formatterWithMS().format(model.getFinalizeData().getCertificationDate());
             }
             if (finalizedDate != null) {


### PR DESCRIPTION
### Description of what the PR does
Prevents an exception when generating an **Event Feed JSON** report during an active (non-finalized) contest.

### Issue which the PR addresses
Fixes #1008 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. On a non-finalized, active contest, go to the **Finalize** Tab on an Administrator
2. Press **Update** and **View** the results (this causes a `FinalizeData `object to be created with a `null `certification time in it, and the `FinalizeData `is not certified).
3. Generate an **Event Feed JSON** report.
4. Observe the **Event Feed JSON** report is correctly generated and no Exception occurs.
