### PR TITLE
i_1069 Added results CLICS extension endpoint

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestAccess.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestAccess.java
@@ -96,7 +96,7 @@ public class CLICSContestAccess {
          */
         String [] serviceNames = { "Contest", "JudgementType", "Language", "Problem", "Group", "Organization",
                 "Team", "Person", "Account", "State", "Submission", "Judgement", "Run", "Clarification",
-                "Scoreboard", "EventFeed", "Award", "Commentary", "Webhooks"
+                "Scoreboard", "EventFeed", "Award", "Commentary", "Webhooks", "Results"
         };
 
         ArrayList<CLICSEndpoint> epList = new ArrayList<CLICSEndpoint>();
@@ -137,7 +137,7 @@ public class CLICSContestAccess {
                     Object args[] = { contest, sc };
                     // invoke static method with the SecurityContext as an argument
                     Object epRet = m.invoke(null, args);
-                    if(epRet instanceof CLICSEndpoint) {
+                    if(epRet != null && epRet instanceof CLICSEndpoint) {
                         // we got one back, so add it to the list
                         CLICSEndpoint ep = (CLICSEndpoint)epRet;
                         epList.add(ep);

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICS_Ex_Results.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICS_Ex_Results.java
@@ -1,0 +1,116 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.clics.API202306;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+
+import javax.xml.bind.JAXBException;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.csus.ecs.pc2.core.exception.IllegalContestState;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.util.TabSeparatedValueParser;
+import edu.csus.ecs.pc2.services.core.JSONUtilities;
+
+/**
+ * Contains an extension to the CLICS spec. consisting of ICPC specific results.
+ *
+ * @author John Buck
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CLICS_Ex_Results {
+
+    @JsonProperty
+    private String time;
+
+    @JsonProperty
+    private String contest_time;
+
+    @JsonProperty
+    private CLICSContestState state;
+
+    @JsonProperty
+    private CLICS_Ex_ResultsRow [] rows;
+
+    /**
+     * Fill in the results information
+     *
+     */
+    public CLICS_Ex_Results(IInternalContest model, String [] tsvResults)  throws IllegalContestState, JAXBException, IOException {
+
+        // Given an array of strings that looks like this (\t = tab):
+        //    results\t1
+        //    965431\t1\tGold Medal\t10\t1087\t263
+        //    965415\t2\tSilver Medal\t9\t911\t282
+        //    965351\t3\tSilver Medal\t9\t1024\t255
+        //    965444\t4\tBronze Medal\t8\t736\t217
+        //    965438\t5\tBronze Medal\t8\t766\t233
+        //    965407\t6\tBronze Medal\t8\t799\t214
+        //    965445\t7\tRanked\t8\t887\t262
+        //    965423\t8\tRanked\t8\t1099\t295
+        //
+        // This is what we want to return:
+        //        {
+        //            "time": "2014-06-25T14:13:07.832+01",
+        //            "contest_time": "4:13:07.832",
+        //            "state": {
+        //              "started": "2014-06-25T10:00:00+01",
+        //              "ended": null,
+        //              "frozen": "2014-06-25T14:00:00+01",
+        //              "thawed": null,
+        //              "finalized": null,
+        //              "end_of_updates": null
+        //            },
+        //            "rows": [
+        //                  { "rank":1,"icpc_id":"965431","citation":"Gold Medal","num_solved":10,"total_time":1087,"last_solved":263 },
+        //                  { "rank":2,"icpc_id":"965415","citation":"Silver Medal","num_solved":9,"total_time":911,"last_solved":282 },
+        //                  { "rank":3,"icpc_id":"965351","citation":"Silver Medal","num_solved":9,"total_time":1024,"last_solved":255 },
+        //                  { "rank":4,"icpc_id":"965444","citation":"Bronze Medal","num_solved":8,"total_time":736,"last_solved":217 },
+        //                  { "rank":5,"icpc_id":"965438","citation":"Bronze Medal","num_solved":8,"total_time":766,"last_solved":233 },
+        //                  { "rank":6,"icpc_id":"965407","citation":"Bronze Medal","num_solved":8,"total_time":799,"last_solved":214 },
+        //                  { "rank":7,"icpc_id":"965445","citation":"Ranked","num_solved":8,"total_time":887,"last_solved":262 },
+        //                  { "rank":8,"icpc_id":"965423","citation":"Ranked","num_solved":8,"total_time":1099,"last_solved":295 }
+        //            ]
+        //          }
+        time = ZonedDateTime.now( ZoneOffset.UTC ).format( DateTimeFormatter.ISO_INSTANT);
+        contest_time = model.getContestTime().getElapsedTimeStr();
+        state = new CLICSContestState(model, null);
+
+        if(tsvResults != null) {
+            ArrayList<CLICS_Ex_ResultsRow>rowsArray = new ArrayList<CLICS_Ex_ResultsRow>();
+
+            for (String result : tsvResults) {
+                String[] resultFields;
+                try {
+                    resultFields = TabSeparatedValueParser.parseLine(result);
+                    if(resultFields.length == CLICS_Ex_ResultsRow.NUM_RESULTS_TSV_FIELDS) {
+                        rowsArray.add(new CLICS_Ex_ResultsRow(resultFields));
+                    }
+                } catch (Exception e) {
+                    // We don't care if a line is bad, in fact, looking at TabSeparatedValueParser,
+                    // it seems there is a question of whether or not an exception is ever thrown! jb-4/25
+                }
+            }
+            rows = rowsArray.toArray(new CLICS_Ex_ResultsRow[0]);
+        } else {
+            rows = new CLICS_Ex_ResultsRow[0];
+        }
+    }
+
+    public String toJSON() {
+
+        try {
+            ObjectMapper mapper = JSONUtilities.getObjectMapper();
+            return mapper.writeValueAsString(this);
+        } catch (Exception e) {
+            return "Error creating JSON for CLICS Ex results info " + e.getMessage();
+        }
+    }
+}

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICS_Ex_ResultsRow.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICS_Ex_ResultsRow.java
@@ -1,0 +1,63 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.clics.API202306;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Contains information about a single entry (row) in the extended CLICS results.
+ *
+ * @author John Buck
+ *
+ */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CLICS_Ex_ResultsRow {
+
+    // eg. "965415\t2\2Silver Medal\29\2911\t282"
+    public static final int NUM_RESULTS_TSV_FIELDS = 6;
+    private static final int ICPC_ID_FIELD = 0;
+    private static final int RANK_FIELD = 1;
+    private static final int CITATION_FIELD = 2;
+    private static final int NUM_SOLVED_FIELD = 3;
+    private static final int TOTAL_TIME_FIELD = 4;
+    private static final int LAST_SOLVED_FIELD = 5;
+
+    @JsonProperty
+    private int rank;
+
+    @JsonProperty
+    private String icpc_id;
+
+    @JsonProperty
+    private String citation;
+
+    @JsonProperty
+    private int num_solved;
+
+    @JsonProperty
+    private int total_time;
+
+    @JsonProperty
+    private int last_solved;
+
+    /**
+     * Fill in results row information properties (for results endpoint)
+     *
+     * @param resultTSVLine TSV line to assign to object
+     */
+    public CLICS_Ex_ResultsRow(String [] resultFields) {
+        String rankField = resultFields[RANK_FIELD];
+        // In the case of Honorable mentions, there is no rank (empty field)
+        if(rankField.isEmpty()) {
+            rank = -1;
+        } else {
+            rank = Integer.valueOf(rankField);
+        }
+        icpc_id = resultFields[ICPC_ID_FIELD];
+        citation = resultFields[CITATION_FIELD];
+        num_solved = Integer.valueOf(resultFields[NUM_SOLVED_FIELD]);
+        total_time = Integer.valueOf(resultFields[TOTAL_TIME_FIELD]);
+        last_solved = Integer.valueOf(resultFields[LAST_SOLVED_FIELD]);
+    }
+}

--- a/src/edu/csus/ecs/pc2/clics/API202306/ResourceConfig202306.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ResourceConfig202306.java
@@ -81,6 +81,8 @@ public class ResourceConfig202306 implements ICLICSResourceConfig {
             resConfig.register(new AwardService(getContest(), getController()));
             showStartingMessage("awards web service");
             resConfig.register(new VersionService(getContest(), getController()));
+            showStartingMessage("results (extension) web service");
+            resConfig.register(new ResultsService(getContest(), getController()));
             showMessage("Starting / endpoint for version web service");
 
         }

--- a/src/edu/csus/ecs/pc2/clics/API202306/ResultsService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ResultsService.java
@@ -1,0 +1,161 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.clics.API202306;
+
+import java.io.IOException;
+
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+import javax.xml.bind.JAXBException;
+
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.exception.IllegalContestState;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.ContestTime;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
+import edu.csus.ecs.pc2.services.core.JSONUtilities;
+import edu.csus.ecs.pc2.services.eventFeed.WebServer;
+/**
+ * Webservice to handle results requests.
+ * This can be used to retrieve results.tsv, results.csv or results.json depending on the query param.
+ *
+ * This is a non-CLICS standard endpoint.
+ *
+ * @author John Buck
+ */
+@Path("/contests/{contestId}/results")
+@Produces(MediaType.APPLICATION_JSON)
+@Provider
+@Singleton
+public class ResultsService implements Feature {
+
+    public static final String RESULTS_FORMAT_TSV = "tsv";
+    public static final String RESULTS_FORMAT_CSV = "csv";
+    public static final String RESULTS_FORMAT_JSON = "json";
+
+    private IInternalContest model;
+    private IInternalController controller;
+
+    public ResultsService(IInternalContest inContest, IInternalController inController) {
+        super();
+        this.model = inContest;
+        this.controller = inController;
+    }
+
+    /**
+     * This method returns a representation of the current contest results in one of several formats.
+     *
+     * @param servletRequest
+     * @param sc
+     * @param contestId
+     * @param format - desired return format
+     * @return {@link Response} object containing the requested results in the desired format
+     */
+    @GET
+    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
+    public Response getResults(@Context HttpServletRequest servletRequest, @Context SecurityContext sc, @PathParam("contestId") String contestId,
+            @QueryParam("format") String format) {
+
+        // check contest id
+        if(contestId.equals(model.getContestIdentifier()) == true) {
+            ContestTime contestTime = model.getContestTime();
+            // verify contest has started and user is admin
+            if (contestTime.getElapsedMS() > 0 && sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN)) {
+
+                ResultsFile resultsFile = new ResultsFile();
+                String [] lines;
+
+                // Default format is TSV if not supplied.  One might expect it to be JSON since this
+                // is a CLICS api, however, since this is an "extension" to the API to facilitate
+                // the ICPC historical (hysterical?) results format, it makes some sense to make
+                // the default TSV.
+                if (format == null) {
+                    format = RESULTS_FORMAT_TSV;
+                }
+                // make sure we can do the format
+                if (format.equalsIgnoreCase(RESULTS_FORMAT_CSV)) {
+                    return(createResultsResponse(resultsFile.createCSVFileLines(model), MediaType.TEXT_PLAIN));
+                }
+                if(format.equalsIgnoreCase(RESULTS_FORMAT_TSV)) {
+                    lines = resultsFile.createTSVFileLines(model);
+                    return(createResultsResponse(resultsFile.createTSVFileLines(model), MediaType.TEXT_PLAIN));
+                }
+                if(format.equalsIgnoreCase(RESULTS_FORMAT_JSON)) {
+                    // We first make a TSV file, then create json from that
+                    try {
+                        CLICS_Ex_Results results = new CLICS_Ex_Results(model, resultsFile.createTSVFileLines(model));
+                        return Response.ok(results.toJSON(), MediaType.APPLICATION_JSON).build();
+                    } catch (IllegalContestState | JAXBException | IOException e) {
+                        controller.getLog().log(Log.WARNING, "Exception creating PC2 results JSON: " + e.getMessage(), e);
+                        return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+                    }
+                } else {
+                    // do not show (return) the results if a bad requested format
+                    return Response.status(Status.BAD_REQUEST).build();
+                }
+            } else {
+                // do not show (return) the results if the contest has not
+                // been started and the requester is not special)
+                return Response.status(Status.FORBIDDEN).build();
+            }
+        }
+        // Contest not found
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    /**
+     * Returns a response created by appending newlines to each string in passed
+     * in array.  The response has the specified mime type.  This is used to create TSV
+     * and CSV response.
+     *
+     * @param lines Array of strings comprising the data to return
+     * @param mimeType desired mime type of response.
+     * @return ready to return Response
+     */
+    private Response createResultsResponse(String [] lines, String mimeType)
+    {
+        StringBuilder result = new StringBuilder();
+        for(String line: lines) {
+            result.append(line);
+            result.append(JSON202306Utilities.NL);
+        }
+        return Response.ok(result.toString(), mimeType).build();
+    }
+
+    /**
+     * Retrieve access information about this endpoint for the supplied user's security context
+     *
+     * @param contest The contest is included in case the inclusion of a property depends on the permissions
+     *        set for the connected client.  It is included for uniformity since this method is called as a result
+     *        of introspection, and the caller does not know what the callee may need.  Therefore, the contest is
+     *        always included, as is the SecurityContext below (for the same reason).
+     * @param sc User's security information
+     * @return CLICSEndpoint object if the user can access this endpoint's properties, null otherwise
+     */
+    public static CLICSEndpoint getEndpointProperties(IInternalContest contest, SecurityContext sc) {
+        // Only admins can use this endpoint.  Returning null will not show the endpoint in the access list
+        if(!sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) && !sc.isUserInRole(WebServer.WEBAPI_ROLE_JUDGE)) {
+            return(null);
+        }
+        return(new CLICSEndpoint("results", JSONUtilities.getJsonProperties(CLICS_Ex_Results.class)));
+    }
+
+    @Override
+    public boolean configure(FeatureContext arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+}

--- a/src/edu/csus/ecs/pc2/clics/API202306/ResultsService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ResultsService.java
@@ -73,7 +73,8 @@ public class ResultsService implements Feature {
         if(contestId.equals(model.getContestIdentifier()) == true) {
             ContestTime contestTime = model.getContestTime();
             // verify contest has started and user is admin
-            if (contestTime.getElapsedMS() > 0 && sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN)) {
+            if (contestTime.getElapsedMS() > 0 &&
+                (sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) || sc.isUserInRole(WebServer.WEBAPI_ROLE_JUDGE))) {
 
                 ResultsFile resultsFile = new ResultsFile();
                 String [] lines;


### PR DESCRIPTION
### Description of what the PR does
Add a` /results `endpoint as an extension to the CLICS 2023-06 API implementation. By default, the endpoint returns the `results.tsv` file for administrators only. An optional query parameter, `format`, is implemented to allow a user to query the results in one of three formats: **tsv**, **csv** or **json**.  eg.

```
curl -k https://localhost:50443/contests/mycontest/results
curl -k https://localhost:50443/contests/mycontest/results?format=tsv
curl -k https://localhost:50443/contests/mycontest/results?format=csv
curl -k https://localhost:50443/contests/mycontest/results ?format=json
```


### Issue which the PR addresses
Fixes #1069 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Ubuntu 24.04
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Bring up a completed contest (one that has results).
Start an event feeder client and start the feeder for 2023-06.
Issue one (or each of) the above curl commands, specifying an administrator account or judge account.
The results should be fetched in the format specified.
Try issuing one of the curls using a non-admin type account, like a team.  Note that it will fail with a FORBIDDEN error.