### PR TITLE
i_1043 Fix GUI so you can see Scoring Properties

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -597,9 +597,9 @@ public class ContestInformationPane extends JPanePlugin {
             judgeSettingsPane = new JPanel();
 
             judgeSettingsPane.setAlignmentX(LEFT_ALIGNMENT);
-            judgeSettingsPane.setMaximumSize(new Dimension(900, 425));
-            judgeSettingsPane.setMinimumSize(new Dimension(900, 425));
-            judgeSettingsPane.setPreferredSize(new Dimension(900,375));
+            judgeSettingsPane.setMaximumSize(new Dimension(900, 525));
+            judgeSettingsPane.setMinimumSize(new Dimension(900, 525));
+            judgeSettingsPane.setPreferredSize(new Dimension(900,525));
 
             if (showPaneOutlines) {
 
@@ -611,7 +611,8 @@ public class ContestInformationPane extends JPanePlugin {
                 judgeSettingsPane.setBorder(new EmptyBorder(2,2,2,2));
             }
 
-            judgeSettingsPane.setLayout(new FlowLayout((FlowLayout.LEFT)));
+//            judgeSettingsPane.setLayout(new FlowLayout((FlowLayout.LEFT)));
+            judgeSettingsPane.setLayout(new BoxLayout(judgeSettingsPane, BoxLayout.Y_AXIS));
 
             //the contents of the pane:
 
@@ -806,6 +807,8 @@ public class ContestInformationPane extends JPanePlugin {
     private JPanel getScoringPropertiesPane() {
         if (scoringPropertiesPane == null) {
             scoringPropertiesPane = new ScoringPropertiesPane(getUpdateButton(),getCancelButton());
+            scoringPropertiesPane.setMaximumSize(new Dimension(700, 200));
+            scoringPropertiesPane.setAlignmentX(Component.LEFT_ALIGNMENT);
 
             scoringPropertiesPane.setBorder(javax.swing.BorderFactory.createTitledBorder(null, "Scoring Properties",
                     javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
@@ -838,7 +841,7 @@ public class ContestInformationPane extends JPanePlugin {
         if (judgesDefaultAnswerPane == null) {
 
             judgesDefaultAnswerPane = new JPanel();
-            judgesDefaultAnswerPane.setMaximumSize(new Dimension(500, 200));
+            judgesDefaultAnswerPane.setMaximumSize(new Dimension(700, 200));
             judgesDefaultAnswerPane.setAlignmentX(Component.LEFT_ALIGNMENT);
 
             judgesDefaultAnswerPane.setLayout(new FlowLayout(FlowLayout.LEFT));
@@ -848,7 +851,6 @@ public class ContestInformationPane extends JPanePlugin {
                     javax.swing.border.TitledBorder.DEFAULT_POSITION, null, null));
 
             //the contents of the pane:
-
             judgesDefaultAnswerPane.add(getJudgesDefaultAnswerTextField(), null);
 
         }
@@ -859,7 +861,7 @@ public class ContestInformationPane extends JPanePlugin {
         if (judgesExecutePane == null) {
 
             judgesExecutePane = new JPanel();
-            judgesExecutePane.setMaximumSize(new Dimension(500, 200));
+            judgesExecutePane.setMaximumSize(new Dimension(700, 200));
             judgesExecutePane.setAlignmentX(Component.LEFT_ALIGNMENT);
 
             judgesExecutePane.setLayout(new FlowLayout(FlowLayout.LEFT));
@@ -1480,10 +1482,10 @@ public class ContestInformationPane extends JPanePlugin {
      */
     private JTextField getJudgesDefaultAnswerTextField() {
         if (judgesDefaultAnswerTextField == null) {
-            judgesDefaultAnswerTextField = new JTextField(50);
+            judgesDefaultAnswerTextField = new JTextField();
             judgesDefaultAnswerTextField.setText("");
-//            judgesDefaultAnswerTextField.setSize(new Dimension(280, 29));
-//            judgesDefaultAnswerTextField.setLocation(new Point(208, 214));
+            // Columns are in 'm' widths, which are quite wide.
+            judgesDefaultAnswerTextField.setColumns(60);
             judgesDefaultAnswerTextField.addKeyListener(new java.awt.event.KeyAdapter() {
                 @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
@@ -1501,7 +1503,9 @@ public class ContestInformationPane extends JPanePlugin {
      */
     private JTextField getJudgesExecuteFolderTextField() {
         if (judgesExecuteFolderTextField == null) {
-            judgesExecuteFolderTextField = new JTextField(50);
+            judgesExecuteFolderTextField = new JTextField();
+            // Column width is that of an 'm', so, 56 'm's.
+            judgesExecuteFolderTextField.setColumns(56);
             judgesExecuteFolderTextField.setText("");
             judgesExecuteFolderTextField.addKeyListener(new java.awt.event.KeyAdapter() {
                 @Override

--- a/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ScoringPropertiesPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -14,6 +14,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
 import com.ibm.webrunner.j2mclb.util.HeapSorter;
+import com.ibm.webrunner.j2mclb.util.StringComparator;
 /**
  * ScoringPropertiesPane is a inner pane for ContestInformationPane
  * Allows editing Scoring Properties for admin.
@@ -21,45 +22,42 @@ import com.ibm.webrunner.j2mclb.util.HeapSorter;
  *
  */
 public class ScoringPropertiesPane extends JPanel {
-    
+
 
     private static final long serialVersionUID = 147946474651407431L;
-
+    private static final int PROPERTY_COL_WIDTH = 170;
+    private static final int VALUE_COL_WIDTH = 500;
     private MCLB propertyListBox = null;
 
     private Properties originalProperties = new Properties(); // @jve:decl-index=0:
-    
+
     private IPropertyUpdater propertyUpdater = null;
-    
+
     private JButton updateButton;
-    
+
     private JButton cancelButton;
-    
-    private int lengthOfColumns;
-    
+
     public ScoringPropertiesPane(JButton updateButtona,JButton cancelButtona) {
         super();
         updateButton = updateButtona;
         cancelButton = cancelButtona;
-        
+
         initialize();
     }
-    
+
     private void initialize() {
         this.setLayout(new BorderLayout());
-        this.setPreferredSize(new Dimension(350, 200));
+        this.setPreferredSize(new Dimension(PROPERTY_COL_WIDTH + VALUE_COL_WIDTH + 8, 200));
+        this.setMinimumSize(new Dimension(PROPERTY_COL_WIDTH + VALUE_COL_WIDTH + 8, 200));
         this.add(getPropertyListBox(), BorderLayout.CENTER);
-        lengthOfColumns = 167;
-        
-
     }
-    
+
     protected void updateProperties(Properties properties) {
         propertyUpdater.updateProperties(properties);
         propertyListBox.removeAllRows();
 
     }
-    
+
     private MCLB getPropertyListBox() {
         if (propertyListBox == null) {
             propertyListBox = new MCLB();
@@ -71,13 +69,15 @@ public class ScoringPropertiesPane extends JPanel {
             propertyListBox.addColumns(cols);
 
             HeapSorter sorter = new HeapSorter();
-            propertyListBox.setColumnSorter(1, sorter, 1);
+            sorter.setComparator(new StringComparator());
+            propertyListBox.setColumnSorter(0, sorter, 1);
 
-            propertyListBox.setColumnSize(0,lengthOfColumns);
-            propertyListBox.setColumnSize(1,lengthOfColumns);
+            propertyListBox.setColumnSize(0,PROPERTY_COL_WIDTH);
+            propertyListBox.setColumnSize(1,VALUE_COL_WIDTH);
             propertyListBox.setResizable(false);
-            
+
             propertyListBox.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyPressed(java.awt.event.KeyEvent e) {
                     enableButtons();
                 }
@@ -85,32 +85,33 @@ public class ScoringPropertiesPane extends JPanel {
         }
         return propertyListBox;
     }
-    
+
     public boolean propertiesChanged() {
         return !originalProperties.equals(getProperties());
     }
-     
+
     public void setProperties(final Properties properties) {
-        
+
         if (properties == null){
             throw new InvalidParameterException("Properties are null");
         }
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 originalProperties = properties;
                 refreshProperties();
             }
         });
     }
-    
+
     protected void refreshProperties() {
 
         propertyListBox.removeAllRows();
 
         Set<Object> set = originalProperties.keySet();
 
-        String[] keys = (String[]) set.toArray(new String[set.size()]);
+        String[] keys = set.toArray(new String[set.size()]);
 
         Arrays.sort(keys);
         for (String key : keys) {
@@ -120,13 +121,13 @@ public class ScoringPropertiesPane extends JPanel {
             objects[1] = createJTextField((String) originalProperties.get(key), false);
             propertyListBox.addRow(objects);
         }
-        
-        propertyListBox.setColumnSize(0,lengthOfColumns);
-        propertyListBox.setColumnSize(1,lengthOfColumns);
+
+        propertyListBox.setColumnSize(0,PROPERTY_COL_WIDTH);
+        propertyListBox.setColumnSize(1,VALUE_COL_WIDTH);
 
         enableButtons();
     }
-    
+
     /**
      * Reads properties from user input.
      * @return
@@ -143,26 +144,27 @@ public class ScoringPropertiesPane extends JPanel {
 
         return fieldProps;
     }
-    
+
     private JTextField createJTextField(String text, boolean passwordField) {
         JTextField textField = new JTextField();
         textField.setText(text);
         textField.addKeyListener(new java.awt.event.KeyAdapter() {
+            @Override
             public void keyReleased(java.awt.event.KeyEvent e) {
                 enableButtons();
             }
         });
         return textField;
     }
-    
+
     public IPropertyUpdater getPropertyUpdater() {
         return propertyUpdater;
     }
-    
+
     public void setPropertyUpdater(IPropertyUpdater propertyUpdater) {
         this.propertyUpdater = propertyUpdater;
-    } 
-    
+    }
+
     protected void enableButtons() {
         boolean changed = propertiesChanged();
 


### PR DESCRIPTION
### Description of what the PR does
Change the layout of the Judge's Settings to be `BoxLayout` to better control placement of the individual judge's panes. Adjust size of `ScoringPropertySheet` so it fits.


### Issue which the PR addresses
Fixes #1043 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Window 11
Linux Ubuntu 22.04
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Build the distribution
2) Start the **pc2server**
3) Start the **pc2admin**
4) Look at the **Settings** tab, and then the **Scoring Properties** under **Judge's Settings**
5) Note that the property sheet fits nicely.
6) This has been tested on both Windows and Linux
