### PR TITLE
i_1084 Implement CLICS commentary endpoint

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSCommentary.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSCommentary.java
@@ -1,0 +1,209 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.clics.API202306;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.log.StaticLog;
+import edu.csus.ecs.pc2.core.model.ContestInformation;
+import edu.csus.ecs.pc2.core.model.ContestTime;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.util.DateDifferizer;
+import edu.csus.ecs.pc2.core.util.DateDifferizer.DateFormat;
+import edu.csus.ecs.pc2.services.core.JSONUtilities;
+
+/**
+ * Contains information about a commentary entry.
+ * This corresponds to the object returned by the CLICS commentary endpoint.
+ *
+ * @author John Buck
+ *
+ */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+//@JsonFilter("rtFilter")
+public class CLICSCommentary {
+
+    @JsonProperty
+    private String id;
+
+    @JsonProperty
+    private String time;
+
+    @JsonProperty
+    private String contest_time;
+
+    @JsonProperty
+    private String entry_point;
+
+    @JsonProperty
+    private String message;
+
+    @JsonProperty
+    private String [] tags;
+
+    @JsonProperty
+    private String source_id;
+
+    @JsonProperty
+    private String [] team_ids;
+
+    @JsonProperty
+    private String [] problem_ids;
+
+    @JsonProperty
+    private String [] submission_ids;
+
+    public CLICSCommentary() {
+        // For Jackson deserialize
+    }
+
+    /**
+     * Fill in API commentary information properties (for commentary endpoint)
+     *
+     * @param model The contest
+     * @param id
+     * @param message the comment
+     * @param tags
+     */
+    public CLICSCommentary(IInternalContest model, int id, String message, String [] tags) {
+        this.id = Integer.valueOf(id).toString();
+        this.message = message;
+        this.tags = tags;
+        setTimes(model);
+    }
+
+    public void setTimes(IInternalContest model) {
+        ContestInformation ci = model.getContestInformation();
+        ContestTime ct = model.getContestTime();
+        if (ct.isContestStarted()) {
+            contest_time = ContestTime.formatTimeMS(ct.getElapsedMS());
+        } else {
+            contest_time = getScheduledTimeClockText(ci);
+        }
+        time = Utilities.getIso8601formatterWithMS().format(GregorianCalendar.getInstance().getTime());
+    }
+
+    /**
+     * Get set of properties for which we do not want to serialize into JSON.
+     * This is so we don't serialize width/height if they are 0
+     *
+     * @param exceptProps Set to fill in with property names to omit
+     */
+    public void getExceptProps(Set<String> exceptProps) {
+//        if(files != null && files[0] != null) {
+//            files[0].getExceptProps(exceptProps);
+//        }
+    }
+
+    public String toJSON() {
+        Set<String> exceptProps = new HashSet<String>();
+
+        getExceptProps(exceptProps);
+        try {
+            ObjectMapper mapper = JSONUtilities.getObjectMapper();
+            // for this file, create filter to omit unused properties (height/width in this case)
+            SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.serializeAllExcept(exceptProps);
+            FilterProvider fp = new SimpleFilterProvider().addFilter("rtFilter", filter).setFailOnUnknownId(false);
+           mapper.setFilters(fp);
+            return mapper.writeValueAsString(this);
+        } catch (Exception e) {
+            return "Error creating JSON for commentary " + e.getMessage();
+        }
+    }
+
+    /**
+     * Create CLICSCommentary object
+     *
+     * @param json string to deserialize
+     * @return new CLICSSubmission object
+     */
+    public static CLICSCommentary fromJSON(String json) {
+        Log log = StaticLog.getLog();
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return(mapper.readValue(json, CLICSCommentary.class));
+            // deserialize exceptions
+        } catch (Exception e) {
+            log.log(Log.WARNING, "could not deserialize commentary string " + json, e);
+        }
+        return(null);
+    }
+
+    private String getScheduledTimeClockText(ContestInformation ci) {
+        GregorianCalendar startTime = ci.getScheduledStartTime();
+        String text;
+
+        // If we have a start time, figure out how long to start
+        if(startTime != null) {
+            Date now = GregorianCalendar.getInstance().getTime();
+            DateDifferizer differizer = new DateDifferizer(now, startTime.getTime());
+            differizer.setFormat(DateFormat.COUNT_DOWN);
+            text = differizer.toString();
+        } else {
+            // no start time, just use beginning of contest.
+            text = "00:00:00";
+        }
+        return text;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getContest_time() {
+        return contest_time;
+    }
+
+    public void setContest_time(String contest_time) {
+        this.contest_time = contest_time;
+    }
+
+    public void setTags(String [] tags) {
+        this.tags = tags;
+    }
+
+    public String [] getTags() {
+        return tags;
+    }
+
+    public void setSource_id(String id) {
+        source_id = id;
+    }
+
+    public String getSource_id() {
+        return source_id;
+    }
+}

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestAccess.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestAccess.java
@@ -33,6 +33,8 @@ public class CLICSContestAccess {
     public static final String API_CAPABILITY_PROXY_CLAR = "proxy_clar";
     public static final String API_CAPABILITY_ADMIN_SUBMIT = "admin_submit";
     public static final String API_CAPABILITY_ADMIN_CLAR = "admin_clar";
+    // Draft CLICS Spec 2025-XX addition
+    public static final String API_CAPABILITY_COMMENTARY_SUBMIT = "post_comment";
     // tentative - not official, but mentioned in the spec
     public static final String API_CAPABILITY_AWARDS_UPDATE = "awards_update";
 
@@ -87,6 +89,9 @@ public class CLICSContestAccess {
         }
         if(AwardService.isAwardsUpdateAllowed(sc)) {
             cap.add(API_CAPABILITY_AWARDS_UPDATE);
+        }
+        if(CommentaryService.isSubmitCommentaryAllowed(sc)) {
+            cap.add(API_CAPABILITY_COMMENTARY_SUBMIT);
         }
         capabilities = cap.toArray(new String[0]);
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/CommentaryEntries.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CommentaryEntries.java
@@ -1,0 +1,129 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.clics.API202306;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+
+import edu.csus.ecs.pc2.core.Utilities;
+import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+
+/**
+ * This class contains support routines for the CLICS commentary endpoint.
+ *
+ * This class is meant to be temporary to save and read commentary entries in a flat
+ * file as ndjson records.  Later, a model will be created to fully implement commentary in PC2.
+ * It is being done this way intially to avoid impact to the rest of the system and to keep this
+ * functionality isolated (insulated?) from the rest of the system, for now.
+ * This class was modeled after the EventFeedLog.java class, since it does many of the same things.
+ * The "flat" ndjson file is stored in the "logs/" folder (like the EventFeed log), and has the name:
+ * logs/Commentary_2023_06_SumH.ndjson  (SumH is the contestId).  Here's an example (each is on a single line
+ * but have been broken here for clarity):
+ *
+ * {"id":"1","time":"2025-04-29T10:27:10.837-04","contest_time":"02:00:05.170",
+ *     "message":"Here is a comment about team 7","tags":["submission","accepted","submission-bronze-medal"],
+ *     "source_id":"admin"}<NL>
+ * {"id":"2","time":"2025-04-29T10:27:24.201-04","contest_time":"02:00:05.170",
+ *     "message":"Yet another comment. Should be ID 2","tags":["submission","accepted","submission-bronze-medal"],
+ *     "source_id":"admin"}<NL>
+ * {"id":"3","time":"2025-04-29T10:27:27.112-04","contest_time":"02:00:05.170",
+ *     "message":"Yet another comment. Should be ID 3","tags":["submission","accepted","submission-bronze-medal"],
+ *     "source_id":"admin"}<NL>
+ * {"id":"4","time":"2025-04-29T11:16:58.493-04","contest_time":"02:00:05.170",
+ *     "message":"This comment has it all.","tags":["submission","accepted","submission-bronze-medal"],
+ *     "source_id":"admin","team_ids":["10","25","3"],"problem_ids":["B-hollow-rectangles-QQZIXK"],
+ *     "submission_ids":["1857","2232"]}<NL>
+ *
+ * @author John Buck, PC^2 Team, pc2@ecs.csus.edu
+ */
+public class CommentaryEntries {
+
+    private String[] fileLines = new String[0];
+
+    private OutputStreamWriter outStream;
+
+    private static String logsDirectory = Log.LOG_DIRECTORY_NAME;
+
+    private String commentaryFileName = null;
+
+    private String filename;
+
+    private long oldFileSize;
+
+    /**
+     * Load all commentary from the ndjson flat file
+     *
+     * @param contest
+     * @throws FileNotFoundException
+     * @throws UnsupportedEncodingException
+     */
+    public CommentaryEntries(IInternalContest contest) throws FileNotFoundException, UnsupportedEncodingException {
+
+        filename = getCommentaryFileName(contest);
+        setCommentaryFileName(filename);
+
+        // Read any existing commentary
+        readCommentary();
+
+        // open commentary file for write/append
+        outStream = new OutputStreamWriter(new FileOutputStream(filename, true), "UTF8");
+    }
+
+    private void readCommentary() {
+        try {
+            fileLines = Utilities.loadFile(filename);
+            oldFileSize = new File(filename).length();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String getCommentaryFileName(IInternalContest contest) {
+        return logsDirectory + File.separator + "Commentary_2023_06_" + contest.getContestIdentifier() + ".ndjson";
+    }
+
+    public String[] getCommentaryLines() {
+        synchronized (filename) {
+            long newFileSize = new File(filename).length();
+            // only need to re-read commentary if the file size changed
+            if (newFileSize != oldFileSize) {
+                // this will also update oldFileSize
+                readCommentary();
+            }
+        }
+        return fileLines;
+    }
+
+    /**
+     * Append new ndjson comment to commentary file.
+     *
+     * @param commentaryJsonString
+     * @throws IOException
+     */
+    public void writeCommentary(String commentaryJsonString) throws IOException {
+        outStream.write(commentaryJsonString);
+        outStream.flush();
+    }
+
+    public static void setLogsDirectory(String logsDirectory) {
+        CommentaryEntries.logsDirectory = logsDirectory;
+    }
+
+    void setCommentaryFileName(String logFileName) {
+        this.commentaryFileName = logFileName;
+    }
+
+    public String getCommentaryFileName() {
+        return commentaryFileName;
+    }
+
+    public void close() throws IOException {
+        outStream.flush();
+        outStream.close();
+    }
+
+}

--- a/src/edu/csus/ecs/pc2/clics/API202306/CommentaryService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CommentaryService.java
@@ -1,0 +1,263 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.clics.API202306;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.StringUtilities;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.services.core.JSONUtilities;
+import edu.csus.ecs.pc2.services.eventFeed.WebServer;
+
+/**
+ * WebService to handle clarifications.
+ *
+ * @author John Buck
+ *
+ */
+@Path("/contests/{contestId}/commentary")
+@Produces(MediaType.APPLICATION_JSON)
+@Provider
+@Singleton
+public class CommentaryService implements Feature {
+
+    private ArrayList<CLICSCommentary> allCommentary = new ArrayList<CLICSCommentary>();
+    private CommentaryEntries commentaryEntries;
+
+    private IInternalContest model;
+
+    private IInternalController controller;
+
+    public CommentaryService(IInternalContest inContest, IInternalController inController) {
+        super();
+        this.model = inContest;
+        this.controller = inController;
+        try {
+            CLICSCommentary comment;
+            commentaryEntries = new CommentaryEntries(model);
+            for(String ndjsonLine : commentaryEntries.getCommentaryLines()) {
+                comment = CLICSCommentary.fromJSON(ndjsonLine);
+                if(comment != null) {
+                    allCommentary.add(comment);
+                }
+            }
+        } catch(FileNotFoundException e) {
+            controller.getLog().info("No commentary file found - one will be created");
+        } catch(Exception e) {
+            controller.getLog().warning("Can not load commentary file " + e);
+        }
+    }
+
+    /**
+     * Read flat file commentary entries and convert the NDJSON to a CLICS object.
+     */
+    private void restoreCommentary() {
+
+    }
+
+    /**
+     * This method returns a representation of the current contest commentary in JSON format
+     * The returned value is a JSON array with one commentary description per array element, complying with 2023-06
+     *
+     * @param sc security info for the user making the request
+     * @param contestId Contest for which info is requested
+     * @return a {@link Response} object containing the clarifications in JSON form
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getCommentary(@Context SecurityContext sc, @PathParam("contestId") String contestId) {
+
+        // check contest id
+        if(contestId.equals(model.getContestIdentifier()) == false) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        // only admin, judge, analyst can get commentary.
+        if(!isSubmitCommentaryAllowed(sc)){
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        try {
+            ObjectMapper mapper = JSONUtilities.getObjectMapper();
+            String json = mapper.writeValueAsString(allCommentary);
+            return Response.ok(json, MediaType.APPLICATION_JSON).build();
+        } catch (Exception e) {
+            return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Error creating JSON for commentary " + e.getMessage()).build();
+        }
+    }
+
+
+    /**
+     * This method returns a representation of the current contest commentary requested in JSON format. The returned value is a single commentary item in json, Complying with 2023-06
+     *
+     * @param sc security info for the user making the request
+     * @param contestId Contest for which info is requested
+     * @param commentaryId the id of the desired clarification
+     * @return a {@link Response} object containing the clarification in JSON form
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{commentaryId}/")
+    public Response getCommentary(@Context SecurityContext sc, @PathParam("contestId") String contestId, @PathParam("commentaryId") String commentaryId) {
+
+        // check contest id
+        if(contestId.equals(model.getContestIdentifier()) == false) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        // only admin, judge, analyst can get commentary.
+        if(!isSubmitCommentaryAllowed(sc)){
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+
+        // Find the commentary to send back
+        for (CLICSCommentary commentary : allCommentary) {
+            if(commentary.getId().equals(commentaryId)) {
+                try {
+                    ObjectMapper mapper = JSONUtilities.getObjectMapper();
+                    String json = mapper.writeValueAsString(commentary);
+                    return Response.ok(json, MediaType.APPLICATION_JSON).build();
+                } catch (Exception e) {
+                    return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Error creating JSON for commentary " + commentaryId + " " + e.getMessage()).build();
+                }
+            }
+        }
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    /**
+     * Post a new commentary item.  (Really, from the Draft 2025-XX spec)
+     *
+     * @param servletRequest details of request
+     * @param sc requesting user's authorization info
+     * @param uriInfo requested uri
+     * @param contestId The contest
+     * @param jsonInputString commentary information.
+     * @return Web Response for the commentary, including the (new) id
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public synchronized Response addNewCommentary(@Context HttpServletRequest servletRequest, @Context SecurityContext sc, @Context UriInfo uriInfo, @PathParam("contestId") String contestId, String jsonInputString) {
+
+        // check contest id
+        if(contestId.equals(model.getContestIdentifier()) == false) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        // only admin, judge, analyst can get commentary.
+        if(!isSubmitCommentaryAllowed(sc)){
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+
+        // check for empty request
+        if (jsonInputString == null || jsonInputString.length() == 0) {
+            // return HTTP 400 response code per CLICS spec
+            return Response.status(Status.BAD_REQUEST).entity("empty json").build();
+        }
+
+        CLICSCommentary commentary = CLICSCommentary.fromJSON(jsonInputString);
+        if(commentary == null) {
+            // return HTTP 400 response code per CLICS spec
+            return Response.status(Status.BAD_REQUEST).entity("invalid json supplied").build();
+        }
+
+        // All these properties are determined by the CCS, so the user can not specify them.
+        if(commentary.getId() != null) {
+            // return HTTP 400 response - can't specify ID
+            return Response.status(Status.BAD_REQUEST).entity("may not include id property").build();
+        }
+        if(commentary.getTime() != null) {
+            // return HTTP 400 response - can't specify contest time
+            return Response.status(Status.BAD_REQUEST).entity("may not include time property").build();
+        }
+        if(commentary.getContest_time() != null) {
+            // return HTTP 400 response - can't specify time
+            return Response.status(Status.BAD_REQUEST).entity("may not include contest_time property").build();
+        }
+        if(commentary.getSource_id() != null) {
+            // return HTTP 400 response - can't specify source_id
+            return Response.status(Status.BAD_REQUEST).entity("may not include contest_time property").build();
+        }
+        if(StringUtilities.isEmpty(commentary.getMessage())) {
+            return Response.status(Status.BAD_REQUEST).entity("message must not be empty").build();
+        }
+
+        commentary.setSource_id(sc.getUserPrincipal().getName());
+
+        allCommentary.add(commentary);
+        commentary.setId("" + allCommentary.size());
+        commentary.setTimes(model);
+
+        try {
+            // we must generate a "Location" header in the 201 (Created) response which is the
+            // uri to the newly created comment.  This is the path of the original post
+            // request with the new comment Id tacked on as a new component:
+            // eg. https://localhost:50443/contests/SumH/commentary/5
+            // In addition, we have to return the newly created object as well (entity below)
+            UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
+            uriBuilder.path(commentary.getId());
+            ObjectMapper mapper = JSONUtilities.getObjectMapper();
+            String json = mapper.writeValueAsString(commentary);
+            if(commentaryEntries != null) {
+                commentaryEntries.writeCommentary(json + JSON202306Utilities.NL);
+            }
+            return Response.created(uriBuilder.build()).entity(json).build();
+        } catch (Exception e) {
+            return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Error creating JSON for commentary " + e.getMessage()).build();
+        }
+    }
+
+    /**
+     * Tests if the supplied user context has a role to submit clarifications
+     *
+     * @param sc User's security context
+     * @return true of the user can submit clarifications
+     */
+    public static boolean isSubmitCommentaryAllowed(SecurityContext sc) {
+        return(sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) ||
+                !sc.isUserInRole(WebServer.WEBAPI_ROLE_JUDGE) ||
+                !sc.isUserInRole(WebServer.WEBAPI_ROLE_ANALYST));
+    }
+
+    /**
+     * Retrieve access information about this endpoint for the supplied user's security context
+     *
+     * @param contest The contest is included in case the inclusion of a property depends on the permissions
+     *        set for the connected client.  It is included for uniformity since this method is called as a result
+     *        of introspection, and the caller does not know what the callee may need.  Therefore, the contest is
+     *        always included, as is the SecurityContext below (for the same reason).
+     * @param sc User's security information
+     * @return CLICSEndpoint object if the user can access this endpoint's properties, null otherwise
+     */
+    public static CLICSEndpoint getEndpointProperties(IInternalContest contest, SecurityContext sc) {
+        return(new CLICSEndpoint("commentary", JSONUtilities.getJsonProperties(CLICSCommentary.class)));
+    }
+
+    @Override
+    public boolean configure(FeatureContext arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+}

--- a/src/edu/csus/ecs/pc2/clics/API202306/ResourceConfig202306.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ResourceConfig202306.java
@@ -81,6 +81,8 @@ public class ResourceConfig202306 implements ICLICSResourceConfig {
             resConfig.register(new AwardService(getContest(), getController()));
             showStartingMessage("awards web service");
             resConfig.register(new VersionService(getContest(), getController()));
+            showStartingMessage("commentary web service");
+            resConfig.register(new CommentaryService(getContest(), getController()));
             showStartingMessage("results (extension) web service");
             resConfig.register(new ResultsService(getContest(), getController()));
             showMessage("Starting / endpoint for version web service");


### PR DESCRIPTION
### Description of what the PR does
Added new cookie-cutter modules to implement the commentary endpoint.  These were mostly copied from existing modules that are similar (like clarifications). Add hook to start the new service in ResourceConfig2023-6 Add new capability for commentary submits.

TODO: create a PC^2 model for Commentary objects.  Currently Commentary objects are stored as NDJSON records in a flat file (similar to the way the EventLog is saved - very similar in fact - the code was  mostly "borrowed" from there.  The idea of using a separate flat file, which is independent from the rest of the system was to minimize potential impact on the system by adding things to the IInternalContest/InternalContest, for example.  Currently, nothing else in the PC2 system needs access to the commentary records (there is currently no GUI to add or display commentary in PC2).  Right now, commentary is viewed and added using a Web  GUI that uses the CLICS API.

### Issue which the PR addresses
Fixes #1084 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Start a contest (such as **Sumithello** or use an existing contest).
2. Start an _event feeder_ client (you may have to add a **feeder1** account)
3. Start the event feeder feeding the _2023-06 API_.
4. Using a browser (or curl), view the access endpoint to observe the commentary properties and the capability.
5. Access the "**commentary**" endpoint.  An empty list should be returned.
6. Add a new commentary item using **curl** or some other tool.  As an example:

```
curl -X POST -k \
        https://admin:admin@localhost:50443/contests/nac25smoke/commentary \
        -D - \
        -H 'Content-Type: application/json' \
        -d '{ "message":"The text of the comment goes here", "tags":["accepted","submission-bronze-medal"], "team_ids":["10","25"], "problem_ids":["B-hollow-rectangles-QQZIXK"], "submission_ids":["1857""] }'
```
You will have to change things like **team_ids**, **problem_ids** and **submission_ids** to match your contest.
The **curl** command should return status code 201 (Created) and show the response headers (`-D -`) option.  One of these headers should be "**Location**" and it should contain a Fully Qualified URI to access the new comment.
7. Now access the "commentary" endpoint again and you should see the new commentary item.