### PR TITLE
I1049 Fix Contest Identifier during Profile Reset

### DIFF
--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -1177,6 +1177,9 @@ public class PacketHandler {
         Profile newProfile = new Profile(settings.getName());
         newProfile.setDescription(settings.getDescription());
         newProfile.setSiteNumber(contest.getSiteNumber());
+        if (!StringUtilities.isEmpty(packet.getContestIdentifier())) {
+            newProfile.setContestId(packet.getContestIdentifier());
+        }
 
         if (settings.getProfilePath() != null){
             newProfile.setProfilePath(settings.getProfilePath());

--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.File;


### PR DESCRIPTION
### Description of what the PR does
When the profile is getting cloned during reset, the `contestId` new profile object is set as same as the old profile's.

### Issue which the PR addresses
Fixes #1049 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10, Eclipse 2021-12 R, JDK 8u381 (1.8), C++ 13.2.0

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Run the Ant script build.xml in the pc2v9 project.
- Start a PC2 Server.
- Start a PC2 Administrator.
- Start a PC2 Event Feeder (Generate one feeder account if not present).
- Click `View Event Feed`.
- The logs should now have the correct id from `contest.yaml` present.
- Now go to `Profiles` tab in Administrator.
- Reset the contest (when prompted keep the boxes unchecked).
- Go back to Event Feeder and `View Event Feed` again.
- The logs should still indicate correct id from `contest.yaml`.