### PR TITLE
i857 Implement countdown pause time CLICS API PATCH

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestInfo.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestInfo.java
@@ -103,6 +103,7 @@ public class CLICSContestInfo {
                 start_time = Utilities.getIso8601formatterWithMS().format(date);
             } else {
                 start_time = null;
+                countdown_pause_time = ci.getContestCountdownPauseTime();
             }
         }
         penalty_time = Integer.valueOf(ci.getScoringProperties().getProperty(DefaultScoringAlgorithm.POINTS_PER_NO, "20"));

--- a/src/edu/csus/ecs/pc2/clics/API202306/ContestService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ContestService.java
@@ -60,6 +60,7 @@ import edu.csus.ecs.pc2.services.eventFeed.WebServer;
  * {
  *  "id":"wf2016",
  *  "start_time":null
+ *  "countdown_pause_time":"2014-06-25T09:00:00+01"
  * }
  *
  * or, to change thaw time:
@@ -192,8 +193,6 @@ public class ContestService implements Feature {
         String startTimeValueString = null;
         // get the countdown_pause_time key, if there
         String countdownPauseTime = null;
-        // Flag to indicate that countdown pause time was specified
-        boolean sawCountdownPauseTime = false;
 
         // if we get here then the JSON parsed correctly; see if it contained "start_time" as a key
         if (!requestMap.containsKey(CONTEST_START_TIME_KEY)) {
@@ -212,7 +211,6 @@ public class ContestService implements Feature {
         startTimeValueString = requestMap.get(CONTEST_START_TIME_KEY);
 
         if(requestMap.containsKey(CONTEST_COUNTDOWN_PAUSE_TIME_KEY)) {
-            sawCountdownPauseTime = true;
             countdownPauseTime = requestMap.get(CONTEST_COUNTDOWN_PAUSE_TIME_KEY);
         }
 
@@ -226,7 +224,8 @@ public class ContestService implements Feature {
             }
             return(HandleContestCountdownPauseTime(sc, contestId, countdownPauseTime));
         }
-        return(HandleContestStartTime(sc, contestId, startTimeValueString, sawCountdownPauseTime));
+        // countdownPauseTime must be null (eg CONTEST_COUNTDOWN_PAUSE_TIME_KEY must be null)
+        return(HandleContestStartTime(sc, contestId, startTimeValueString));
     }
 
     /**
@@ -238,7 +237,7 @@ public class ContestService implements Feature {
      * @param sawCountdownPauseTime
      * @return web response
      */
-    private Response HandleContestStartTime(SecurityContext sc, String contestId, String startTimeValueString, boolean sawCountdownPauseTime) {
+    private Response HandleContestStartTime(SecurityContext sc, String contestId, String startTimeValueString) {
 
         StartTimeRequestType requestType = StartTimeRequestType.ILLEGAL;
         GregorianCalendar requestedStartTime = null;
@@ -315,7 +314,7 @@ public class ContestService implements Feature {
 
                     // ok to set scheduled start to "undefined"
                     controller.getLog().log(Log.INFO, LOG_PREFIX + contestId + ": setting contest start time to \"null\".");
-                    success = setScheduledStart(null, sawCountdownPauseTime);
+                    success = setScheduledStart(null, null);
                     if (success) {
                         return Response.ok().entity("Contest start time updated to \"null\" (no scheduled start)").build();
                     } else {
@@ -347,7 +346,7 @@ public class ContestService implements Feature {
 
                 // ok to set scheduled start to a specific time
                 controller.getLog().log(Log.INFO, LOG_PREFIX + contestId + ": setting contest start time to " + requestedStartTime);
-                success = setScheduledStart(requestedStartTime, sawCountdownPauseTime);
+                success = setScheduledStart(requestedStartTime, null);
                 if (success) {
                     return Response.ok().entity("/contests/" + contestId).build();
                 } else {
@@ -389,9 +388,15 @@ public class ContestService implements Feature {
         // MIN_VALUE is returned on format error
         if(pauseTime != Long.MIN_VALUE) {
             // want to stop the countdown with this many milliseconds left
-            // TODO: tell PC2 to stop countdown when clock is 'pauseTime' ms away from start
-            controller.getLog().log(Log.WARNING, LOG_PREFIX + contestId + ": countdown_pause_time not implemented");
-            return Response.status(Status.NOT_MODIFIED).entity("Unable to set countdown_pause_time to " + pauseTime + " ms").build();
+            // tell PC2 to stop countdown when clock is 'pauseTime' ms away from start
+            boolean success = setScheduledStart(null, countdownPauseTime);
+            if (success) {
+                controller.getLog().log(Log.INFO, LOG_PREFIX + contestId + ": countdown paused (set contest start time to null)");
+                return Response.ok().entity("Contest countdown paused - start time updated to \"null\" (no scheduled start)").build();
+            } else {
+                controller.getLog().log(Log.SEVERE, LOG_PREFIX + contestId + ": can not pause countdown - error setting contest start time to \"undefined\".");
+                return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Server failed to pause countdown").build();
+            }
         }
         return Response.status(Status.BAD_REQUEST).entity("Bad value for count down pause time request").build();
     }
@@ -463,10 +468,10 @@ public class ContestService implements Feature {
      *
      * @param theDate
      *            the date/time to which the automatic start of the contest should be set, or null if the start date/time should be set to "undefined"
-     * @param unPauseCountdown tell pc2 that the countdown pause (if in effect) should be cancelled, and countdown should resume, if there's a valid start time
+     * @param contestPauseRelTime Relative time before contest starts: HH:MM:SS, null if not pausing
      * @return true if the method was successful in setting the scheduled start time; false otherwise
      */
-    private boolean setScheduledStart(GregorianCalendar theDate, boolean unPauseCountdown) {
+    private boolean setScheduledStart(GregorianCalendar theDate, String contestPauseRelTime) {
 
         // get the local model's ContestInformation
         ContestInformation ci = model.getContestInformation();
@@ -476,9 +481,12 @@ public class ContestService implements Feature {
             if (theDate != null) {
                 // if we have a valid start date, set the contest to auto-start
                 ci.setAutoStartContest(true);
+            } else {
+                // only set pause time if start time was not specified.
+                ci.setContestCountdownPauseTime(contestPauseRelTime);
             }
-            // TODO unpause countdown - this will be a flag in "ci"
             // tell the Controller to update the ContestInformation
+            // note: setting a new contest start time (eg theData != null) will automatically start the countdown
             controller.updateContestInformation(ci);
             return true;
         } else {

--- a/src/edu/csus/ecs/pc2/clics/API202306/ContestService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ContestService.java
@@ -60,7 +60,7 @@ import edu.csus.ecs.pc2.services.eventFeed.WebServer;
  * {
  *  "id":"wf2016",
  *  "start_time":null
- *  "countdown_pause_time":"2014-06-25T09:00:00+01"
+ *  "countdown_pause_time":"2016-05-19T10:00:00+07"
  * }
  *
  * or, to change thaw time:
@@ -234,7 +234,6 @@ public class ContestService implements Feature {
      * @param sc
      * @param contestId which contest
      * @param startTimeValueString new contest start time (ISO format) or null to make it undefined
-     * @param sawCountdownPauseTime
      * @return web response
      */
     private Response HandleContestStartTime(SecurityContext sc, String contestId, String startTimeValueString) {
@@ -391,14 +390,14 @@ public class ContestService implements Feature {
             // tell PC2 to stop countdown when clock is 'pauseTime' ms away from start
             boolean success = setScheduledStart(null, countdownPauseTime);
             if (success) {
-                controller.getLog().log(Log.INFO, LOG_PREFIX + contestId + ": countdown paused (set contest start time to null)");
-                return Response.ok().entity("Contest countdown paused - start time updated to \"null\" (no scheduled start)").build();
+                controller.getLog().log(Log.INFO, LOG_PREFIX + contestId + ": countdown paused at " + countdownPauseTime + " and set contest start time to null.");
+                return Response.ok().entity("Contest countdown paused at " + countdownPauseTime + " and start time updated to \"null\" (no scheduled start)").build();
             } else {
-                controller.getLog().log(Log.SEVERE, LOG_PREFIX + contestId + ": can not pause countdown - error setting contest start time to \"undefined\".");
-                return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Server failed to pause countdown").build();
+                controller.getLog().log(Log.SEVERE, LOG_PREFIX + contestId + ": can not pause countdown at " + countdownPauseTime + " - error setting contest start time to \"undefined\".");
+                return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Server failed to pause countdown at " + countdownPauseTime).build();
             }
         }
-        return Response.status(Status.BAD_REQUEST).entity("Bad value for count down pause time request").build();
+        return Response.status(Status.BAD_REQUEST).entity("Bad value (" + countdownPauseTime + ") for count down pause time request").build();
     }
 
     /**
@@ -466,6 +465,10 @@ public class ContestService implements Feature {
      * This is accomplished by telling the controller to update the {@link ContestInformation} with the scheduled start date. The controller then sends a packet to the server to do that; the server in
      * turn creates a task to start the contest at the specified date/time.
      *
+     * When a contest is paused, the start date will be specified as null and the contest pause rel time will
+     * be set to the time remaining in the countdown ((h)*h:mm:ss(.uuu)).  When the contest is resumed,
+     * the date will be the new start date for the contest and the pause rel time will be null.
+     *
      * @param theDate
      *            the date/time to which the automatic start of the contest should be set, or null if the start date/time should be set to "undefined"
      * @param contestPauseRelTime Relative time before contest starts: HH:MM:SS, null if not pausing
@@ -486,7 +489,7 @@ public class ContestService implements Feature {
                 ci.setContestCountdownPauseTime(contestPauseRelTime);
             }
             // tell the Controller to update the ContestInformation
-            // note: setting a new contest start time (eg theData != null) will automatically start the countdown
+            // note: setting a new contest start time (eg theDate != null) will automatically start the countdown
             controller.updateContestInformation(ci);
             return true;
         } else {

--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -173,7 +173,7 @@ public class ContestInformation implements Serializable{
 
     private boolean autoStopContest = false ;
 
-    // RELTIME (HH:MM:SS) of when contest countdown was paused (Before start)
+    // RELTIME ((h)*h:mm:ss(.uuu)) of when contest countdown was paused (Before start)
     private String contestCountdownPauseTime = null;
 
     /**

--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.Serializable;
@@ -173,6 +173,9 @@ public class ContestInformation implements Serializable{
 
     private boolean autoStopContest = false ;
 
+    // RELTIME (HH:MM:SS) of when contest countdown was paused (Before start)
+    private String contestCountdownPauseTime = null;
+
     /**
      * Scoreboard freeze time.
      */
@@ -232,6 +235,33 @@ public class ContestInformation implements Serializable{
      */
     public void setScheduledStartTime(GregorianCalendar newScheduledStartTime) {
         scheduledStartTime = newScheduledStartTime;
+        // if setting start time, pause time must be null
+        if(scheduledStartTime != null) {
+            contestCountdownPauseTime = null;
+        }
+    }
+
+    /**
+     * Gets the time before start when the countdown was paused.
+     *
+     * @return "HH:MM:SS" (RELTIME) of when contest was paused, null if not paused
+     */
+    public String getContestCountdownPauseTime() {
+        return contestCountdownPauseTime;
+    }
+
+    /**
+     * Sets the relative time before contest start when the contest countdown was paused.
+     * This also clears (nulls) the scheduledStartTime since you can't have both a start time
+     * and a pause time.  When the countdown is resumed, the scheduled start time will be reset.
+     *
+     * @param relPauseTime (HH:MM:SS)
+     */
+    public void setContestCountdownPauseTime(String relPauseTime) {
+        if(relPauseTime != null) {
+            scheduledStartTime = null;
+        }
+        contestCountdownPauseTime = relPauseTime;
     }
 
     public String getContestTitle() {
@@ -384,6 +414,10 @@ public class ContestInformation implements Serializable{
                         contestInformation.getScheduledStartTime().getTime())) {
                     return false;
                 }
+            }
+            if ((contestCountdownPauseTime == null && contestInformation.getContestCountdownPauseTime() != null) ||
+                (contestCountdownPauseTime != null && !contestCountdownPauseTime.equals(contestInformation.getContestCountdownPauseTime()))) {
+                return false;
             }
 
             //both scheduledStartTime and contestInformation.getScheduledStartTime() must be null (hence, "same")

--- a/src/edu/csus/ecs/pc2/ui/ContestClockDisplay.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestClockDisplay.java
@@ -47,8 +47,8 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     private static final long serialVersionUID = 8137635697344335832L;
 
-    private static final String NO_SCHEDULE_START_TIME = "No scheduled start";
-    private static final String NO_SCHEDULE_START_HINT = "Still no scheduled start";
+    private static final String NO_SCHEDULED_START_TIME = "No scheduled start";
+    private static final String NO_SCHEDULED_START_HINT = "Still no scheduled start";
 
     private static final String COUNTDOWN_PAUSED = "Countdown Paused";
 
@@ -515,8 +515,8 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
         if (scheduledStartTimeLabelList.size() > 0) {
 
-            String text = NO_SCHEDULE_START_TIME;
-            String hint = NO_SCHEDULE_START_HINT;
+            String text = NO_SCHEDULED_START_TIME;
+            String hint = NO_SCHEDULED_START_HINT;
 
             if (scheduledStartTime != null) {
 
@@ -537,7 +537,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
             ContestTime contestTime = contest.getContestTime();
 
-            String [] textAndHint = getScheduleOrRemainingTimeAndHint(contestTime);
+            String [] textAndHint = getScheduledOrRemainingTimeAndHint(contestTime);
 
             if(textAndHint != null && textAndHint.length == 2) {
                 for (JLabel jLabel : schedAndRemainingTimeLabelList) {
@@ -548,13 +548,22 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         }
     }
 
-    public String [] getScheduleOrRemainingTimeAndHint(ContestTime contestTime) {
+    /**
+     * Returns the text and tooltip (hint) of what should be displayed for the contest clock.
+     * If the contest is not started, it gives the count down to start of contest, unless the contest is
+     * paused, in which case it gives a message indicating the contest count down is paused.
+     * If the contest is underway, it gives the remaining time in contest.
+     *
+     * @param contestTime - provides information about clock state of the contest.
+     * @return two element string array
+     */
+    public String [] getScheduledOrRemainingTimeAndHint(ContestTime contestTime) {
 
         String [] textAndHint = new String[2];
 
         // These are always set below, but just in case someone forgets.
-        String text = NO_SCHEDULE_START_TIME;
-        String hint = NO_SCHEDULE_START_HINT;
+        String text = NO_SCHEDULED_START_TIME;
+        String hint = NO_SCHEDULED_START_HINT;
 
         boolean isContestStarted = contestTime.isContestStarted();
 
@@ -595,7 +604,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     // This is used for unit tests only at the moment.
     public String getScheduleOrRemainingTime(ContestTime contestTime) {
-        return getScheduleOrRemainingTimeAndHint(contestTime)[0];
+        return getScheduledOrRemainingTimeAndHint(contestTime)[0];
     }
 
     public String getScheduledTimeClockHint() {

--- a/src/edu/csus/ecs/pc2/ui/ContestClockDisplay.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestClockDisplay.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.Color;
@@ -39,7 +39,7 @@ import edu.csus.ecs.pc2.core.util.DateDifferizer.DateFormat;
  * then the remaining or elapsed time will automatically
  * reflect that change.
  * <P>
- * Add a label and the format of the time {@link #addLabeltoUpdateList(JLabel, DisplayTimes, int)} 
+ * Add a label and the format of the time {@link #addLabeltoUpdateList(JLabel, DisplayTimes, int)}
  * <P>
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
@@ -48,6 +48,14 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
     private static final long serialVersionUID = 8137635697344335832L;
 
     private static final String NO_SCHEDULE_START_TIME = "No scheduled start";
+    private static final String NO_SCHEDULE_START_HINT = "Still no scheduled start";
+
+    private static final String COUNTDOWN_PAUSED = "Countdown Paused";
+
+    private static final String TIME_REMAINING_HINT = "Time remaining in the contest";
+    private static final String TIME_UNTIL_START_HINT = "Time until the contest starts";
+
+    private static final String CONTEST_STOPPED_TEAM = "STOPPED";
 
     /**
      * Labels to be updated with contest time.
@@ -65,35 +73,42 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
      * List of remaining time JLabels to update
      */
     private Hashtable<Integer, Vector<JLabel>> sitesRemainingtimeLabelList = new Hashtable<Integer, Vector<JLabel>>();
-    
+
     /**
      * List of scheduled start time JLabels to update.
      */
     private List<JLabel> scheduledStartTimeLabelList = new ArrayList<>();
 
     /**
-     * 
+     *
      */
     private List<JLabel> schedAndRemainingTimeLabelList = new ArrayList<>();
 
     private Hashtable<Integer, ContestTime> contestTimes = new Hashtable<Integer, ContestTime>();
-    
+
     /**
      * The date/time when the contest is scheduled (intended) to start.
      * This value is null (undefined) if no scheduled start time has been set.
-     * This value ONLY applies BEFORE THE CONTEST STARTS; once 
+     * This value ONLY applies BEFORE THE CONTEST STARTS; once
      * any "start contest" operation (e.g. pushing the "Start Button") has occurred,
      * this value no longer has meaning.
      */
     private GregorianCalendar scheduledStartTime = null ;
-    
+
+    /*
+     * The "REL" time string (HH:MM:SS) of when the countdown was paused, or null if
+     * not paused.  This value only applies before the contest starts, and the countdown
+     * was paused.
+     */
+    private String countdownPauseTime = null;
+
     private Timer timer = new Timer(500, this);
 
     private JFrame clientFrame = null;
 
     /**
      * Special display for team.
-     * 
+     *
      * Primarily if there are < 2 minutes in the contest or
      * beyond, will display < 2 minutes.
      */
@@ -112,18 +127,18 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
     private Log log = null;
     /**
      * Ways to display contest time.
-     * 
+     *
      */
 
     private IInternalController controller;
 
     private IInternalContest contest;
-    
+
     /**
-     * 
+     *
      * @author pc2@ecs.csus.edu
      * @version $Id$
-     * 
+     *
      */
     public enum DisplayTimes {
         /**
@@ -147,14 +162,14 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Update JLabels with contest time.
-     * 
+     *
      * If ContestTime.isRunning() is true, will start countdown timer, set label color to Color.BLACK. <br>
      * When contestTimer is not running, will stop countdown and set label color to Color.RED. <br>
      * isTeamDisplay == true, if clock is stopped shows STOPPED in label, if &lt; 2 minutes remaining will display "&lt; 2 mins".
      * <br>
      * isTeamDisplay == false, always shows remaining time.
-     * 
-     * 
+     *
+     *
      * @param contestTime
      *            contest time (running and values)
      * @param isTeamDisplay
@@ -172,45 +187,47 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         sitesRemainingtimeLabelList.put(localSiteNumber, remainingtimeLabelList);
 
         setClientFrame (clientFrame);
-        
+
         this.teamDisplayMode = isTeamDisplay;
         this.clientFrame = clientFrame;
         fireClockStateChange(contestTime);
 
     }
-    
-    
+
+
     /**
      * Update clock times with scheduled information.
-     * 
+     *
      * @param contestInformation
      */
     public void fireClockStateChange(final ContestInformation contestInformation) {
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 setScheduledStartTime(contestInformation);
                 updateTimeLabels();
             }
         });
-        
+
     }
 
 
     /**
      * Update clock display using contestTime.
-     * 
+     *
      * Uses contestTime state (running or not) to determine whether to update clock every second.
-     * 
+     *
      * The display is different for {@link #teamDisplayMode}.
-     * 
+     *
      * @param contestTime
      */
     public void fireClockStateChange(final ContestTime contestTime) {
-        
+
         contestTimes.put(contestTime.getSiteNumber(), contestTime);
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 if (contestTime.isContestRunning()) {
                     startClockDisplay(contestTime.getSiteNumber());
@@ -229,22 +246,22 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         Enumeration<Integer> enumeration = contestTimes.keys();
 
         while (enumeration.hasMoreElements()) {
-            Integer element = (Integer) enumeration.nextElement();
+            Integer element = enumeration.nextElement();
             updateTimeLabel(element.intValue());
 
         }
-        
+
         updateScheduledStartLabels();
-        
+
     }
 
     /**
      * Update clock display using contestTime.
-     * 
+     *
      * Uses contestTime state (running or not) to determine whether to update clock every second.
-     * 
+     *
      * The display is different for {@link #teamDisplayMode}.
-     * 
+     *
      * @param contestTime
      * @param siteNumber
      */
@@ -255,6 +272,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         final ContestTime theContestTime = contestTimes.get(new Integer(siteNumber));
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 if (theContestTime.isContestRunning()) {
                     startClockDisplay(siteNumber);
@@ -266,22 +284,22 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
             }
         });
     }
-    
-    
+
+
 
     /**
      * Add a label to be the update list.
      * <P>
      * This adds a label to update
-     * 
+     *
      * @param labelToUpdate the label to update
      * @param whichTime the remaining or elapsed time form
      * @param siteNumber the site number for this contest time.
      */
     public void addLabeltoUpdateList(JLabel labelToUpdate, DisplayTimes whichTime, int siteNumber) {
-        
+
         Vector<JLabel> list = null;
-        
+
         switch (whichTime) {
             case ELAPSED_TIME:
                 list = sitesElapsedTimeLabelList.get(new Integer(siteNumber));
@@ -291,23 +309,23 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
                 list.addElement(labelToUpdate);
                 sitesElapsedTimeLabelList.put(new Integer(siteNumber), list);
                 break;
-                
+
             case REMAINING_TIME:
-                
+
                 list = sitesRemainingtimeLabelList.get(new Integer(siteNumber));
-                
+
                 if (list == null) {
                     list = new Vector<JLabel>();
                 }
                 list.addElement(labelToUpdate);
                 sitesRemainingtimeLabelList.put(new Integer(siteNumber), list);
                 break;
-                
+
             case TO_SCHEDULED_START_TIME:
-                
+
                 scheduledStartTimeLabelList.add(labelToUpdate);
                 break;
-                
+
             case SCHEDULED_THEN_REMAINING_TIME:
                 schedAndRemainingTimeLabelList.add(labelToUpdate);
                 break;
@@ -317,7 +335,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         }
 
         updateTimeLabels();
-        
+
     }
 
     public void removeLabelFromAllUpdateLists(JLabel labelToUpdate) {
@@ -325,7 +343,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
             Enumeration<Integer> enumeration = contestTimes.keys();
 
             while (enumeration.hasMoreElements()) {
-                Integer element = (Integer) enumeration.nextElement();
+                Integer element = enumeration.nextElement();
                 removeLabelFromUpdateList(labelToUpdate, element.intValue());
             }
         } catch (Exception e) {
@@ -356,7 +374,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Start the clock updating.
-     * 
+     *
      */
     private void startClockDisplay(final int siteNumber) {
         // public void schedule(TimerTask task, long delay, long period)
@@ -365,6 +383,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         timer.start();
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 Vector<JLabel> list = sitesElapsedTimeLabelList.get(siteNumber);
 
@@ -384,7 +403,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
                         list.elementAt(i).setForeground(Color.BLACK);
                     }
                 }
-                
+
                 for (JLabel jLabel : scheduledStartTimeLabelList) {
                     jLabel.setForeground(Color.BLACK);
                 }
@@ -394,7 +413,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Stop the display updating.
-     * 
+     *
      */
     private void stopClockDisplay(int siteNumber) {
         if (scheduledStartTime == null){
@@ -421,12 +440,13 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Update the label (display).
-     * 
+     *
      */
     private void updateTimeLabel(final int siteNumber) {
         final ContestTime contestTime = contestTimes.get(new Integer(siteNumber));
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
 
                 try {
@@ -446,7 +466,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
                             list.elementAt(i).setText(clockText);
                         }
                     }
-                    
+
                     updateScheduledStartLabels();
 
                     if (siteNumber == localSiteNumber.intValue() && clientFrame != null) { // only update Title bar if the local site
@@ -472,10 +492,10 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Adjust contest time display if after end of contest.
-     * 
+     *
      * If input time, ex remaining time, is -HHM:MM:SS will
-     * change string to +HH:MMSS, else returns string unchanged.  
-     * 
+     * change string to +HH:MMSS, else returns string unchanged.
+     *
      * @param string
      * @return +HH:MM:SS if input is -HH:MM:SS, else returns string unchanged.
      */
@@ -496,12 +516,15 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         if (scheduledStartTimeLabelList.size() > 0) {
 
             String text = NO_SCHEDULE_START_TIME;
-            String hint = "Still no scheduled start";
+            String hint = NO_SCHEDULE_START_HINT;
 
             if (scheduledStartTime != null) {
 
                 text = getScheduledTimeClockText();
                 hint = getScheduledTimeClockHint();
+            } else if(countdownPauseTime != null) {
+                text = COUNTDOWN_PAUSED;
+                hint = "with " + countdownPauseTime + " before start";
             }
 
             for (JLabel jLabel : scheduledStartTimeLabelList) {
@@ -512,37 +535,48 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
         if (schedAndRemainingTimeLabelList.size() > 0) {
 
-//            String hint = "Still no scheduled start";
-
             ContestTime contestTime = contest.getContestTime();
 
-            String text = getScheduleOrRemainingTime(contestTime);
+            String [] textAndHint = getScheduleOrRemainingTimeAndHint(contestTime);
 
-            for (JLabel jLabel : schedAndRemainingTimeLabelList) {
-                jLabel.setText(text);
-                jLabel.setToolTipText(text);
+            if(textAndHint != null && textAndHint.length == 2) {
+                for (JLabel jLabel : schedAndRemainingTimeLabelList) {
+                    jLabel.setText(textAndHint[0]);
+                    jLabel.setToolTipText(textAndHint[1]);
+                }
             }
         }
     }
 
-    public String getScheduleOrRemainingTime(ContestTime contestTime) {
-        
-        String text = NO_SCHEDULE_START_TIME; 
-        
-        boolean showRemainingTime = true;
-        
-        if (scheduledStartTime  != null && ! contestTime.isContestStarted()){
-            showRemainingTime = false;
-        }
-        
-        if (showRemainingTime){
-            
-            /**
-             * Show Remaining time count down. 
+    public String [] getScheduleOrRemainingTimeAndHint(ContestTime contestTime) {
+
+        String [] textAndHint = new String[2];
+
+        // These are always set below, but just in case someone forgets.
+        String text = NO_SCHEDULE_START_TIME;
+        String hint = NO_SCHEDULE_START_HINT;
+
+        boolean isContestStarted = contestTime.isContestStarted();
+
+        // If there's no scheduled start time or the contest is started,
+        // then we show the time remaining in the contest or,
+        // if the countdown is paused, we show a paused message
+        if (scheduledStartTime == null || isContestStarted){
+            /*
+             * if the contest is not started yet, see if the countdown is paused,
+             * if so, show the paused message instead of the contest length
              */
-            text = contestTime.getRemainingTimeStr();
-            text = adjustForPostContest(text);
-            
+            if(!isContestStarted && countdownPauseTime != null) {
+                text = COUNTDOWN_PAUSED;
+                hint = "with " + countdownPauseTime + " before start";
+            } else {
+                /**
+                 * Show Remaining time in contest count down.
+                 */
+                text = contestTime.getRemainingTimeStr();
+                text = adjustForPostContest(text);
+                hint = TIME_REMAINING_HINT;
+            }
         } else {
             /**
              * Show schedule start count down
@@ -551,11 +585,18 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
             DateDifferizer differizer = new DateDifferizer(now, scheduledStartTime.getTime());
             differizer.setFormat(DateFormat.COUNT_DOWN);
             text = differizer.toString();
+            hint = TIME_UNTIL_START_HINT;
         }
-        
-        return text;
+
+        textAndHint[0] = text;
+        textAndHint[1] = hint;
+        return textAndHint;
     }
 
+    // This is used for unit tests only at the moment.
+    public String getScheduleOrRemainingTime(ContestTime contestTime) {
+        return(getScheduleOrRemainingTimeAndHint(contestTime)[0]);
+    }
 
     public String getScheduledTimeClockHint() {
         Date now = GregorianCalendar.getInstance().getTime();
@@ -572,6 +613,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         return text;
     }
 
+    @Override
     public void actionPerformed(ActionEvent arg0) {
         ContestTime contestTime = contestTimes.get(localSiteNumber);
         fireClockStateChange(contestTime);
@@ -579,7 +621,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Sets the default site and contest time.
-     * 
+     *
      * @param contestTime
      * @param siteNumber
      */
@@ -603,25 +645,27 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         this.titleTimeToDisplay = titleTimeToDisplay;
     }
 
+    @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         this.contest = inContest;
         this.controller = inController;
         log = controller.getLog();
-        
+
         contest.addContestTimeListener(new ContestTimeListenerImplementation());
         contest.addContestInformationListener(new ContestInformationListenerImplementation());
-        
+
         setScheduledStartTime(inContest.getContestInformation());
     }
 
+    @Override
     public String getPluginTitle() {
         return "Contest Clock Display";
     }
-    
-    
+
+
     /**
      * Listener.
-     * 
+     *
      * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
      */
     public class ContestInformationListenerImplementation implements IContestInformationListener {
@@ -629,71 +673,77 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
         @Override
         public void contestInformationAdded(ContestInformationEvent event) {
             fireClockStateChange(event.getContestInformation());
-            
+
         }
 
         @Override
         public void contestInformationChanged(ContestInformationEvent event) {
             fireClockStateChange(event.getContestInformation());
-            
+
         }
 
         @Override
         public void contestInformationRemoved(ContestInformationEvent event) {
             fireClockStateChange(event.getContestInformation());
-            
+
         }
 
         @Override
         public void contestInformationRefreshAll(ContestInformationEvent event) {
             fireClockStateChange(event.getContestInformation());
-            
+
         }
 
         @Override
         public void finalizeDataChanged(ContestInformationEvent event) {
             fireClockStateChange(event.getContestInformation());
-            
+
         }
-        
+
     }
-    
-    
+
+
     /**
      * Implementor.
-     * 
+     *
      * @author pc2@ecs.csus.edu
      * @version $Id$
      */
     public class ContestTimeListenerImplementation implements IContestTimeListener {
 
+        @Override
         public void contestTimeAdded(ContestTimeEvent event) {
             fireClockStateChange(event.getContestTime(), event.getContestTime().getSiteNumber());
         }
 
+        @Override
         public void contestTimeRemoved(ContestTimeEvent event) {
-            // no action 
-            
+            // no action
+
         }
 
+        @Override
         public void contestTimeChanged(ContestTimeEvent event) {
             fireClockStateChange(event.getContestTime(), event.getContestTime().getSiteNumber());
         }
 
+        @Override
         public void contestStarted(ContestTimeEvent event) {
             fireClockStateChange(event.getContestTime(), event.getContestTime().getSiteNumber());
-            
+
         }
 
+        @Override
         public void contestStopped(ContestTimeEvent event) {
             fireClockStateChange(event.getContestTime(), event.getContestTime().getSiteNumber());
-            
+
         }
 
+        @Override
         public void refreshAll(ContestTimeEvent event) {
             fireClockStateChange(event.getContestTime(), event.getContestTime().getSiteNumber());
         }
-        
+
         /** This method exists to support differentiation between manual and automatic starts,
          * in the event this is desired in the future.
          * Currently it just delegates the handling to the contestStarted() method.
@@ -706,13 +756,13 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     /**
      * Set Client Frame that when minimized changes to a countdown timer.
-     * 
+     *
      * This uses the default contest time when it updates the title.
      * The original frame title is saved, when frame is minimized will show
      * contest time, when non-minimized will show the saved frame title.
      * <P>
-     * Uses the contest time set using {@link #setContestTime(ContestTime, int)}. 
-     * 
+     * Uses the contest time set using {@link #setContestTime(ContestTime, int)}.
+     *
      * @param clientFrame
      */
     public void setClientFrame(JFrame clientFrame) {
@@ -725,17 +775,24 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
     public GregorianCalendar getScheduledStartTime() {
         return scheduledStartTime;
     }
-    
+
     public void setScheduledStartTime(GregorianCalendar scheduledStartTime) {
         this.scheduledStartTime = scheduledStartTime;
         if (scheduledStartTime != null){
             timer.start();
         }
     }
-    
+
+    /**
+     * Set the contest schedule start time from the supplied contest information
+     * This also sets the countdownPauseTime, if the start of the contest is paused.
+     *
+     * @param info ContestInformation
+     */
     public void setScheduledStartTime(ContestInformation info) {
         if (info != null){
             setScheduledStartTime(info.getScheduledStartTime());
+            countdownPauseTime = info.getContestCountdownPauseTime();
         }
     }
 
@@ -778,7 +835,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
             } else {
                 if (teamDisplayMode) {
-                    clockText = "STOPPED";
+                    clockText = CONTEST_STOPPED_TEAM;
                 } else {
                     clockText = contestTime.getRemainingTimeStr();
                     clockText = adjustForPostContest(clockText);

--- a/src/edu/csus/ecs/pc2/ui/ContestClockDisplay.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestClockDisplay.java
@@ -595,7 +595,7 @@ public class ContestClockDisplay implements ActionListener, UIPlugin {
 
     // This is used for unit tests only at the moment.
     public String getScheduleOrRemainingTime(ContestTime contestTime) {
-        return(getScheduleOrRemainingTimeAndHint(contestTime)[0]);
+        return getScheduleOrRemainingTimeAndHint(contestTime)[0];
     }
 
     public String getScheduledTimeClockHint() {


### PR DESCRIPTION
### Description of what the PR does
Fix _CLICS 202306_ contest  information service to correctly handle the `countdown_pause_time` **RELTIME** property.  This will simply clear the scheduled contest start time (setting it to _undefined_), and remember when the contest was paused (in `ContestInformation`).

Fix contest clock displays to show the countdown is paused, if it is.  A tooltip for the clock display label will show how much time was left before the contest was supposed to start when it was paused.

** NOTE: Must be merged AFTER #864 since this is a branch from that branch.

### Issue which the PR addresses
Fixes #857 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Ubuntu 24.04
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load up a new contest that has a start time defined that is in the future (implies starting the server).  You can use the `samps/clics_sumithello`, and then set a start time in the future after loading up the contest using the "**Times**" tab on the server.
2) Start an _event feeder_ client, and press **Start** so it is listening for connections
3) Start an _administrator_ client - note the countdown clock in the upper left is counting down to the start of the contest
<img width="278" alt="image" src="https://github.com/user-attachments/assets/c9a8b8ca-6f0c-47b2-bf6f-3fa48f4fb025" />

From this point, you have 2 choices of how to test, the easy way by using "curl" and the "practical" way by using a CDS.  Both methods will be described below:

4a) Curl: To pause contest **SumH** and have it tell the CCS it was paused with 2 hours remaining:
```
curl -X PATCH -k \
            https://admin:admin@localhost:50443/contests/SumH \
            -H 'Content-Type: application/json' \
            -d '{"id":"SumH", "start_time":null, "countdown_pause_time":"2:00:00" }'
```
When you pause, the countdown clock will stop and say **Paused** or **Stopped** depending on the client.  Hovering over the **Paused** or **Stop** message will tell you how much time was left when it was paused.  To resume contest **SumH** and have it start at the specified time (2025-04-20T14:00:00-04:00):
```
curl -X PATCH -k \
        https://admin:admin@localhost:50443/contests/SumH \
        -H 'Content-Type: application/json' \
        -d '{"id":"SumH", "start_time":"2025-04-17T14:00:00-04:00", "countdown_pause_time":null }'
```

4b) CDS:  The remaining steps are all to test using a CDS.  Configure an _ICPC Tools_ CDS (at least version 2.6.1177).  For the `cdsConfig.xml `PC2 credentials you can use "**adminsitrator1**" as the user and "**administrator1**" as the password, assuming that is how you have that account configured in PC2.  Also, you'll have to add an "**administrator1**" admin account to the accounts.yaml.  [Here is a TXT file that you can rename as `accounts.yaml`]([accounts.yaml.txt](https://github.com/user-attachments/files/19805971/accounts.yaml.txt)
) and put it in the `config `folder.  The user/password when you log in to the browser will be **administrator1**/**administrator1**.

5b) Start the CDS (From a command prompt: `bin\server run cds`)- it takes awhile - wait until the "_smarter planet_" message comes up in the console window.

```
> [AUDIT   ] CWWKZ0001I: Application CDS started in 1.612 seconds.
> [AUDIT   ] CWWKF0012I: The server installed the following features: [appSecurity-5.0, cdi-4.0, distributedMap-1.0, expressionLanguage-5.0, jndi-1.0, jsonp-2.1, pages-3.1, servlet-6.0, ssl-1.0, transportSecurity-1.0, websocket-2.1].
> [AUDIT   ] CWWKF0011I: The cds server is ready to run a smarter planet. The cds server started in 19.358 seconds.
> 
```

6b) Open a browser to https://localhost:8443/  ( found it works faster if you use the IP address of your PC instead of "localhost", but that's on my machine.
7b) Login (upper right) using:  administrator1/administrator1  (same as in the accounts.yaml and the same as PC2 has for administrator1).  Give it a chance to log in.  Here is the CDS console log:
```
Reading feed cache
Unknown property ignored: state/paused
Unknown property ignored: state/resumed
Unknown property ignored: state/contest_time
Done reading feed cache
```

8b) Select the **Countdown Control** selection in the left pane
9b) You should see the contest countdown clock in the browser window counting down, and it should match the admin countdown.
<img width="836" alt="image" src="https://github.com/user-attachments/assets/a6cc1bbf-34a6-4a64-a105-c1a56fc31add" />

10) Press the: Pause button.  Paused message should appear on the administrator window as well as the CDS browser window.
<img width="299" alt="image" src="https://github.com/user-attachments/assets/10ca4c88-cd7f-4ee8-b36c-71e51974bcf3" />
<img width="824" alt="image" src="https://github.com/user-attachments/assets/f05dedec-0260-415c-be3c-993ada01ceaa" />

11b) Press the: Resume button.  The contest should resume counting down on both the administrator as well as the CDS browser window.  Here is the CDS console log:

```
Start time command: pause
Setting start time to paused at: 23:32:40.000
Adding client-side event to feed cache
Setting contest time at https://localhost:50443/contests/SumH
Start time command: resume
Setting start time to: 2025-04-21T20:15:07.000-04:00 (8:15.07 PM April 21, 2025)
Adding client-side event to feed cache
Setting contest time at https://localhost:50443/contests/SumH
Start time command: pause
Setting start time to paused at: 23:32:39.000
Adding client-side event to feed cache
Setting contest time at https://localhost:50443/contests/SumH
Finished scanning SumH for changed resources in 3ms
```
12b) repeat the process if desired.  You can "set" various countdown resume times using the CDS browser window.