### PR TITLE
i_1071 Fix account type on event feed "accounts" endpoint and notifications

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSAccount.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSAccount.java
@@ -72,10 +72,18 @@ public class CLICSAccount {
         if(sc != null && sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN)) {
             password = account.getPassword();
         }
-        type = "" + cid.getClientType();
-        type = type.toLowerCase();
-        if(account.isTeam()) {
+        // Map known CLICS account types to clics strings since PC2 type strings
+        // are different
+        if(cid.getClientType() == Type.ADMINISTRATOR) {
+            type = "admin";
+        } else if(cid.getClientType() == Type.TEAM) {
+            type = "team";
             team_id = username;
+        } else if(cid.getClientType() == Type.JUDGE) {
+            type = "judge";
+        } else {
+            type = "" + cid.getClientType();
+            type = type.toLowerCase();
         }
     }
 


### PR DESCRIPTION
### Description of what the PR does
The _CLICS 2023-06_ specification says that administrator accounts should have property `type ` = "**admin**" on the event feed and the API.  We previously just used the `ClientId `type, which was "**administrator**".  This fixes that.
Also, we now manually set the other types so we do not depend on what PC2 uses for the client type string.  It is unclear how we should map other accounts, such as "scoreboards" and "feeders".  For now, they will be left using the PC2 type, eg. "scoreboard" and "feeders" respectively.  There is some discussion as to whether these should be "staff" type accounts, which leads to a discussion of whether "staff" accounts have "administrator" privileges.  Reference: Information Access Policy "Staff" column.

### Issue which the PR addresses
Fixes #1071 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Start the `samps/clics_sumithello` contest.
2) Generate an event feeder account, eg **feeder1**
3) Start the event feeder client using the newly created **feeder1** account.
4) Start the feed using the 2023-06 API
5) Query the "accounts" endpoint: `https://administrator1:administrator1@localhost:50443/contests/SumH/accounts`
6) Note the administrator account(s) listed show `type`: "**admin**"