### PR TITLE
I253 add counts to team status pane

### DIFF
--- a/src/edu/csus/ecs/pc2/core/TeamStatus.java
+++ b/src/edu/csus/ecs/pc2/core/TeamStatus.java
@@ -1,0 +1,33 @@
+package edu.csus.ecs.pc2.core;
+
+/**
+ * Team contact status.
+ * 
+ * @author Douglas A. Lane <pc2@ecs.csus.edu>
+ *
+ */
+public enum TeamStatus {
+    /**
+     * Team has not logged in.
+     */
+    NO_TEAM_CONTACT,
+    /**
+     * Team has logged in only.
+     */
+    TEAM_HAS_LOGGED_IN,
+    
+    /**
+     * Team has submitted runs only.
+     */
+    TEAM_HAS_SUBMITTED_RUNS_ONLY,
+    
+    /**
+     * Team has submitted clars only.
+     */
+    TEAM_HAS_SUBMITTED_CLARS_ONLY,
+    /**
+     * Team has submitted runs and clars
+     */
+    TEAM_HAS_SUBMITTED_RUNS_AND_CLARS,
+}
+

--- a/src/edu/csus/ecs/pc2/ui/TeamStatusPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TeamStatusPane.java
@@ -11,11 +11,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
 
+import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
 
 import edu.csus.ecs.pc2.core.IInternalController;
@@ -42,8 +44,12 @@ import edu.csus.ecs.pc2.core.model.RunEvent;
 import edu.csus.ecs.pc2.core.model.Site;
 import edu.csus.ecs.pc2.core.model.SiteEvent;
 import edu.csus.ecs.pc2.core.security.Permission;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.Dimension;
 
 /**
  * Team Status Pane.
@@ -56,7 +62,7 @@ import java.awt.event.MouseEvent;
  * 
  * @author pc2@ecs.csus.edu
  * @author Doug Lane -- added Status Counts (posthumous credit)
- * @author John Clevenger -- merged Doug's code, made minor changes
+ * @author John Clevenger -- ported Doug's code, made minor changes
  */
 
 public class TeamStatusPane extends JPanePlugin {
@@ -135,6 +141,7 @@ public class TeamStatusPane extends JPanePlugin {
      * 
      */
     private boolean showSimpleStatusCounts = true;
+    private JPanel statusCountTypePanel;
     
     /**
      * This method initializes
@@ -151,7 +158,7 @@ public class TeamStatusPane extends JPanePlugin {
      */
     private void initialize() {
         this.setLayout(new BorderLayout());
-        this.setSize(new java.awt.Dimension(583, 193));
+        this.setSize(new Dimension(770, 249));
         this.add(getTeamStatusPane(), java.awt.BorderLayout.CENTER);
         this.add(getMessagePane(), java.awt.BorderLayout.NORTH);
         this.add(getButtonPane(), java.awt.BorderLayout.SOUTH);
@@ -624,6 +631,7 @@ public class TeamStatusPane extends JPanePlugin {
             buttonPane.add(getReloadButton(), null);
             buttonPane.add(getSiteComboBox(), null);
             buttonPane.add(getShowTeamsCheckBox(), null);
+            buttonPane.add(getStatusCountTypePanel());
         }
         return buttonPane;
     }
@@ -787,5 +795,49 @@ public class TeamStatusPane extends JPanePlugin {
             });
         }
         return showTeamsCheckBox;
+    }
+    
+    /**
+     * Initializes a panel containing a button group which can be used to select the type of "status counts"
+     * displayed in the Status Panel header.  If "By State" is selected, the counts for each header status
+     * are the counts of teams currently in that state (in other words, the number of teams currently rendered
+     * in that state's color).  If "Cummulative" is selected, the header counts reflect how many teams have
+     * reached, or move past, that state (for example, if a team logs in and submits a run, that team will be
+     * counted in both the "Has Logged In" count and the "Has Submitted Runs" count -- whereas with the "By State"
+     * selection the team would ONLY appear in the "Has Submitted Runs" count).
+     * 
+     * @return a Panel containing a button group for selecting the type of status count.
+     */
+    private JPanel getStatusCountTypePanel() {
+        if (statusCountTypePanel == null) {
+        	statusCountTypePanel = new JPanel();
+        	statusCountTypePanel.add(new JLabel("Show status counts: "));
+        	
+        	JRadioButton byStateButton = new JRadioButton("By State");
+        	byStateButton.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    showSimpleStatusCounts = true;
+                    repopulateGrid(true);
+                }
+        	});
+        	statusCountTypePanel.add(byStateButton);
+        	
+        	JRadioButton cummulativeButton = new JRadioButton("Cummulative");
+        	cummulativeButton.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    showSimpleStatusCounts = false;
+                    repopulateGrid(true);
+                }
+            });
+        	statusCountTypePanel.add(cummulativeButton);
+        	
+        	ButtonGroup statusButtonGroup = new ButtonGroup();
+        	statusButtonGroup.add(byStateButton);
+        	statusButtonGroup.add(cummulativeButton);
+        	byStateButton.setSelected(true);
+        }
+        return statusCountTypePanel;
     }
 }

--- a/src/edu/csus/ecs/pc2/ui/TeamStatusPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TeamStatusPane.java
@@ -4,7 +4,11 @@ package edu.csus.ecs.pc2.ui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.FlowLayout;
+import java.awt.Graphics2D;
 import java.awt.GridLayout;
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -12,13 +16,18 @@ import java.util.Map;
 import java.util.Vector;
 
 import javax.swing.ButtonGroup;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.border.LineBorder;
 
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.TeamStatus;
@@ -49,6 +58,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
 import java.awt.Dimension;
 
 /**
@@ -62,7 +72,7 @@ import java.awt.Dimension;
  * 
  * @author pc2@ecs.csus.edu
  * @author Doug Lane -- added Status Counts (posthumous credit)
- * @author John Clevenger -- ported Doug's code, made minor changes
+ * @author John Clevenger -- ported Doug's code, added buttons to select between count modes.
  */
 
 public class TeamStatusPane extends JPanePlugin {
@@ -142,6 +152,8 @@ public class TeamStatusPane extends JPanePlugin {
      */
     private boolean showSimpleStatusCounts = true;
     private JPanel statusCountTypePanel;
+
+    private JLabel statusCountWhatsThisButton;
     
     /**
      * This method initializes
@@ -811,6 +823,7 @@ public class TeamStatusPane extends JPanePlugin {
     private JPanel getStatusCountTypePanel() {
         if (statusCountTypePanel == null) {
         	statusCountTypePanel = new JPanel();
+        	statusCountTypePanel.setBorder(new LineBorder(Color.black, 1));
         	statusCountTypePanel.add(new JLabel("Show status counts: "));
         	
         	JRadioButton byStateButton = new JRadioButton("By State");
@@ -837,7 +850,61 @@ public class TeamStatusPane extends JPanePlugin {
         	statusButtonGroup.add(byStateButton);
         	statusButtonGroup.add(cummulativeButton);
         	byStateButton.setSelected(true);
+        	
+        	statusCountTypePanel.add(getStatusCountWhatsThisButton());
         }
         return statusCountTypePanel;
     }
+    
+    /**
+     * This method initializes customizeHonorsSolvedCountWhatsThisButton
+     *
+     * @return javax.swing.JLabel
+     */
+    private JLabel getStatusCountWhatsThisButton() {
+
+        if (statusCountWhatsThisButton == null) {
+            Icon questionIcon = UIManager.getIcon("OptionPane.questionIcon");
+            if (questionIcon == null || !(questionIcon instanceof ImageIcon)) {
+                // the current PLAF doesn't have an OptionPane.questionIcon that's an ImageIcon
+                statusCountWhatsThisButton = new JLabel("<What's This?>");
+                statusCountWhatsThisButton.setForeground(Color.blue);
+            } else {
+                Image image = ((ImageIcon) questionIcon).getImage();
+                statusCountWhatsThisButton = new JLabel(new ImageIcon(getScaledImage(image, 20, 20)));
+            }
+
+            statusCountWhatsThisButton.setToolTipText("What's This? (click for additional information)");
+            statusCountWhatsThisButton.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    JOptionPane.showMessageDialog(null, statusCountWhatsThisMessage, "About Status Count values", JOptionPane.INFORMATION_MESSAGE, null);
+                }
+            });
+            statusCountWhatsThisButton.setBounds(new Rectangle(620, 242, 20, 20));
+        }
+        return statusCountWhatsThisButton;
+    }
+
+    private String statusCountWhatsThisMessage = //
+            "\nThe count values (in parentheses) in the STATUS header can be configured in two modes." //
+            + "\nIf 'By State' is selected, each count represents the total number of teams in precisely that state." //
+            + "\nIf 'Cummulative' is selected, each count represents the total number of teams who are OR WERE AT SOME POINT in that state." //
+            + "\n\nFor example, if two teams login in, and then one of those teams submits a run," //
+            + "\n'By State' will show one team in the 'Has Logged In' state and one team in the 'Submitted Run(s)' state," //
+            + "\nwhereas 'Cummulative' will show that TWO teams have logged in (and one is currently in the 'Submitted Run(s)' state)." //
+            + " \n\n";
+    
+    private Image getScaledImage(Image srcImg, int w, int h) {
+        BufferedImage resizedImg = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = resizedImg.createGraphics();
+
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g2.drawImage(srcImg, 0, 0, w, h, null);
+        g2.dispose();
+
+        return resizedImg;
+    }
+
+
 }

--- a/src/edu/csus/ecs/pc2/ui/TeamStatusPane.java
+++ b/src/edu/csus/ecs/pc2/ui/TeamStatusPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -7,6 +7,8 @@ import java.awt.FlowLayout;
 import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import javax.swing.JButton;
@@ -17,6 +19,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
 import edu.csus.ecs.pc2.core.IInternalController;
+import edu.csus.ecs.pc2.core.TeamStatus;
 import edu.csus.ecs.pc2.core.list.AccountComparator;
 import edu.csus.ecs.pc2.core.list.SiteComparatorBySiteNumber;
 import edu.csus.ecs.pc2.core.log.Log;
@@ -39,6 +42,8 @@ import edu.csus.ecs.pc2.core.model.RunEvent;
 import edu.csus.ecs.pc2.core.model.Site;
 import edu.csus.ecs.pc2.core.model.SiteEvent;
 import edu.csus.ecs.pc2.core.security.Permission;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 /**
  * Team Status Pane.
@@ -50,10 +55,10 @@ import edu.csus.ecs.pc2.core.security.Permission;
  * If one hovers over a team name will display the number of clarifications and runs that the team has submitted.
  * 
  * @author pc2@ecs.csus.edu
- * @version $Id$
+ * @author Doug Lane -- added Status Counts (posthumous credit)
+ * @author John Clevenger -- merged Doug's code, made minor changes
  */
 
-// $HeadURL$
 public class TeamStatusPane extends JPanePlugin {
 
     /**
@@ -117,6 +122,20 @@ public class TeamStatusPane extends JPanePlugin {
 
     private JCheckBox showTeamsCheckBox = null;
 
+    private Map<TeamStatus, Integer> teamStatusCount = new HashMap<TeamStatus, Integer>();
+    
+    /**
+     * Use simple status counts.
+     * <br>
+     * 
+     * true - show counts based on only the team color.
+     * false - show counts based on "logical" counts.
+     * <br>
+     * See https://github.com/pc2ccs/pc2v9/pull/264 and https://github.com/pc2ccs/pc2v9/issues/253 for details.
+     * 
+     */
+    private boolean showSimpleStatusCounts = true;
+    
     /**
      * This method initializes
      * 
@@ -127,7 +146,7 @@ public class TeamStatusPane extends JPanePlugin {
     }
 
     /**
-     * This method initializes this
+     * This method initializes the Team Status Pane.
      * 
      */
     private void initialize() {
@@ -147,7 +166,7 @@ public class TeamStatusPane extends JPanePlugin {
 
     @Override
     public String getPluginTitle() {
-        return "Teams Pane";
+        return "Team Status Pane";
     }
 
     /**
@@ -235,6 +254,8 @@ public class TeamStatusPane extends JPanePlugin {
      */
     private void repopulateGrid(boolean populate) {
 
+        teamStatusCount = new HashMap<TeamStatus, Integer>();
+        
         boolean allSites = false;
 
         Site site = null;
@@ -312,6 +333,7 @@ public class TeamStatusPane extends JPanePlugin {
                 }
 
                 teamStatusColor = getStatusColor(clientId, runs, clarifications);
+                updateStatusCounters(clientId, runs, clarifications);
             }
 
             toolTipText = toolTipText + " (" + account.getDisplayName() + ")";
@@ -321,9 +343,62 @@ public class TeamStatusPane extends JPanePlugin {
             teamLabel.setToolTipText(toolTipText);
             centerPane.add(teamName, teamLabel);
         }
+        
         centerPane.repaint();
+        
+        /**
+         * Update counts for each status
+         */
+        
+        submittedClarsLabel.setText("Submitted Clar(s) (" + toInt( teamStatusCount.get(TeamStatus.TEAM_HAS_SUBMITTED_CLARS_ONLY), 0) + ")");
+        submittedRunsLabel.setText("Submitted Run(s) (" +toInt(  teamStatusCount.get(TeamStatus.TEAM_HAS_SUBMITTED_RUNS_ONLY) , 0) + ")");
+        hasLoggedInLabel.setText("Has Logged In (" + toInt( teamStatusCount.get(TeamStatus.TEAM_HAS_LOGGED_IN), 0 ) + ")");
+        nocontactLabel.setText("No Contact (" + toInt( teamStatusCount.get(TeamStatus.NO_TEAM_CONTACT), 0) + ")");
+        readyLabel.setText("READY (" + toInt( teamStatusCount.get(TeamStatus.TEAM_HAS_SUBMITTED_RUNS_AND_CLARS),0) + ")");
+        
+        getController().getLog().log(Log.INFO, "Use simple team status counts "+showSimpleStatusCounts);
     }
 
+    private int toInt(Integer integer, int defaultValue) {
+        if (integer == null) {
+            return defaultValue;
+        } else {
+            return integer.intValue();
+        }
+    }
+    
+    /**
+     * Determine status and increment the count for the status.
+     * @param clientId
+     * @param runs an array of runs submitted by the specified client
+     * @param clarifications an array of clarifications submitted by the specified client
+     */
+    private void updateStatusCounters(ClientId clientId, Run[] runs, Clarification[] clarifications) {
+
+        if (runs.length > 0 && clarifications.length > 0) {
+            incrementStatusCount(TeamStatus.TEAM_HAS_SUBMITTED_RUNS_AND_CLARS);
+            if (! showSimpleStatusCounts) {
+                incrementStatusCount(TeamStatus.TEAM_HAS_LOGGED_IN);
+                incrementStatusCount(TeamStatus.TEAM_HAS_SUBMITTED_RUNS_ONLY);
+                incrementStatusCount(TeamStatus.TEAM_HAS_SUBMITTED_CLARS_ONLY);
+            }
+        } else if (runs.length > 0) {
+            incrementStatusCount(TeamStatus.TEAM_HAS_SUBMITTED_RUNS_ONLY);
+            if (! showSimpleStatusCounts) {
+                incrementStatusCount(TeamStatus.TEAM_HAS_LOGGED_IN);
+            }
+        } else if (clarifications.length > 0) {
+            incrementStatusCount(TeamStatus.TEAM_HAS_SUBMITTED_CLARS_ONLY);
+            if (! showSimpleStatusCounts) {
+                incrementStatusCount(TeamStatus.TEAM_HAS_LOGGED_IN);
+            }
+        } else if (hasLoggedIn(clientId)) {
+            incrementStatusCount(TeamStatus.TEAM_HAS_LOGGED_IN);
+        } else {
+            incrementStatusCount(TeamStatus.NO_TEAM_CONTACT);
+        }
+    }
+    
     private Color getStatusColor(ClientId clientId, Run[] runs, Clarification[] clarifications) {
         Color outColor = NO_CONTACT_COLOR;
 
@@ -338,6 +413,20 @@ public class TeamStatusPane extends JPanePlugin {
         }
 
         return outColor;
+    }
+
+    private void incrementStatusCount(TeamStatus teamStatus) {
+        
+        Integer value = teamStatusCount.get(teamStatus);
+        if (value == null) {
+            
+            value = 0;
+        }
+        
+        value++;
+        
+        teamStatusCount.put(teamStatus,value);
+        
     }
 
     /**
@@ -615,6 +704,14 @@ public class TeamStatusPane extends JPanePlugin {
             nocontactLabel.setText("No Contact");
             nocontactLabel.setFont(new java.awt.Font("Dialog", java.awt.Font.BOLD, 14));
             stateDescriptonPane = new JPanel();
+            stateDescriptonPane.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    if (e.getClickCount() > 0 && e.isControlDown()) {
+                        switchTeamStatusCounters();
+                    }
+                }
+            });
             stateDescriptonPane.setLayout(flowLayout);
             stateDescriptonPane.add(nocontactLabel, null);
             stateDescriptonPane.add(hasLoggedInLabel, null);
@@ -623,6 +720,17 @@ public class TeamStatusPane extends JPanePlugin {
             stateDescriptonPane.add(readyLabel, null);
         }
         return stateDescriptonPane;
+    }
+
+    protected void switchTeamStatusCounters() {
+        
+        /**
+         * Change state and repopulate status counts.
+         */
+        showSimpleStatusCounts = ! showSimpleStatusCounts;
+        populateGUI();
+
+        
     }
 
     /**
@@ -669,7 +777,7 @@ public class TeamStatusPane extends JPanePlugin {
     private JCheckBox getShowTeamsCheckBox() {
         if (showTeamsCheckBox == null) {
             showTeamsCheckBox = new JCheckBox();
-            showTeamsCheckBox.setText("Show enabled teams");
+            showTeamsCheckBox.setText("Show only scoreboard teams");
             showTeamsCheckBox.setToolTipText("Show only teams who can login and are on the scoreboard");
             showTeamsCheckBox.setSelected(true);
             showTeamsCheckBox.addActionListener(new java.awt.event.ActionListener() {
@@ -680,4 +788,4 @@ public class TeamStatusPane extends JPanePlugin {
         }
         return showTeamsCheckBox;
     }
-} // @jve:decl-index=0:visual-constraint="10,10"
+}


### PR DESCRIPTION

### Description of what the PR does

Adds "counts" to the Team Status screen labels.  Includes a button group that allows toggling between two representations of count values:  either the raw number of teams _currently in each status category_ (essentially, a count of the number of teams of each "status color"), or a cummulative total of teams that are _or have been_ in that state.

For example, if two teams have logged in, and one of them has subsequently submitted a run, then the "raw" count display would show one team in the "Has Logged In" state and one team in the "Has Submitted Runs" state, while the "cummulative" count display would show two teams in the "Has Logged In" state and one in the "Has Submitted Runs" state.

The majority of the development (code) in this PR was done by Doug Lane (R.I.P.) and was ported from a branch in his fork (see for reference PR #264, which was closed by Doug without being merged.) The main contribution of the author of this PR (other than porting Doug's work into the current codebase) was to add GUI radio buttons which allow toggling between the two "count modes" (Doug's work already had support for a mouse CTRL-CLICK doing the same thing.)

### Issue which the PR addresses
Fixes #253 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2020-12, Java version "11.0.16.1" 2022-08-18 LTS

### Precise steps for _testing_ the PR

- Start a contest.
- Start a PC2 Admin, select the "Team Status" screen.
  - Verify that the "By Status" radio button is selected (this is the default).
  - Verify that the five labels across the top show counts (in parentheses) as follows:
    - No Contact:  the total number of teams in your contest.
    - All others:  "(0)".
  - Click the "Cummulative" button at the bottom.
  - Verify that the five labels still show the same counts.
- Login as a team.
- On the Admin Team Status screen, select the "By State" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  one less than the number of teams in your contest
  - Has Logged in:  (1)
  - All others:  (0)
- Select the "Cummulative" button; verify that the counts in the Status labels do not change.
- Login as a different team.
- On the Admin Team Status screen, select the "By State" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (2)
  - All others:  (0)
- Select the "Cummulative" button; verify that the counts in the Status labels do not change.
- Submit a Run from one of the teams.
- On the Admin Team Status screen, select the "By State" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (1)  (this is because the team that submitted a run has moved on from the "logged in" state)
  - Submitted Runs: (1)
  - All others:  (0)
- Select the "Cummulative" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (2)  ("Cummulative" shows "how many teams have logged in", not just "who's still only 'just logged in'")
  - Submitted Runs: (1)
  - All others:  (0)
- Submit a Clarification from the team that did NOT submit the run.
- On the Admin Team Status screen, select the "By State" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (0)  (this is because all teams that have logged in have moved to a new state)
  - Submitted Runs: (1)
  - Submitted Clars: (1)
  - Ready:  (0)
- Select the "Cummulative" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (2)
  - Submitted Runs: (1)
  - Submitted Clars: (1)
  - Ready:  (0)
- Submit a Clarification from the team that previously submitted a run.
- On the Admin Team Status screen, select the "By State" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (0)  (again, this is because all teams that have logged in have moved to a new state)
  - Submitted Runs: (0) (this is because the [only] team that has submitted a run has moved to a new state, "Ready")
  - Submitted Clars: (1)
  - Ready:  (1)
- Select the "Cummulative" button, then verify that the counts in the Status labels are as follows:
  - No Contact:  two less than the number of teams in your contest
  - Has Logged in:  (2)
  - Submitted Runs: (1)
  - Submitted Clars: (2)
  - Ready:  (1)

The above sequence should be sufficient to demonstrate that "By State" shows counts of teams IN EACH STATE (i.e., the counts of teams rendered in the corresponding color), while "Cummulative" shows counts of how many teams are _or ever were_ in that state.