### PR TITLE
i_1079 Fix team_id property on accounts endpoint

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSAccount.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSAccount.java
@@ -78,7 +78,7 @@ public class CLICSAccount {
             type = "admin";
         } else if(cid.getClientType() == Type.TEAM) {
             type = "team";
-            team_id = username;
+            team_id = Integer.valueOf(cid.getClientNumber()).toString();
         } else if(cid.getClientType() == Type.JUDGE) {
             type = "judge";
         } else {


### PR DESCRIPTION
### Description of what the PR does
If an account is a team, the "`team_id`" property should be the `id` of the team, not the account name.  That is, it should match the "`id`" field of the corresponding "`teams`" endpoint.


### Issue which the PR addresses
Fixes #1079 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
WIndows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Bring up a contest.
2. Start an event feeder.
3. Start the feeder feeding the _2023-06 CLICS_ api.
4. From an administrator account, query the "`accounts`" endpoint from the CLICS feed.
5. Check that the `team_id `property only contains the team number, and not the full team name.

Right:

```
{
"id": "team7",
"username": "team7",
"password": "team7",
"name": "Columbia University",
"type": "team",
"team_id": "7"
}

```

Wrong:
```
{
"id": "team7",
"username": "team7",
"password": "team7",
"name": "Columbia University",
"type": "team",
"team_id": "team7"
}
```
