### PR TITLE
i_1080 Use Finalize tab settings for awards endpoint

### DIFF
--- a/src/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilities.java
@@ -242,13 +242,13 @@ public class CLICSAwardUtilities {
         int lastRankSilver = 8;
         int lastRankBronze = 12;
 
+        // TODO: If no finalizeData, we should do what ResultsFile.GenDefaultFinalizeData() does,
+        // in fact, that should be a Utility method someplace that creats a "default" FinalizeData.
         FinalizeData finalizeData = contest.getFinalizeData();
         if (finalizeData != null) {
-            if (finalizeData.isCertified()) {
-                lastRankGolds = finalizeData.getGoldRank();
-                lastRankSilver = finalizeData.getSilverRank();
-                lastRankBronze = finalizeData.getBronzeRank();
-            }
+            lastRankGolds = finalizeData.getGoldRank();
+            lastRankSilver = finalizeData.getSilverRank();
+            lastRankBronze = finalizeData.getBronzeRank();
         }
 
 

--- a/test/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/clics/CLICSAwardUtilitiesTest.java
@@ -436,7 +436,7 @@ public class CLICSAwardUtilitiesTest extends AbstractTestCase {
 
         assertTeamCount(awards, CLICSAwardUtilities.ID_GOLD_MEDAL, 4);
         assertTeamCount(awards, CLICSAwardUtilities.ID_SILVER_MEDAL, 4);
-        assertTeamCount(awards, CLICSAwardUtilities.ID_BRONZE_MEDAL, 11);
+        assertTeamCount(awards, CLICSAwardUtilities.ID_BRONZE_MEDAL, 13);
 
         assertEquals("Awards expected ", 7, awards.size());
     }
@@ -451,8 +451,8 @@ public class CLICSAwardUtilitiesTest extends AbstractTestCase {
     protected FinalizeData createFinalizeData(int numberGolds, int numberSilvers, int numberBronzes) {
         FinalizeData data = new FinalizeData();
         data.setGoldRank(numberGolds);
-        data.setSilverRank(numberSilvers);
-        data.setBronzeRank(numberBronzes);
+        data.setSilverRank(numberSilvers+numberGolds);
+        data.setBronzeRank(numberBronzes+numberSilvers+numberGolds);
         data.setComment("Finalized by Director of Operations, no, really!");
         return data;
     }


### PR DESCRIPTION
### Description of what the PR does
If the contest is not finalized, the default values used for the `awards `endpoint are always the World Finals defaults: namely, 4 gold, 4 silver, 4 bronze with "_Bill_" Honors rankings.    This is inappropriate for regionals.  

### Issue which the PR addresses
Fixes #1080 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11/Ubuntu 24.04
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Start a contest that has many runs, but is not yet finalized.  
2. Create a feeder account, if one doesn't exist.
3. Log in to the feeder account and start the feeding the _2023-06 CLICS_ API.
4. Start an administrator client
5. Go to the **Run Contest**->**Finalize** tab
6. Change the medal counts to 1, 2 and 3, and uncheck the "**Use World Finals group rankings for results**" check box.
7. Press the **Update** button
8. Hit the `awards `endpoint, eg: [Local Awards Endpoint](https://admin:admin@localhost:50443/contests/SumH/awards)
9. Note that the medals show 1G/2S/3B, and there are no "**Highest Honors**", "**High Honors**" and "**Honors**" categories.  The settings used for the `awards `endpoint were obtained from the `Finalize `tab settings.
