### PR TITLE
i_1075 Include announcement text in Event Feed

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSClarification.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSClarification.java
@@ -105,13 +105,10 @@ public class CLICSClarification {
         }
         // Announcements do not have a reply_to_id or a question, but they do have an answer
         if(clar.isAnnounced()) {
-            reply_to_id = null;
             ClarificationAnswer[] clarAnswers = clar.getClarificationAnswers();
             if(clarAnswers != null && clarAnswers.length > 0) {
                 clarAns = clarAnswers[clarAnswers.length - 1];
             }
-        } else {
-            reply_to_id = clar.getElementId().toString();
         }
         if (clarAns != null) {
             // does the answer go to a team (as opposed to everyone)?
@@ -155,6 +152,12 @@ public class CLICSClarification {
                         }
                     }
                 }
+            }
+            // Announcements do not have a question.
+            if(clar.isAnnounced()) {
+                reply_to_id = null;
+            } else {
+                reply_to_id = clar.getElementId().toString();
             }
             text = clarAns.getAnswer();
             time = Utilities.getIso8601formatterWithMS().format(clarAns.getDate());

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSClarification.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSClarification.java
@@ -78,7 +78,10 @@ public class CLICSClarification {
      * answer has a property called "reply_to_id".
      * This CLICSClarification class is used for both questions and answers.
      * If the clarAns argument is null, it means it's a question and "clar"
-     * contains that question (see the comment for @param clarAns).
+     * contains that question (see the comment for @param clarAns).  To complicate matters,
+     * a Clarification may also be a annoucement, in which case, there is no separate answer that
+     * would result in a clarification change event, rather the
+     * announcement text is included when the clarification is created.
      *
      * So, ClarificationService creates a separate CLICSClarification object
      * for the question (clarAns == null) and the answer to that question (clarAns != null).
@@ -99,6 +102,16 @@ public class CLICSClarification {
         }
         if (clar.getSubmitter().getClientType().equals(ClientType.Type.TEAM) && clarAns == null) {
             from_team_id = "" + clar.getSubmitter().getClientNumber();
+        }
+        // Announcements do not have a reply_to_id or a question, but they do have an answer
+        if(clar.isAnnounced()) {
+            reply_to_id = null;
+            ClarificationAnswer[] clarAnswers = clar.getClarificationAnswers();
+            if(clarAnswers != null && clarAnswers.length > 0) {
+                clarAns = clarAnswers[clarAnswers.length - 1];
+            }
+        } else {
+            reply_to_id = clar.getElementId().toString();
         }
         if (clarAns != null) {
             // does the answer go to a team (as opposed to everyone)?
@@ -142,12 +155,6 @@ public class CLICSClarification {
                         }
                     }
                 }
-            }
-            // Announcements do not have a question.
-            if(clar.isAnnounced()) {
-                reply_to_id = null;
-            } else {
-                reply_to_id = clar.getElementId().toString();
             }
             text = clarAns.getAnswer();
             time = Utilities.getIso8601formatterWithMS().format(clarAns.getDate());


### PR DESCRIPTION
### Description of what the PR does
If a clarification is an announcement, look up the announcement text from the answer attached to the clarification because there will not be a separate update when the answer (announcement) is added - it's already there when the clarification was created.

### Issue which the PR addresses
Fixes #1075 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
WIndows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Start a contest such as **clics_sumithello**.
2. Generate an event feeder client (feeder1) account
3. Start the event feeder client.
4. Start the event feeder feeding _CLICS 2023-06 API_.
5. Start a judge client and log in as **judge10**
6. Generate a clarification announcement.
7. Observe the event feed (https://administrator1:administrator1@localhost:50443/contests/SumH/event-feed)
8. Note the clarification notification for the announcement has the `text` property populated with the announcement text.


```
{"type":"clarifications","token":"pc2-9","id":"Clarification--5818384884585899859",
  "data": {"id":"Clarification--5818384884585899859",
    "from_team_id":null,
    "to_team_id":null,
    "to_team_ids":null,
    "to_group_ids":null,
    "reply_to_id":null,
    "problem_id":null,
    "text":"This is announcement number 2.",
    "time":"2025-04-21T22:05:17.676-04",
    "contest_time":"00:10:42.469",
    "number":2
  }
}

```