### PR TITLE
I1073 Control which notifications on the event feed can use collections

### DIFF
--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -27,4 +27,5 @@ wtiwsName=/websocket
 
 [clics]
 apiVersionsSupported=2023-06,2020-03
+disable-collections=all
 # eof 

--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -27,5 +27,11 @@ wtiwsName=/websocket
 
 [clics]
 apiVersionsSupported=2023-06,2020-03
-disable-collections=all
+# Comma separated list of notification types (EventFeedTypes) to not use collections on.
+# "all" means all notifications are sent individually, not grouped into collections.
+# disable-collections=all
+# Due to the way the ICPC tools CDS works, we do not want to send "accounts" as collections
+# since the CDS will interpret a collection as a complete list of accounts and remove any
+# accounts configured by the CDS.  This is not desirable.
+disable-collections=accounts
 # eof 

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedJSON.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedJSON.java
@@ -18,6 +18,8 @@ import edu.csus.ecs.pc2.core.list.AccountComparator;
 import edu.csus.ecs.pc2.core.list.ClarificationComparator;
 import edu.csus.ecs.pc2.core.list.GroupComparator;
 import edu.csus.ecs.pc2.core.list.RunComparator;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.Clarification;
 import edu.csus.ecs.pc2.core.model.ClarificationAnswer;
@@ -61,11 +63,17 @@ public class EventFeedJSON extends JSON202306Utilities {
         super();
         this.jsonTool = jsonTool;
 
-        try {
-            String [] disList = CommaSeparatedValueParser.parseLine(IniFile.getValue(CLICS_DISABLE_COLLECTIONS_KEY));
-            this.disableNotificationCollections(disList);
-        } catch (Exception e) {
-            // Use default values for collections
+        String disCSVList = IniFile.getValue(CLICS_DISABLE_COLLECTIONS_KEY);
+        if(disCSVList != null && !disCSVList.isEmpty()) {
+            try {
+                String [] disList = CommaSeparatedValueParser.parseLine(disCSVList);
+                this.disableNotificationCollections(disList);
+            } catch (Exception e) {
+                Log log = StaticLog.getLog();
+                if(log != null) {
+                    log.warning("Error parsing INI key: " + CLICS_DISABLE_COLLECTIONS_KEY + " (" + disCSVList + "): " + e);
+                }
+            }
         }
     }
 
@@ -1089,7 +1097,7 @@ public class EventFeedJSON extends JSON202306Utilities {
 
     /**
      * Tests if notification collections should be used for a specific notification type.
-     * This first tests is notification collections are being used in general, then if so,
+     * This first tests if notification collections are being used in general, then if so,
      * checks if the specific type is not disabled.
      *
      * @param notificationType
@@ -1100,12 +1108,12 @@ public class EventFeedJSON extends JSON202306Utilities {
     }
 
     /**
-     * Adds the comma-separated list of notification types (EventFeedType's) to the HashSet of
+     * Adds the array of notification types (EventFeedType strings) to the HashSet of
      * disabled notification types.  Any notification type in this list will not use collections
      * on the event feed.  The special type ALL_NOTIFICATION_TYPES will disable collections for all
-     * notification and will clear the HashSet of disabled types and simply set the useCollections flag to false.
+     * notifications and will clear the HashSet of disabled types and simply set the useCollections flag to false.
      *
-     * @param list Comma-separated list of notification types (EventFeedType's) to not use
+     * @param list array of notification types (EventFeedType strings) to not use
      *      collections on.
      */
     public void disableNotificationCollections(String [] list) {
@@ -1122,13 +1130,14 @@ public class EventFeedJSON extends JSON202306Utilities {
     }
 
     /**
-     * Remove the comma-separated list of notification types (EventFeedType's) from the Hashset
-     * of disabled notification types.  If collections are enabled, then the types included in the
-     * supplied list will be allowed to generate collections.  The special type ALL_NOTIFICATION_TYPES will disable collections for all
+     * Remove the array of notification types (EventFeedType strings) from the Hashset
+     * of disabled notification types.  The types included in the
+     * supplied list will be allowed to generate collections, assuming collections are
+     * being used (useCollections).  The special type ALL_NOTIFICATION_TYPES will enable collections for all
      * notification and will simply set the useCollections flag to true and clear the HashSet of
      * disabled types.
      *
-     * @param list Comma-separated list of notification types (EventFeedType's) to allow collections on.
+     * @param list array of notification types (EventFeedType strings) to allow collections on.
      */
     public void enableNotificationCollections(String [] list) {
         if(list != null) {

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedJSON.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedJSON.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.SecurityContext;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import edu.csus.ecs.pc2.core.IniFile;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.list.AccountComparator;
 import edu.csus.ecs.pc2.core.list.ClarificationComparator;
@@ -33,6 +34,7 @@ import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.model.RunTestCase;
 import edu.csus.ecs.pc2.core.security.Permission;
+import edu.csus.ecs.pc2.core.util.CommaSeparatedValueParser;
 import edu.csus.ecs.pc2.core.util.IJSONTool;
 
 /**
@@ -46,7 +48,11 @@ public class EventFeedJSON extends JSON202306Utilities {
     public static final String EVENT_ID_PREFIX = "pc2-";
     public static final int EVENT_ID_PREFIX_LENGTH = EVENT_ID_PREFIX.length();
 
+    public static final String CLICS_DISABLE_COLLECTIONS_KEY = "clics.disable-collections";
+    public static final String ALL_NOTIFICATION_TYPES = "all";
+
     private boolean useCollections = true;
+    private HashSet<String> disableCollections = new HashSet<String>();
 
     /**
      *
@@ -54,6 +60,13 @@ public class EventFeedJSON extends JSON202306Utilities {
     public EventFeedJSON(IJSONTool jsonTool) {
         super();
         this.jsonTool = jsonTool;
+
+        try {
+            String [] disList = CommaSeparatedValueParser.parseLine(IniFile.getValue(CLICS_DISABLE_COLLECTIONS_KEY));
+            this.disableNotificationCollections(disList);
+        } catch (Exception e) {
+            // Use default values for collections
+        }
     }
 
     /**
@@ -116,7 +129,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         StringBuilder stringBuilder = new StringBuilder();
 
         Judgement[] judgements = contest.getJudgements();
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.JUDGEMENT_TYPES)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -157,7 +170,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         StringBuilder stringBuilder = new StringBuilder();
 
         Language[] languages = contest.getLanguages();
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.LANGUAGES)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -207,7 +220,7 @@ public class EventFeedJSON extends JSON202306Utilities {
 
         Problem[] problems = contest.getProblems();
         int id = 1;
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.PROBLEMS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -252,7 +265,7 @@ public class EventFeedJSON extends JSON202306Utilities {
 
         HashSet<ElementId> usedGroups = getGroupsUsed(contest);
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.GROUPS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -335,7 +348,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         Hashtable<String, Account> organizations = new Hashtable<String, Account>();
 
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.ORGANIZATIONS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -391,7 +404,7 @@ public class EventFeedJSON extends JSON202306Utilities {
 
         Account[] accounts = EventFeedJSON.getTeamAccounts(contest);
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.TEAMS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -434,7 +447,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         Account[] accounts = contest.getAccounts();
         Arrays.sort(accounts, new AccountComparator());
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.ACCOUNTS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -498,7 +511,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         int memberId;
         Account[] accounts = EventFeedJSON.getTeamAccounts(contest);
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.PERSONS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -585,7 +598,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         Run[] runs = contest.getRuns();
 
         Arrays.sort(runs, new RunComparator());
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.SUBMISSIONS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -644,7 +657,7 @@ public class EventFeedJSON extends JSON202306Utilities {
 
         Arrays.sort(runs, new RunComparator());
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.JUDGEMENTS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -696,7 +709,7 @@ public class EventFeedJSON extends JSON202306Utilities {
 
         Arrays.sort(runs, new RunComparator());
 
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.RUNS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             dataCollection.append("[");
@@ -755,7 +768,7 @@ public class EventFeedJSON extends JSON202306Utilities {
         Clarification[] clarifications = contest.getClarifications();
 
         Arrays.sort(clarifications, new ClarificationComparator());
-        if(isUseCollections()) {
+        if(isUseNotificationCollection(EventFeedType.CLARIFICATIONS)) {
             StringBuilder dataCollection = new StringBuilder();
             boolean bFirst = true;
             boolean isQuestion = false;
@@ -1056,13 +1069,80 @@ public class EventFeedJSON extends JSON202306Utilities {
         this.filter = filter;
     }
 
+    /**
+     * Check if we are using collections for notifications
+     *
+     * @return true if collections are enabled, false otherwise
+     */
     public boolean isUseCollections() {
         return useCollections;
     }
 
+    /**
+     * Set if we want to try to use collections when possible for notifications
+     *
+     * @param useCollections - true to try to use collections
+     */
     public void setUseCollections(boolean useCollections) {
         this.useCollections = useCollections;
     }
+
+    /**
+     * Tests if notification collections should be used for a specific notification type.
+     * This first tests is notification collections are being used in general, then if so,
+     * checks if the specific type is not disabled.
+     *
+     * @param notificationType
+     * @return
+     */
+    public boolean isUseNotificationCollection(EventFeedType notificationType) {
+        return(isUseCollections() && !disableCollections.contains(notificationType.toString()));
+    }
+
+    /**
+     * Adds the comma-separated list of notification types (EventFeedType's) to the HashSet of
+     * disabled notification types.  Any notification type in this list will not use collections
+     * on the event feed.  The special type ALL_NOTIFICATION_TYPES will disable collections for all
+     * notification and will clear the HashSet of disabled types and simply set the useCollections flag to false.
+     *
+     * @param list Comma-separated list of notification types (EventFeedType's) to not use
+     *      collections on.
+     */
+    public void disableNotificationCollections(String [] list) {
+        if(list != null) {
+            for(String notificationType : list) {
+                if(notificationType.equals(ALL_NOTIFICATION_TYPES)) {
+                    setUseCollections(false);
+                    disableCollections.clear();
+                    break;
+                }
+                disableCollections.add(notificationType);
+            }
+        }
+    }
+
+    /**
+     * Remove the comma-separated list of notification types (EventFeedType's) from the Hashset
+     * of disabled notification types.  If collections are enabled, then the types included in the
+     * supplied list will be allowed to generate collections.  The special type ALL_NOTIFICATION_TYPES will disable collections for all
+     * notification and will simply set the useCollections flag to true and clear the HashSet of
+     * disabled types.
+     *
+     * @param list Comma-separated list of notification types (EventFeedType's) to allow collections on.
+     */
+    public void enableNotificationCollections(String [] list) {
+        if(list != null) {
+            for(String notificationType : list) {
+                if(notificationType.equals(ALL_NOTIFICATION_TYPES)) {
+                    setUseCollections(true);
+                    disableCollections.clear();
+                    break;
+                }
+                disableCollections.remove(notificationType);
+            }
+        }
+    }
+
     /**
      * Get event id property for the event feed notification
      *

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedLog.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedLog.java
@@ -42,7 +42,7 @@ public class EventFeedLog {
      */
     public EventFeedLog(IInternalContest contest) throws FileNotFoundException, UnsupportedEncodingException {
 
-        filename = getEventFeedLogName(contest.getContestIdentifier());
+        filename = getEventFeedLogName(contest);
         setLogFileName(filename);
 
         // First read log
@@ -62,8 +62,8 @@ public class EventFeedLog {
         }
     }
 
-    private String getEventFeedLogName(String id) {
-        return logsDirectory + File.separator + "Eventfeed_2023_06_" + id + ".log";
+    private String getEventFeedLogName(IInternalContest contest) {
+        return logsDirectory + File.separator + "Eventfeed_2023_06_" + contest.getContestIdentifier() + "_" + contest.getClientId().getName() + ".log";
     }
 
     public String[] getLogLines() {

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedType.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedType.java
@@ -72,7 +72,7 @@ public enum EventFeedType {
     /**
      *
      */
-    TEAM_MEMBERS("team-members");
+    PERSONS("persons");
 
     private final String name;
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/JSON202306Utilities.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/JSON202306Utilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.text.SimpleDateFormat;
@@ -13,7 +13,7 @@ import edu.csus.ecs.pc2.services.core.JSONUtilities;
  * @author John Buck, updated for CLICS 2023-06
  */
 public class JSON202306Utilities extends JSONUtilities {
-    public static final String TEAM_MEMBERS_KEY = "team-members";
+    public static final String TEAM_MEMBERS_KEY = "persons";
 
     public static final String CLARIFICATIONS_KEY = "clarifications";
 


### PR DESCRIPTION
### Description of what the PR does
Allow specification of when to use notification collections on the event feed in the `pc2v9.ini `file.
Change default setting for the `disable-collections` property in the `pc2v9.ini` file due to the way the ICPC tools CDS works.  We do not want to send `accounts` as collections since the CDS will interpret a collection as a complete list of accounts and remove any accounts configured by the CDS.  This is not desirable since it would loose the CDS' 'admin' account privileges and other CDS accounts.

CI: Give the EventFeed feeder log (list of event feed notifications sent) a unique name based on the client doing the feeding.   This will prevent event feed log corruption if someone decides to run 2 event feeders are run on different ports, for example. Ex.
Old Name: `Eventfeed_2023_06_SumH.log` 
New Name after CI: `Eventfeed_2023_06_SumH_feeder1.log`
CI: change endpoint from "**team-members**" to "**persons**", even though we don't use this at the moment.  We want it right for the future.

### Issue which the PR addresses
Fixes #1073
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Load and bring up the clics_sumithello sample contest.
2. Generate a feeder account (feeder1).
3. Start the event feeder client using the newly generated feeder1 account.
4. Start the event feed feeding the CLICS 2023-06 API.
5. Using curl, or another utility, access the event feed: https://administrator1:administrator1@localhost:50443/contests/SumH/event-feed
6. Note that the accounts notifications are now individual instead of grouped into a collection (like the other notifications: teams, problems, etc).  
[SampleEventFeed.txt](https://github.com/user-attachments/files/19835577/SampleEventFeed.txt)

7. You can try setting the disable-collections property in the pc2v9.ini file to "all", or add additional notification types to the list to test it out.
8. You can leave out (comment out) the disable-collections line in the pc2v9.ini file to allow collections on all notification types.



