### PR TITLE
I764 throttle submissions

### DIFF
--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -17,6 +17,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 
 import edu.csus.ecs.pc2.api.exceptions.NotLoggedInException;
+import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.api.IClient;
 import edu.csus.ecs.pc2.api.ILanguage;
@@ -270,6 +271,13 @@ public class TeamsController extends MainController {
 		}
 		catch(NotLoggedInException e) {
 			return Response.status(Response.Status.UNAUTHORIZED)
+					.type(MediaType.APPLICATION_JSON)
+					.build();
+		}
+		catch (SubmissionRejectedException e) {
+			String msg = e.getMessage();
+			return Response.status(Response.Status.TOO_MANY_REQUESTS)
+					.entity(Entity.json(new ServerErrorResponseModel(Response.Status.TOO_MANY_REQUESTS, msg)))
 					.type(MediaType.APPLICATION_JSON)
 					.build();
 		}

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, OnDestroy, Inject, ViewChildren, QueryList, ElementRef } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 import { FileSubmission } from 'src/app/modules/core/models/file-submission';
 import { Submission } from 'src/app/modules/core/models/submission';
 import { takeUntil } from 'rxjs/operators';
@@ -137,8 +138,10 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	        this.close();
 	        this._uiHelper.alertOk('Run has been submitted successfully!');
 	        this._teamService.runsUpdated.next();
-	      }, (error: any) => {
-	        this._uiHelper.alertError('Error submitting problem! Check console for details');
+	      }, (error: HttpErrorResponse) => {
+	    	  
+	        this._uiHelper.alertError(error.error.entity.message);
+	        //this._uiHelper.alertError('Error submitting problem! Check console for details');
 	        console.error(error);
 	      });
 	}

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -22,6 +22,7 @@ import edu.csus.ecs.pc2.core.InternalController;
 import edu.csus.ecs.pc2.core.ParseArguments;
 import edu.csus.ecs.pc2.core.PermissionGroup;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
+import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
@@ -600,7 +601,13 @@ public class ServerConnection {
         try {
             controller.submitJudgeRun(submittedProblem, submittedLanguage, serializedMainFile, serializedAdditionalFiles, 
                                         overrideSubmissionTimeMS, overrideRunId);
-        } catch (Exception e) {
+        } 
+        catch (SubmissionRejectedException e) {
+            //the submission was rejected, presumably because of the submitJudgeRun() method's ThrottleStrategy;
+            //forward the exception to the caller
+            throw e ;
+        }
+        catch (Exception e) {
             throw new Exception("Unable to submit run " + e);
         }
     }

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2020 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.api;
 
 import java.io.File;

--- a/src/edu/csus/ecs/pc2/core/IThrottleStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/IThrottleStrategy.java
@@ -1,6 +1,4 @@
-/**
- * 
- */
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import edu.csus.ecs.pc2.core.model.Run;

--- a/src/edu/csus/ecs/pc2/core/IThrottleStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/IThrottleStrategy.java
@@ -1,0 +1,21 @@
+/**
+ * 
+ */
+package edu.csus.ecs.pc2.core;
+
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * This interface defines the methods which a "throttler" (governor) of submission rates must implement.
+ * 
+ * @author John Clevenger
+ *
+ */
+public interface IThrottleStrategy {
+    /**
+     * This method returns true if the implementing Strategy indicates the specified Submission ("Run" in PC2 terms)
+     * should be accepted (that is, forwarded to the PC2 server); false if the Submission exceeds the 
+     * implementation-defined strategy for submission limits.
+     */
+    boolean accept(Run run);
+}

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -78,8 +78,8 @@ import edu.csus.ecs.pc2.core.security.FileSecurity;
 import edu.csus.ecs.pc2.core.security.FileSecurityException;
 import edu.csus.ecs.pc2.core.security.Permission;
 //import edu.csus.ecs.pc2.core.strategies.AcceptAllStrategy;
-//import edu.csus.ecs.pc2.core.strategies.MaxSubmissionsPerMinuteStrategy;
-import edu.csus.ecs.pc2.core.strategies.RejectAllStrategy;
+import edu.csus.ecs.pc2.core.strategies.MaxSubmissionsPerMinuteStrategy;
+//import edu.csus.ecs.pc2.core.strategies.RejectAllStrategy;
 import edu.csus.ecs.pc2.core.transport.ConnectionHandlerID;
 import edu.csus.ecs.pc2.core.transport.IBtoA;
 import edu.csus.ecs.pc2.core.transport.ITransportManager;
@@ -621,7 +621,8 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
             // GUI (such as the PC2 Admin)
 //            IThrottleStrategy strategy = new AcceptAllStrategy();
-            IThrottleStrategy strategy = new RejectAllStrategy();
+//            IThrottleStrategy strategy = new RejectAllStrategy();
+            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,4);
 //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
             
             accept = strategy.accept(run);

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -31,6 +31,7 @@ import edu.csus.ecs.pc2.core.archive.PacketArchiver;
 import edu.csus.ecs.pc2.core.exception.ContestSecurityException;
 import edu.csus.ecs.pc2.core.exception.ProfileException;
 import edu.csus.ecs.pc2.core.exception.ServerProcessException;
+import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.log.EvaluationLog;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.log.StaticLog;
@@ -76,6 +77,9 @@ import edu.csus.ecs.pc2.core.report.ContestSummaryReports;
 import edu.csus.ecs.pc2.core.security.FileSecurity;
 import edu.csus.ecs.pc2.core.security.FileSecurityException;
 import edu.csus.ecs.pc2.core.security.Permission;
+//import edu.csus.ecs.pc2.core.strategies.AcceptAllStrategy;
+//import edu.csus.ecs.pc2.core.strategies.MaxSubmissionsPerMinuteStrategy;
+import edu.csus.ecs.pc2.core.strategies.RejectAllStrategy;
 import edu.csus.ecs.pc2.core.transport.ConnectionHandlerID;
 import edu.csus.ecs.pc2.core.transport.IBtoA;
 import edu.csus.ecs.pc2.core.transport.ITransportManager;
@@ -605,8 +609,31 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         Run run = new Run(contest.getClientId(), language, problem);
         RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);
 
-        Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
-        sendToLocalServer(packet);
+        //determine whether to apply the "current throttling strategy" to this submission 
+        // (i.e., whether to accept the run for submission to the PC2 Server)
+        boolean accept = true;
+        Account submitterAccount = contest.getAccount(contest.getClientId());
+        
+        if (submitterAccount.isTeam()) {
+            //Determine the throttling strategy to be applied to team submissions.
+            //The following shows several alternative strategy selections, with only one being enabled.
+            //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
+            // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
+            // GUI (such as the PC2 Admin)
+//            IThrottleStrategy strategy = new AcceptAllStrategy();
+            IThrottleStrategy strategy = new RejectAllStrategy();
+//            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+            
+            accept = strategy.accept(run);
+        }
+        
+        Packet packet ;
+        if (accept) {
+            packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
+            sendToLocalServer(packet);
+        } else {
+            throw new SubmissionRejectedException("Submission threshhold exceeded");
+        }
     }
 
     @Override

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -620,9 +620,9 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             // GUI (such as the PC2 Admin)
 //            IThrottleStrategy strategy = new AcceptAllStrategy();
 //            IThrottleStrategy strategy = new RejectAllStrategy();
-            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,4);
+            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,6);
 //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
-            
+//            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest); //uses DEFAULT_MAX_SUBMISSIONS_PER_MINUTE; same as prev line
             accept = strategy.accept(run);
         }
         

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -605,9 +605,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
     public void submitJudgeRun(Problem problem, Language language, SerializedFile mainFile, SerializedFile[] otherFiles,
                                 long overrideSubmissionTimeMS, long overrideRunId, boolean overrideStopOnFailure) throws Exception {
 
-        ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
         Run run = new Run(contest.getClientId(), language, problem);
-        RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);
 
         //determine whether to apply the "current throttling strategy" to this submission 
         // (i.e., whether to accept the run for submission to the PC2 Server)
@@ -630,6 +628,8 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         
         Packet packet ;
         if (accept) {
+            ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
+            RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);            
             packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
             sendToLocalServer(packet);
         } else {

--- a/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
+++ b/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
@@ -1,0 +1,54 @@
+/**
+ * 
+ */
+package edu.csus.ecs.pc2.core.exception;
+
+import edu.csus.ecs.pc2.core.IThrottleStrategy;
+
+/**
+ * This exception is intended to be thrown when a team makes a submission ("submits a Run" in PC2 terminology)
+ * but the system refuses to accept the run, for example due to the team having exceeded the submission threshhold
+ * defined by the current {@link IThrottleStrategy}.
+ * 
+ * @author John Clevenger
+ *
+ */
+public class SubmissionRejectedException extends Exception {
+
+    private static final long serialVersionUID = 5282881959866727134L;
+
+    /**
+     * Constructs a SubmissionRejectedException which contains no information about the reason for the Exception.
+     */
+    public SubmissionRejectedException() {
+    }
+
+    /**
+     * Constructs a SubmissionRejectedException containing text message.
+     * 
+     * @param message A text message associated with the Exception, typically the reason for the Exception.
+     */
+    public SubmissionRejectedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a SubmissionRejectedException containing a {@link Throwable} which caused this exception.
+     * 
+     * @param cause A {@link Throwable} which caused the Exception.
+     */
+    public SubmissionRejectedException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a SubmissionRejectedException containing a text message and a {@link Throwable} which caused the exception.
+     * 
+     * @param message A text message associated with the Exception, typically the reason for the Exception.
+     * @param cause A {@link Throwable} which caused the Exception.
+     */
+    public SubmissionRejectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
+++ b/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
@@ -1,6 +1,4 @@
-/**
- * 
- */
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.exception;
 
 import edu.csus.ecs.pc2.core.IThrottleStrategy;

--- a/src/edu/csus/ecs/pc2/core/strategies/AcceptAllStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/AcceptAllStrategy.java
@@ -1,3 +1,4 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.strategies;
 
 import edu.csus.ecs.pc2.core.IThrottleStrategy;

--- a/src/edu/csus/ecs/pc2/core/strategies/AcceptAllStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/AcceptAllStrategy.java
@@ -1,0 +1,22 @@
+package edu.csus.ecs.pc2.core.strategies;
+
+import edu.csus.ecs.pc2.core.IThrottleStrategy;
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * This class implements an {@link IThrottleStrategy} which accepts every run.
+ * This is primarily intended as a mechanism for testing the ThrottleStrategy mechanism,
+ * but it could also be used as a default implementation where "no throttling" is desired.
+ * 
+ * @author John Clevenger
+ *
+ */
+public class AcceptAllStrategy implements IThrottleStrategy {
+
+    @Override
+    public boolean accept(Run run) {
+        //accept every run
+        return true;
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -1,3 +1,4 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.strategies;
 
 import java.util.ArrayList;

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -15,10 +15,27 @@ import edu.csus.ecs.pc2.core.model.Run;
  *
  */
 public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
+    
+    public static int DEFAULT_MAX_SUBMISSIONS_PER_MINUTE = 10 ;
 
     private  IInternalContest contest;
     private int maxPerMinute;
     
+    /**
+     * Construct a strategy with a default limit on submissions per minute.
+     * 
+     * @param inContest the {@link IInternalContest} with which this strategy is associated.
+     */
+    public MaxSubmissionsPerMinuteStrategy (IInternalContest inContest) {
+        this.contest = inContest ;
+        this.maxPerMinute = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE ;
+    }
+
+    /**
+     * Construct a strategy with a caller-specified limit on submissions per minute.
+     * 
+     * @param inContest the {@link IInternalContest} with which this strategy is associated.
+     */
     public MaxSubmissionsPerMinuteStrategy (IInternalContest inContest, int maxAllowed) {
         this.contest = inContest ;
         this.maxPerMinute = maxAllowed ;
@@ -26,7 +43,7 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
 
     @Override
     /**
-     * Rejects the specified run if the submitting team has submitted the maximum allowed number of runs in the past minute. 
+     * Rejects the specified run if the submitting team has already submitted the maximum allowed number of runs in the past minute. 
      */
     public boolean accept(Run run) {
         int numSoFar = getNumberOfRunsSubmittedInTheLastMinute(contest, run);
@@ -34,7 +51,7 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
           return true;
         else 
           return false ;
-       }
+    }
 
     /**
      * Queries the specified contest to find the runs already submitted by the submitter of the specified run,

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -52,13 +52,13 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
     /**
      * Queries the specified contest to obtain the complete list of runs, then determines whether 
      * the count of runs previously submitted in the last minute by the new-run submitter
-     * exceeds the maximum allowed.
+     * has already reached the maximum allowed.
      * 
      * @param contest the contest containing runs submitted by teams.
      * @param newRun the (new) {@link Run} submitted by a team about which a strategy decision (i.e. whether or not
      *                  to forward the run to the PC2 Server) is to be made.  
      * 
-     * @return true if the number of runs which the team has submitted in the last minute exceeds the maximum; false if not.
+     * @return true if the number of runs which the team has submitted in the last minute has already reached the maximum; false if not.
      */
     private boolean numSubmittedInTheLastMinuteExceedsMaximum(IInternalContest contest, Run newRun) {
         
@@ -91,8 +91,8 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
                     //the run was submitted in the last minute; count it
                     countSoFar++ ;
                     
-                    //if the submitter has already exceeded the limit, no need to check any more runs
-                    if (countSoFar > maxPerMinute) {
+                    //if the submitter has already reached or exceeded the limit, no need to check any more runs
+                    if (countSoFar >= maxPerMinute) {
                         limitReached = true;
                         break;
                     }

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -1,0 +1,94 @@
+package edu.csus.ecs.pc2.core.strategies;
+
+import java.util.ArrayList;
+import edu.csus.ecs.pc2.core.IThrottleStrategy;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ContestTime;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * This class implements an {@link IThrottleStrategy} which rejects runs when the submitting team
+ * has submitted more than "N" runs in the last minute.  The value of N is set when the class is instantiated.
+ * 
+ * @author John Clevenger
+ *
+ */
+public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
+
+    private  IInternalContest contest;
+    private int maxPerMinute;
+    
+    public MaxSubmissionsPerMinuteStrategy (IInternalContest inContest, int maxAllowed) {
+        this.contest = inContest ;
+        this.maxPerMinute = maxAllowed ;
+    }
+
+    @Override
+    /**
+     * Rejects the specified run if the submitting team has submitted the maximum allowed number of runs in the past minute. 
+     */
+    public boolean accept(Run run) {
+        int numSoFar = getNumberOfRunsSubmittedInTheLastMinute(contest, run);
+        if (numSoFar < maxPerMinute) 
+          return true;
+        else 
+          return false ;
+       }
+
+    /**
+     * Queries the specified contest to find the runs already submitted by the submitter of the specified run,
+     * then determines how many of those previously-submitted runs occurred in the last minute.
+     * 
+     * @param contest the contest containing runs submitted by teams.
+     * @param newRun the (new) {@link Run} submitted by a team about which a strategy decision (i.e. whether or not
+     *                  to forward the run to the PC2 Server) is to be made.  
+     * 
+     * @return the number of runs which the team has already submitted in the last minute.
+     */
+    private int getNumberOfRunsSubmittedInTheLastMinute(IInternalContest contest, Run newRun) {
+        
+        //get the clientId for the new Run
+        ClientId newSubmitter = newRun.getSubmitter();
+
+        //a list of runs submitted by the same submitter as who submitted "newRun", initially empty
+        ArrayList<Run> teamRuns = new ArrayList<Run>();
+
+        //get all the runs in the contest
+        Run[] allRuns = contest.getRuns();
+        
+        //check each contest run to see if it came from the same submitter
+        for (Run curRun : allRuns ) {
+            if (curRun.getSubmitter().equals(newSubmitter)) {
+                //add the current run to the list of runs submitted by the newRun submitter
+                teamRuns.add(curRun);
+            }
+        }
+        
+        //check if the team has actually submitted anything
+        if (teamRuns.size()==0) {
+            return 0;
+        }
+        
+        //get the current contest time
+        ContestTime contestTime = contest.getContestTime();
+        long contestElapsedSecs = contestTime.getElapsedSecs();
+        
+        //count the number of runs previously submitted in the last minute
+        int numSubmittedInLastMinute = 0;
+        for (Run run : teamRuns) {
+            //get the submission time (in seconds) for the run
+            long runSubmisionTimeSecs = run.getOriginalElapsedMS()/1000;
+            
+            //check if the run submission time was within the last minute (60 seconds)
+            if (runSubmisionTimeSecs >= contestElapsedSecs-60) {
+                //the run was submitted in the last minute; count it
+                numSubmittedInLastMinute++ ;
+            }
+        }
+        
+        return numSubmittedInLastMinute ;
+
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -46,24 +46,21 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
      * Rejects the specified run if the submitting team has already submitted the maximum allowed number of runs in the past minute. 
      */
     public boolean accept(Run run) {
-        int numSoFar = getNumberOfRunsSubmittedInTheLastMinute(contest, run);
-        if (numSoFar < maxPerMinute) 
-          return true;
-        else 
-          return false ;
+        return numSubmittedInTheLastMinuteExceedsMaximum(contest, run);
     }
 
     /**
-     * Queries the specified contest to find the runs already submitted by the submitter of the specified run,
-     * then determines how many of those previously-submitted runs occurred in the last minute.
+     * Queries the specified contest to obtain the complete list of runs, then determines whether 
+     * the count of runs previously submitted in the last minute by the new-run submitter
+     * exceeds the maximum allowed.
      * 
      * @param contest the contest containing runs submitted by teams.
      * @param newRun the (new) {@link Run} submitted by a team about which a strategy decision (i.e. whether or not
      *                  to forward the run to the PC2 Server) is to be made.  
      * 
-     * @return the number of runs which the team has already submitted in the last minute.
+     * @return true if the number of runs which the team has submitted in the last minute exceeds the maximum; false if not.
      */
-    private int getNumberOfRunsSubmittedInTheLastMinute(IInternalContest contest, Run newRun) {
+    private boolean numSubmittedInTheLastMinuteExceedsMaximum(IInternalContest contest, Run newRun) {
         
         //get the clientId for the new Run
         ClientId newSubmitter = newRun.getSubmitter();
@@ -76,7 +73,8 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
         Run[] allRuns = contest.getRuns();
         
         //count the number of runs previously submitted in the last minute by the same client
-        int numSubmittedInLastMinute = 0;
+        int countSoFar = 0;
+        boolean limitReached = false;
         
         //check each contest run 
         for (Run curRun : allRuns ) {
@@ -91,12 +89,18 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
                 if (runSubmisionTimeSecs >= contestElapsedSecs-60) {
                     
                     //the run was submitted in the last minute; count it
-                    numSubmittedInLastMinute++ ;
+                    countSoFar++ ;
+                    
+                    //if the submitter has already exceeded the limit, no need to check any more runs
+                    if (countSoFar > maxPerMinute) {
+                        limitReached = true;
+                        break;
+                    }
                 }
             }
         }
         
-        return numSubmittedInLastMinute ;
+        return limitReached ;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -1,7 +1,6 @@
 // Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.strategies;
 
-import java.util.ArrayList;
 import edu.csus.ecs.pc2.core.IThrottleStrategy;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ContestTime;
@@ -69,44 +68,35 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
         //get the clientId for the new Run
         ClientId newSubmitter = newRun.getSubmitter();
 
-        //a list of runs submitted by the same submitter as who submitted "newRun", initially empty
-        ArrayList<Run> teamRuns = new ArrayList<Run>();
-
-        //get all the runs in the contest
-        Run[] allRuns = contest.getRuns();
-        
-        //check each contest run to see if it came from the same submitter
-        for (Run curRun : allRuns ) {
-            if (curRun.getSubmitter().equals(newSubmitter)) {
-                //add the current run to the list of runs submitted by the newRun submitter
-                teamRuns.add(curRun);
-            }
-        }
-        
-        //check if the team has actually submitted anything
-        if (teamRuns.size()==0) {
-            return 0;
-        }
-        
-        //get the current contest time
+        //get the current contest time so we can check run submission times against current time
         ContestTime contestTime = contest.getContestTime();
         long contestElapsedSecs = contestTime.getElapsedSecs();
         
-        //count the number of runs previously submitted in the last minute
+        //get all the runs in the contest
+        Run[] allRuns = contest.getRuns();
+        
+        //count the number of runs previously submitted in the last minute by the same client
         int numSubmittedInLastMinute = 0;
-        for (Run run : teamRuns) {
-            //get the submission time (in seconds) for the run
-            long runSubmisionTimeSecs = run.getOriginalElapsedMS()/1000;
+        
+        //check each contest run 
+        for (Run curRun : allRuns ) {
             
-            //check if the run submission time was within the last minute (60 seconds)
-            if (runSubmisionTimeSecs >= contestElapsedSecs-60) {
-                //the run was submitted in the last minute; count it
-                numSubmittedInLastMinute++ ;
+            //see if the current run came from the same submitter
+            if (curRun.getSubmitter().equals(newSubmitter)) {
+
+                //yes, same submitter; get the submission time (in seconds) for the current run
+                long runSubmisionTimeSecs = curRun.getOriginalElapsedMS()/1000;
+                
+                //check if the run submission time was within the last minute (60 seconds)
+                if (runSubmisionTimeSecs >= contestElapsedSecs-60) {
+                    
+                    //the run was submitted in the last minute; count it
+                    numSubmittedInLastMinute++ ;
+                }
             }
         }
         
         return numSubmittedInLastMinute ;
-
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -46,7 +46,7 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
      * Rejects the specified run if the submitting team has already submitted the maximum allowed number of runs in the past minute. 
      */
     public boolean accept(Run run) {
-        return numSubmittedInTheLastMinuteExceedsMaximum(contest, run);
+        return !numSubmittedInTheLastMinuteExceedsMaximum(contest, run);
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/strategies/RejectAllStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/RejectAllStrategy.java
@@ -1,6 +1,4 @@
-/**
- * 
- */
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.strategies;
 
 import edu.csus.ecs.pc2.core.IThrottleStrategy;

--- a/src/edu/csus/ecs/pc2/core/strategies/RejectAllStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/RejectAllStrategy.java
@@ -1,0 +1,25 @@
+/**
+ * 
+ */
+package edu.csus.ecs.pc2.core.strategies;
+
+import edu.csus.ecs.pc2.core.IThrottleStrategy;
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * This class implements an {@link IThrottleStrategy} which rejects every run.
+ * This is primarily intended as a mechanism for testing the ThrottleStrategy mechanism,
+ * since there isn't really any practical reason for rejecting all runs. 
+ * 
+ * @author John Clevenger
+ *
+ */
+public class RejectAllStrategy implements IThrottleStrategy {
+
+    @Override
+    public boolean accept(Run run) {
+        //reject every run
+        return false;
+    }
+
+}


### PR DESCRIPTION
### Description of what the PR does
Adds a framework for specifying "throttling strategies" to limit run submissions.  

Specifically, defines a new interface `IThrottleStrategy`, together with multiple classes which "implement" the interface and provide different throttling strategies including `AcceptAll`, `RejectAll` (useful for testing), and `MaxSubmissionsPerMinute`.
Updates `InternalController` to apply the currently-instantiated strategy to all team submissions, performing a client-side rejection of those which exceed the throttle limit defined by the current strategy. Also updates `pc2.api.ServerConnection`, WTI-API `TeamsController`, and WTI-UI `new-run.component` to handle the new exception type which is thrown when the throttling strategy rejects a run.

Note that the current implementation "hard-codes" an instance of a strategy within `InternalController`; switching strategies currently requires updating `InternalController` (specifically, method `submitJudgeRun()`) and rebuilding the system. 
A better approach would be to support dynamic (run-time) selection of the strategy; a separate issue has been filed for that enhancement (see #1054).  Another enhancement would be the creation of a more complex strategy, such as a variable-window limit.

### Issue which the PR addresses
Fixes #764.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Java 1.8.381, Eclipse 2021-12 (4.22.0)

### Precise steps for _testing_ the PR:

- Download the branch distribution.
- Start a contest (e.g. "sumithello").
- Start a PC2 Admin.
- Start a WTI server.
- Open a browser and login via WTI as a team.
- Use the WTI "Submit Problem" GUI to submit five runs in a row, as fast as possible -- all within the same minute (check the Runs grid on the PC2 Admin to verify the submission times are in the same minute).

The first four runs should be accepted (i.e. they should appear on the PC2 Admin's Runs grid).  The FIFTH run should be rejected, displaying a red dialog on the WTI screen saying "Submission threshhold exceeded".  This is because the currently-instantiated "ThrottleStrategy" is `MaxSubmissionsPerMinute(4)`.

To test other strategies (e.g. a different MaxSubmissionsPerMinute value, or the `AcceptAll` or `RejectAll` strategies),  edit method `InternalController.submitJudgeRun()` around line 618; comment-out the current strategy and uncomment the desired strategy then rebuild the system and start a new contest.  You'll also have to comment-out/uncomment the related `import` statements at the top of `InternalController`.

### Additional Notes
The PR code sets the current strategy to "MaxSubmissionPerMinute(4)". This was done to make it easy to test the PR via manual WTI GUI operations (it should be easy to submit 5 or more runs in a single minute, even manually).  However, "MaxSubmissionsPerMinute" of 4 is not a good value to put into production.  Before the PR is actually merged, `InternalController.submitJudgeRun()` should be edited to instantiate the `MaxSubmissionsPerMinute(DEFAULT_MAX_SUBMISSIONS_PER_MINUTE)` strategy.

