### PR TITLE
i1025: bump WTI version to 1.2 in BuildWTI.xml and in user scripts.

### DIFF
--- a/projects/WTI-API/buildWTI.xml
+++ b/projects/WTI-API/buildWTI.xml
@@ -16,7 +16,7 @@
     <property name="main-class" value="config.JettyConfig" />
     <property name="bin" location="bin" />
     <property name="build.dir" location="build" />
-    <property name="wtiversion" value="1.1" />
+    <property name="wtiversion" value="1.2" />
     <property name="liblocation" location="WebContent\WEB-INF\lib" />
 	<property name="frontendlocation" location="../WTI-UI" />
     <property name="websockets" location="websockets" />

--- a/projects/WTI-API/scripts/pc2wti
+++ b/projects/WTI-API/scripts/pc2wti
@@ -13,6 +13,6 @@ else
   PC2XOPS=""
 fi
 
-java -Djdk.crypto.KeyAgreement.legacyKDF=true $PC2XOPS -Xms64M -Xmx2048M -jar WebTeamInterface-1.1.jar
+java -Djdk.crypto.KeyAgreement.legacyKDF=true $PC2XOPS -Xms64M -Xmx2048M -jar WebTeamInterface-1.2.jar
 
 # eof pc2wti 

--- a/projects/WTI-API/scripts/pc2wti.bat
+++ b/projects/WTI-API/scripts/pc2wti.bat
@@ -4,6 +4,6 @@ REM Copyright (C) 1989-2020 PC2 Development Team: John Clevenger, Douglas Lane, 
 rem Purpose: start the WebTeamInterface (WTI) project team webserver module
 rem Author : pc2@ecs.csus.edu
 
-java -Djdk.crypto.KeyAgreement.legacyKDF=true -Xms64M -Xmx2048M -jar WebTeamInterface-1.1.jar
+java -Djdk.crypto.KeyAgreement.legacyKDF=true -Xms64M -Xmx2048M -jar WebTeamInterface-1.2.jar
 
 rem eof pc2wti.bat 

--- a/projects/WTI-API/scripts/wtizip
+++ b/projects/WTI-API/scripts/wtizip
@@ -13,6 +13,6 @@ else
   PC2XOPS=""
 fi
 
-java -Djdk.crypto.KeyAgreement.legacyKDF=true -Xms64M -Xmx2048M -cp WebTeamInterface-1.1.jar edu.csus.ecs.pc2.wti.core.archive.ZipWTI %1 %2 %3 %4 %5 %6 %7 %8 %9 
+java -Djdk.crypto.KeyAgreement.legacyKDF=true -Xms64M -Xmx2048M -cp WebTeamInterface-1.2.jar edu.csus.ecs.pc2.wti.core.archive.ZipWTI %1 %2 %3 %4 %5 %6 %7 %8 %9 
 
 # eof pc2wti 

--- a/projects/WTI-API/scripts/wtizip.bat
+++ b/projects/WTI-API/scripts/wtizip.bat
@@ -4,6 +4,6 @@ REM Copyright (C) 1989-2020 PC2 Development Team: John Clevenger, Douglas Lane, 
 rem Purpose: start the ZipWTI to archive WTI files
 rem Author : Douglas A. Lane <pc2@ecs.csus.edu>
 
-java -Djdk.crypto.KeyAgreement.legacyKDF=true -Xms64M -Xmx2048M -cp WebTeamInterface-1.1.jar edu.csus.ecs.pc2.wti.core.archive.ZipWTI %1 %2 %3 %4 %5 %6 %7 %8 %9 
+java -Djdk.crypto.KeyAgreement.legacyKDF=true -Xms64M -Xmx2048M -cp WebTeamInterface-1.2.jar edu.csus.ecs.pc2.wti.core.archive.ZipWTI %1 %2 %3 %4 %5 %6 %7 %8 %9 
 
 rem eof pc2wti.bat 


### PR DESCRIPTION
### Description of what the PR does
Bumps references to WTI version number from 1.1 to 1.2.   Accomplishing this required changes to five files: 
* `BuildWTI.xml`: the `wtiversion` property value was changed from "1.1" to "1.2"
* The four "user scripts" under **/bin**: pc2wti, pc2wti.bat, wtizip, and wtizip.bat.  The command-line argument in each of these files which previously referred to the "1.1" jar file was changed to refer instead to the "1.2" jar file.

### Issue which the PR addresses
Fixes Issue #1025 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse Version: 2021-12 (4.22.0), Java version  1.8.0_381

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
#### Static Testing
* Download and upzip the PR distribution.
* Unzip the distribution.
* Change to the **/projects** folder; verify that the zip file therein indicates version "1.2".
* Unzip the WebTeamInterface-1.2 zip file.
* Change to the WebTeamInterface-1.2 folder resulting from the unzip.
* Change to the **bin** folder.
* Open each of the four script files; verify that any place they reference "WebTeamInterface" it refers to version "1.2" in the command.
#### Dynamic Testing
* Using the unzipped PC2 distribution, start a PC2 Server using **--load sumithello**.
* Start a PC2 Admin and use it to start the contest running (or, edit the file **samps/contests/sumithello/config/contest.yaml** so that it automatically sets the contest "running" -- you'll have to do this before starting the server).
* In the **/projects/WebTeamInterface-1.2** folder, open a command terminal and execute **./bin/pc2wti**.  Verify that this starts the WTI Server.
* Open a browser to **http://localhost:50443** (or your machine's IP and WTI port).  Verify that you are presented with the PC2 WTI Login page.
* Submit a run using the WTI "Submit Problem" button.
* Use the Admin to edit the run's "State" from QUEUED_FOR_COMPUTER_JUDGEMENT to "NEW".   (Or, you could have started an AJ to handled the judging).
* Verify that when the run has been judged, a Judgement Notifcation appears on the WTI Team page.
* Open a command prompt in the **projects/WebTeamInterface-1.2** folder and enter the command **./bin/wtizip**.  Verify that this creates an **archive** folder, and stores a **pc2wtiarchive** file beneath it.
* Ideally: repeat all the above on a different platform (so that it's been tested in different environments).