### PR TITLE
i_1077 Handle each EF client in its own thread

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.SecurityContext;
@@ -128,15 +130,29 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
      *
      * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
      */
-    protected class StreamAndFilter {
+    protected class StreamAndFilter implements Runnable {
+
+        private static final int QUEUE_WAIT_TIME_MS = 1000;
 
         private OutputStream stream;
 
         private EventFeedFilter filter;
 
+        private LinkedBlockingQueue<String> outputQueue = new LinkedBlockingQueue<String>();
+
+        private boolean terminateClient = false;
+
         public StreamAndFilter(OutputStream outputStream, EventFeedFilter filter) {
             stream = outputStream;
             this.filter = filter;
+        }
+
+        public boolean wantTerminateClient() {
+            return terminateClient;
+        }
+
+        public void setTerminateClient() {
+            terminateClient = true;
         }
 
         public OutputStream getStream() {
@@ -145,6 +161,40 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
 
         public EventFeedFilter getFilter() {
             return filter;
+        }
+
+        public void put(String s){
+            try {
+                outputQueue.put(s);
+            } catch (InterruptedException e) {
+                terminateClient = true;
+            }
+        }
+
+        @Override
+        public void run() {
+            String line;
+
+            try {
+                while(!terminateClient) {
+                    line = outputQueue.poll(QUEUE_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+                    if(line != null) {
+                        try {
+                            stream.write(line.getBytes("UTF-8"));
+                            stream.flush();
+                        } catch (Exception e) {
+                            if(line.equals(NL)) {
+                                log.log(Log.INFO, "Problem trying to send keep-alive to " + getFilter().getClient(), e);
+                            } else {
+                                log.log(Log.INFO, "Problem trying to send JSON '" + line + "' to " + getFilter().getClient(), e);
+                            }
+                            terminateClient = true;
+                        }
+                    }
+                }
+            } catch (InterruptedException e) {
+                terminateClient = true;
+            }
         }
     }
 
@@ -172,8 +222,9 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
      */
     public void addStream(OutputStream outputStream, EventFeedFilter filter) {
         StreamAndFilter sandf = new StreamAndFilter(outputStream, filter);
+        new Thread(sandf).start();
         streamsMap.put(outputStream, sandf);
-        sendEventsFromEventFeedLog(outputStream, filter);
+        sendEventsFromEventFeedLog(sandf, filter);
     }
 
     /**
@@ -185,7 +236,12 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
 
         if (isStreamActive(stream)) {
             try {
-                log.log(Log.INFO, "Closing client stream " + stream);
+                StreamAndFilter sandf = streamsMap.get(stream);
+                log.log(Log.INFO, "Stopping client thread and closing client stream " + stream);
+                // Stop thread
+                if(sandf != null) {
+                    sandf.setTerminateClient();
+                }
                 stream.close();
                 log.log(Log.INFO, "Closed client stream.");
                 streamsMap.remove(stream);
@@ -253,7 +309,7 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
      * @param filter
      * @param
      */
-    private void sendEventsFromEventFeedLog(OutputStream stream, EventFeedFilter filter) {
+    private void sendEventsFromEventFeedLog(StreamAndFilter sandf, EventFeedFilter filter) {
 
         /**
          * Number of lines/events in log.
@@ -274,9 +330,7 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
                     }
 
                     if (filter.matchesFilter(line)) {
-                        stream.write(line.getBytes("UTF-8"));
-                        stream.write(NL.getBytes("UTF-8"));
-                        stream.flush();
+                        sandf.put(line + NL);
                     }
                 }
             }
@@ -864,29 +918,30 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
 
         string = replaceEventId (string, newId);
 
+        // Add notification to log before sending to clients
+        try {
+            eventFeedLog.writeEvent(string);
+        } catch (Exception e) {
+            e.printStackTrace();
+            log.log(Log.WARNING, "Problem trying to write event feed log for '" + string + "'", e);
+        }
+
+
         /**
          * Send JSON to each
          */
         for (Map.Entry<OutputStream, StreamAndFilter> entry : streamsMap.entrySet()) {
             StreamAndFilter streamAndFilter = entry.getValue();
 
-            try {
-                if (streamAndFilter.getFilter().matchesFilter(string)) {
-                    OutputStream stream = streamAndFilter.getStream();
-                    stream.write(string.getBytes("UTF-8"));
-                    stream.flush();
-                }
-            } catch (Exception e) {
-                log.log(Log.INFO, "Problem trying to send JSON '" + string + "'", e);
+            // Check if there was a problem with this client, if so, we are no longer
+            // interested in providing it with data
+            if (streamAndFilter.wantTerminateClient()) {
                 removeStream(streamAndFilter.getStream());
+            } else {
+                if (streamAndFilter.getFilter().matchesFilter(string)) {
+                    streamAndFilter.put(string);
+                }
             }
-        }
-
-        try {
-            eventFeedLog.writeEvent(string);
-        } catch (Exception e) {
-            e.printStackTrace();
-            log.log(Log.WARNING, "Problem trying to write event feed log for '" + string + "'", e);
         }
 
         lastSent = System.currentTimeMillis();
@@ -927,19 +982,15 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
             if (System.currentTimeMillis() > lastSent + KEEP_ALIVE_DELAY) {
 
                 // Send keep alive to every running stream.
-
                 for (Iterator<OutputStream> streams = streamsMap.keySet().iterator(); streams.hasNext();) {
                     OutputStream stream = streams.next();
                     StreamAndFilter streamAndFilter = streamsMap.get(stream);
 
-                    try {
-                        // OutputStream stream = streamAndFilter.getStream();
-                        stream.write(NL.getBytes());
-                        stream.flush();
-
-                    } catch (Exception e) {
-                        log.log(Log.INFO, "Problem writing keep alive newline to stream to " + streamAndFilter.getFilter().getClient(), e);
+                    // If client had a write issue, we are no longer interested in it.
+                    if(streamAndFilter.wantTerminateClient()) {
                         removeStream(streamAndFilter.getStream());
+                    } else {
+                        streamAndFilter.put(NL);;
                     }
                 }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
@@ -152,9 +152,11 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
         }
 
         public void setTerminateClient() {
-            // if terminateClient is false, this means he caller is asking us
-            // to stop because they're done.  (eg. removeClient() being called)
-            // If there's data pending, we want to wait a big for it to drain.
+            // if terminateClient is false, this means the caller is asking us
+            // to stop because they're done.  (eg. removeStream() being called)
+            // If there's data pending, we want to wait a bit for it to drain.
+            // if terminateClient is already true before this is called, it means
+            // an error has occurred, and there's no point waiting for it to drain.
             if(terminateClient == false && outputQueue.isEmpty() == false) {
                 // wait for the thread to pick it up
                 try {
@@ -944,13 +946,15 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
         for (Map.Entry<OutputStream, StreamAndFilter> entry : streamsMap.entrySet()) {
             StreamAndFilter streamAndFilter = entry.getValue();
 
-            // Check if there was a problem with this client, if so, we are no longer
-            // interested in providing it with data
-            if (streamAndFilter.wantTerminateClient()) {
-                removeStream(streamAndFilter.getStream());
-            } else {
-                if (streamAndFilter.getFilter().matchesFilter(string)) {
-                    streamAndFilter.put(string);
+            if(streamAndFilter != null) {
+                // Check if there was a problem with this client, if so, we are no longer
+                // interested in providing it with data
+                if (streamAndFilter.wantTerminateClient()) {
+                    removeStream(streamAndFilter.getStream());
+                } else {
+                    if (streamAndFilter.getFilter().matchesFilter(string)) {
+                        streamAndFilter.put(string);
+                    }
                 }
             }
         }
@@ -997,11 +1001,13 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
                     OutputStream stream = streams.next();
                     StreamAndFilter streamAndFilter = streamsMap.get(stream);
 
-                    // If client had a write issue, we are no longer interested in it.
-                    if(streamAndFilter.wantTerminateClient()) {
-                        removeStream(streamAndFilter.getStream());
-                    } else {
-                        streamAndFilter.put(NL);;
+                    if(streamAndFilter != null) {
+                        // If client had a write issue, we are no longer interested in it.
+                        if(streamAndFilter.wantTerminateClient()) {
+                            removeStream(streamAndFilter.getStream());
+                        } else {
+                            streamAndFilter.put(NL);;
+                        }
                     }
                 }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
@@ -152,6 +152,17 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
         }
 
         public void setTerminateClient() {
+            // if terminateClient is false, this means he caller is asking us
+            // to stop because they're done.  (eg. removeClient() being called)
+            // If there's data pending, we want to wait a big for it to drain.
+            if(terminateClient == false && outputQueue.isEmpty() == false) {
+                // wait for the thread to pick it up
+                try {
+                    Thread.sleep(QUEUE_WAIT_TIME_MS);
+                } catch(Exception e) {
+                    // Do nothing - If this happens, the client is dead already.
+                }
+            }
             terminateClient = true;
         }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -86,6 +86,7 @@ import edu.csus.ecs.pc2.services.eventFeed.WebServer;
 public class SubmissionService implements Feature {
     // How long to wait for the submission to be entered into the system before returning error
     private long WAIT_SUBMISSION_TIMEOUT_SECS = 20;
+    private static final int MAX_RUNFILE_RETRIES = 3;
 
     private IInternalContest model;
 
@@ -309,10 +310,11 @@ public class SubmissionService implements Feature {
                             + submissionId + " from local model", e2);
                 }
 
-                //if runFiles is still null we failed to get the runfiles from the local model
-                if (runFiles == null) {
+                // We try to fetch the runfiles a few times
+                for(int nTry = 1; runFiles == null && nTry <= MAX_RUNFILE_RETRIES; nTry++) {
+                    // we failed to get the runfiles from the local model
                     // try getting the submission from the server
-                    controller.getLog().log(Log.INFO, "No runfiles for submission " + submission.getNumber() + " found locally; requesting Submission from server");
+                    controller.getLog().log(Log.INFO, "No runfiles for submission " + submission.getNumber() + " found locally; requesting Submission from server - Try " + nTry);
 
                     try {
                         controller.fetchRun(submission);  //note: requires having "Fetch_Run" permission for the Feeder account...
@@ -332,57 +334,54 @@ public class SubmissionService implements Feature {
                         }
                         waitedMS += 100;
                     }
-                } else {
-                    // if we have the runFiles already, bypass fetching the run and waiting on the server
-                    serverReplied = true;
-                }
-                if (serverReplied) {
-
-                    controller.getLog().log(Log.INFO, "Got a reply from the server...");
+                    if (serverReplied) {
+                        controller.getLog().log(Log.INFO, "Got a reply from the server...");
+                    }
+                    // see if the runfiles showed up
                     try {
                         runFiles = model.getRunFiles(submission);
                     } catch (ClassNotFoundException | IOException | FileSecurityException e1) {
                         controller.getLog().throwing("SubmissionService", "getSubmissionFiles", e1);
                     }
-                    if (runFiles != null) {
-                        controller.getLog().log(Log.INFO, "Returning runFiles: " + runFiles.toString());
+                }
+                if (runFiles != null) {
+                    controller.getLog().log(Log.INFO, "Returning runFiles: " + runFiles.toString());
 
-                        SerializedFile mainFile = runFiles.getMainFile();
-                        SerializedFile[] otherFiles = runFiles.getOtherFiles();
-                        java.nio.file.Path tmpDir = null;
-                        try {
-                            tmpDir = Files.createTempDirectory("subService");
-                            // dump mainFile and otherFiles to tmpDir
-                            HashMap<Integer, String> filesToWrite = new HashMap<Integer, String>();
-                            if (mainFile != null) {
-                                filesToWrite.put(Integer.valueOf(0), mainFile.getName());
-                                mainFile.buffer2file(mainFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + mainFile.getName());
-                            }
-                            if (otherFiles != null) {
-                                for (int j = 0; j < otherFiles.length; j++) {
-                                    SerializedFile serializedFile = otherFiles[j];
-                                    filesToWrite.put(Integer.valueOf(j + 1), serializedFile.getName());
-                                    serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
-                                }
-                            }
-                            String zipFileName = tmpDir.toAbsolutePath().toString() + File.pathSeparator + "files.zip";
-                            createZip(submission, tmpDir, filesToWrite, zipFileName);
-                            // set file (and path) to be download
-                            File file = new File(zipFileName);
-                            ResponseBuilder responseBuilder = Response.ok(file);
-                            responseBuilder.header("Content-Disposition", "attachment; filename=\"files.zip\"");
-                            return responseBuilder.build();
-                        } catch (IOException e) {
-                            controller.getLog().throwing("SubmissionService", "getSubmissionFiles", e);
-                        } finally {
-                            if (tmpDir != null) {
-                                deleteDir(tmpDir);
+                    SerializedFile mainFile = runFiles.getMainFile();
+                    SerializedFile[] otherFiles = runFiles.getOtherFiles();
+                    java.nio.file.Path tmpDir = null;
+                    try {
+                        tmpDir = Files.createTempDirectory("subService");
+                        // dump mainFile and otherFiles to tmpDir
+                        HashMap<Integer, String> filesToWrite = new HashMap<Integer, String>();
+                        if (mainFile != null) {
+                            filesToWrite.put(Integer.valueOf(0), mainFile.getName());
+                            mainFile.buffer2file(mainFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + mainFile.getName());
+                        }
+                        if (otherFiles != null) {
+                            for (int j = 0; j < otherFiles.length; j++) {
+                                SerializedFile serializedFile = otherFiles[j];
+                                filesToWrite.put(Integer.valueOf(j + 1), serializedFile.getName());
+                                serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
                             }
                         }
-                    } else {
-                        controller.getLog().log(Log.INFO, "Returned runFiles was null; returning 'NOT_FOUND'");
-                        return Response.status(Status.NOT_FOUND).build();
+                        String zipFileName = tmpDir.toAbsolutePath().toString() + File.pathSeparator + "files.zip";
+                        createZip(submission, tmpDir, filesToWrite, zipFileName);
+                        // set file (and path) to be download
+                        File file = new File(zipFileName);
+                        ResponseBuilder responseBuilder = Response.ok(file);
+                        responseBuilder.header("Content-Disposition", "attachment; filename=\"files.zip\"");
+                        return responseBuilder.build();
+                    } catch (IOException e) {
+                        controller.getLog().throwing("SubmissionService", "getSubmissionFiles", e);
+                    } finally {
+                        if (tmpDir != null) {
+                            deleteDir(tmpDir);
+                        }
                     }
+                } else {
+                    controller.getLog().log(Log.INFO, "Returned runFiles was null; returning 'NOT_FOUND'");
+                    return Response.status(Status.NOT_FOUND).build();
                 }
             }
         }

--- a/test/edu/csus/ecs/pc2/services/web/EventFeedStreamerTest.java
+++ b/test/edu/csus/ecs/pc2/services/web/EventFeedStreamerTest.java
@@ -232,7 +232,8 @@ public class EventFeedStreamerTest extends AbstractTestCase {
 
         assertNotNull(json);
 
-        assertTrue("Expected long json ",  json.length() > 8000);
+        int len = json.length();
+        assertTrue("Expected long json at least 8000 bytes (got:" + len + ")",  json.length() > 8000);
 
         // Note that collections are in effect, so only 1 clarification collection
         assertCountEvent(1, EventFeedJSON.CLARIFICATIONS_KEY, json);


### PR DESCRIPTION
### Description of what the PR does
This will prevent one bad client from clogging up the `EventFeedStreamer`.
Also write new event to log FIRST so we don't get duplicate events in the event that PC2 is stopped while sending to clients.
Retry submission fetching.

### Issue which the PR addresses
Fixes #1077 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. This bug fix is very hard to test.
2. You need a full contest.
3. You need playback data for the contest (via feeder1)
4. You need to start up a 2023-06 API server (via feeder2)
5. You need to start several shadows to the primary (3 shadows should do)
6. You need to start 2 CDS's to the primary.
7. You then have to "jam -up" one or more of the shadows/CDS's by blocking their firewall or unplugging their network cable.  This will cause the connection to hang on the PC2 Event Feeder side.
8. PC2 should recover from these type of connected client failures.
