### PR TITLE
i_1065 Do not send RUN confirm to proxy client submitters twice

### DIFF
--- a/src/edu/csus/ecs/pc2/core/PacketHandler.java
+++ b/src/edu/csus/ecs/pc2/core/PacketHandler.java
@@ -1616,12 +1616,19 @@ public class PacketHandler {
             contest.updateRun(run, getServerClientId());
         }
 
-        // Send to team
         Packet confirmPacket = PacketFactory.createRunSubmissionConfirm(contest.getClientId(), fromId, run);
-        controller.sendToClient(confirmPacket);
+        boolean isThisServer = isServer();
+
+        // Send to remote client (on another server) or a local team
+        // Note that if this was proxy submit by say, a feeder on this server, the response
+        // will get sent below in sendToJudgesAndOthers().  We don't want
+        // to send the same packet to the same client twice.
+        if(!isThisServer || fromId.getClientType() == ClientType.Type.TEAM) {
+            controller.sendToClient(confirmPacket);
+        }
 
         // Send to clients and servers
-        if (isServer()) {
+        if (isThisServer) {
             controller.sendToJudgesAndOthers(confirmPacket, false);
             Packet dupSubmissionPacket = PacketFactory.createRunSubmissionConfirmation(contest.getClientId(), fromId, run, runFiles);
             controller.sendToServers(dupSubmissionPacket);


### PR DESCRIPTION
### Description of what the PR does
If a run is submitted by a proxy (not a team), then the proxy client who submitted it will receive two **RUN_SUBMISSION_CONFIRM** notifications.  One is sent directory using `sendToClient() `and the other is sent as a result of `sendToJudgesAndOthers()`.  Test for this condition and prevent that from happening.


### Issue which the PR addresses
Fixes #1065 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Start a contest
2. Start an event feeder server for 2023-06.
3. Start a curl event feed consumer, eg: curl -l https://administrator1:administrator1@localhost:50443/contests/sumithello/event-feed
4. Use the CLICs API to submit a run (eg. the python version of pc2submit)
5. Note that only 1 submission notifications appears on the event feed. 