### PR TITLE
i_1058 Extra submission notification on event feed

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
@@ -486,6 +486,13 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
 
                     } else {
                         log.info("runChanged: (not adding) " + run.toString());
+
+                        // The following lines are commented out for now (April 14, 2025) and can probably
+                        // be removed in the future.  We are unsure why this code was here in the first place
+                        // and we feel it is wrong.  It causes 2 "submissions" events for the same
+                        // submission to appear on the event feed if an autojudge claims the submission.
+                        // We should not be indicating a new submission on the event feed for *any*
+                        // runChanged event (that I can think of). -- JohnB 4/14/2025
 //                        String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), IJSONTool.getSubmissionId(run), jsonTool.convertToJSON(run, servletRequest, null).toString());
 //                        sendJSON(json + NL);
                     }

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
@@ -459,7 +459,7 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
             Run run = event.getRun();
             Account account = contest.getAccount(run.getSubmitter());
             if (account.isAllowed(Permission.Type.DISPLAY_ON_SCOREBOARD) && !run.isDeleted()) {
-
+                log.info("runAdded: " + run.toString());
                 String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), IJSONTool.getSubmissionId(run), jsonTool.convertToJSON(run, servletRequest, null).toString());
                 sendJSON(json + NL);
             }
@@ -485,8 +485,9 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
                         }
 
                     } else {
-                        String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), IJSONTool.getSubmissionId(run), jsonTool.convertToJSON(run, servletRequest, null).toString());
-                        sendJSON(json + NL);
+                        log.info("runChanged: (not adding) " + run.toString());
+//                        String json = getJSONEvent(SUBMISSION_KEY, getNextEventId(), IJSONTool.getSubmissionId(run), jsonTool.convertToJSON(run, servletRequest, null).toString());
+//                        sendJSON(json + NL);
                     }
                 }
             }


### PR DESCRIPTION
### Description of what the PR does
Do not send an added submission notification if a run changes, only if the run is added.  If a run changes, it implies that was already added at some point, so why add it again.  Appropriate log messages are now provided in the feeder log when runs are added, and, in the case of a change where a run WOULD have been added.

### Issue which the PR addresses
Fixes #1058 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Configure a contest and start the following clients: Server, Feeder, Team, Autojudge
2. Start the feeder feeding a 2023-06 API feed.
3. Start the autojudge.
4. Start the contest.
5. Start a "`curl`" to read the event feed, eg:  `curl -k https://administrator1:administrator1@localhost:50443/contests/sumithello/event-feed`
6. On the team client, submit a run to a problem being autojudged.
7. Observe the curl reader and notice the event feed has 1 submission notifications for the team submission.
