### PR TITLE
I 764 add throttling to run submit for CLICS API pc2submits submissions

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -665,10 +665,10 @@ public class SubmissionService implements Feature {
                 }
                 // No run entered, this is really really bad
                 log.log(Level.WARNING, "No Run added after submitting CLICS API run for team " + team_id + " by " + user);
-                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("unable to add submission").build();
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Unable to add submission").build();
             } catch (Exception e) {
                 log.log(Level.WARNING, "Exception submitting CLICS API run for team " + team_id + " by " + user, e);
-                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("unable to submit run" + e.toString()).build();
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Unable to submit run: " + e.getLocalizedMessage()).build();
             }
         }
 

--- a/src/edu/csus/ecs/pc2/core/IInternalController.java
+++ b/src/edu/csus/ecs/pc2/core/IInternalController.java
@@ -854,8 +854,9 @@ public interface IInternalController {
      * @param additionalFiles
      * @param overrideTimeMS
      * @param overrideRunId
+     * @throws Exception if an error occurs while attempting to send the Run to the Server
      */
-    void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId);
+    void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) throws Exception;
 
     /**
      * Submit a run to the server for a different client with entry_point
@@ -868,8 +869,9 @@ public interface IInternalController {
      * @param additionalFiles
      * @param overrideTimeMS
      * @param overrideRunId
+     * @throws Exception if an error occurs while attempting to send the Run to the Server
      */
-    void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId);
+    void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) throws Exception;
 
 
 }

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -607,11 +607,11 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
 
         Run run = new Run(contest.getClientId(), language, problem);
 
-        //determine whether to apply the "current throttling strategy" to this submission 
+        //determine whether to apply the "current throttling strategy" to this submission
         // (i.e., whether to accept the run for submission to the PC2 Server)
         boolean accept = true;
         Account submitterAccount = contest.getAccount(contest.getClientId());
-        
+
         if (submitterAccount.isTeam()) {
             //Determine the throttling strategy to be applied to team submissions.
             //The following shows several alternative strategy selections, with only one being enabled.
@@ -625,7 +625,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
 //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest); //uses DEFAULT_MAX_SUBMISSIONS_PER_MINUTE; same as prev line
             accept = strategy.accept(run);
         }
-        
+
         Packet packet ;
         if (accept) {
             ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
@@ -4988,22 +4988,50 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
     }
 
     @Override
-    public void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) {
+    public void submitRun(ClientId submitter, Problem problem, Language language, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideRunId) throws Exception {
 
         submitRun(submitter, problem, language, null, mainSubmissionFile, additionalFiles, overrideTimeMS, overrideRunId);
     }
 
     @Override
-    public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideSubmissionId) {
+    public void submitRun(ClientId submitter, Problem problem, Language language, String entry_point, SerializedFile mainSubmissionFile, SerializedFile[] additionalFiles, long overrideTimeMS, long overrideSubmissionId) throws Exception {
 
-        ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
         Run run = new Run(submitter, language, problem);
         run.setEntryPoint(entry_point);
-        RunFiles runFiles = new RunFiles(run, mainSubmissionFile, additionalFiles);
 
-        Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideSubmissionId);
-        sendToLocalServer(packet);
+        //determine whether to apply the "current throttling strategy" to this submission
+        // (i.e., whether to accept the run for submission to the PC2 Server)
+        // Note: when shadowing, as opposed to getting submissions from the CLICS SubmissionService API
+        //       endpoint, we may have to tune the algorithm (or, in the case of MaxSubmissionsPerMinuteStrategy,
+        //       increase the # of subs/minute.  The shadow can feeds submissions very fast in normal operation
+        //       There should probably be a "bypass" flag that can be set via config file, or
+        //       a separate user created for receiving CLICS API requests.
+        boolean accept = true;
+        // use the submitter account, not this client.  This client is doing a proxy submit for a team.
+        Account submitterAccount = contest.getAccount(submitter);
 
+        if (submitterAccount.isTeam()) {
+            //Determine the throttling strategy to be applied to team submissions.
+            //The following shows several alternative strategy selections, with only one being enabled.
+            //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
+            // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
+            // GUI (such as the PC2 Admin)
+//            IThrottleStrategy strategy = new AcceptAllStrategy();
+//            IThrottleStrategy strategy = new RejectAllStrategy();
+            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 4);
+//            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+
+            accept = strategy.accept(run);
+        }
+
+        if (accept) {
+            ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
+            RunFiles runFiles = new RunFiles(run, mainSubmissionFile, additionalFiles);
+            Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideSubmissionId);
+            sendToLocalServer(packet);
+        } else {
+            throw new SubmissionRejectedException("Submission threshhold exceeded");
+        }
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -629,7 +629,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         Packet packet ;
         if (accept) {
             ClientId serverClientId = new ClientId(contest.getSiteNumber(), Type.SERVER, 0);
-            RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);            
+            RunFiles runFiles = new RunFiles(run, mainFile, otherFiles);
             packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
             sendToLocalServer(packet);
         } else {
@@ -5018,7 +5018,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             // GUI (such as the PC2 Admin)
 //            IThrottleStrategy strategy = new AcceptAllStrategy();
 //            IThrottleStrategy strategy = new RejectAllStrategy();
-            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 4);
+            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 6);
 //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
 
             accept = strategy.accept(run);

--- a/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
@@ -50,6 +50,7 @@ public class RemoteRunSubmitter {
      * @param auxFiles - other submittted files
      * @param overrideTimeMS - override submission time in MS
      * @param overrideRunId - override run id
+     * @throws Exception if run can't be submitted, eg. throttling
      */
     public void submitRun(String clientIdString, String problemID, String languageID, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) throws Exception {
         submitRun(clientIdString, problemID, languageID, null, mainFile, auxFiles, overrideTimeMS, overrideRunId);
@@ -66,7 +67,7 @@ public class RemoteRunSubmitter {
      * @param auxFiles - other submittted files
      * @param overrideTimeMS - override submission time in MS
      * @param overrideRunId - override run id
-     * @throws Exception
+     * @throws Exception if run can't be submitted, eg. throttling
      */
     public void submitRun(String clientIdString, String problemID, String languageID, String entry_point, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) throws Exception {
 

--- a/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteRunSubmitter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
 import java.security.InvalidParameterException;
@@ -16,13 +16,13 @@ import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 
 /**
- * This class is used to submit runs, obtained from a remote CCS being shadowed by this instance of PC2, 
+ * This class is used to submit runs, obtained from a remote CCS being shadowed by this instance of PC2,
  * to the local PC2 server.
- * 
+ *
  * The class is instantiated with a PC2 Controller ({@link IInternalController}) which it uses to submit
  * the run to the local server.
- * 
- * 
+ *
+ *
  * @author pc2@ecs.csus.edu
  *
  */
@@ -42,32 +42,33 @@ public class RemoteRunSubmitter {
 
     /**
      * Submit a run to the server.
-     * 
+     *
      * @param clientIdString - "teamN" client name
      * @param problemID - problem id
      * @param languageID - CLICS language id
      * @param mainFile - main file name
-     * @param auxFiles - other submittted files 
+     * @param auxFiles - other submittted files
      * @param overrideTimeMS - override submission time in MS
      * @param overrideRunId - override run id
      */
-    public void submitRun(String clientIdString, String problemID, String languageID, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) {
+    public void submitRun(String clientIdString, String problemID, String languageID, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) throws Exception {
         submitRun(clientIdString, problemID, languageID, null, mainFile, auxFiles, overrideTimeMS, overrideRunId);
     }
-    
+
     /**
      * Submit a run to the server.
-     * 
+     *
      * @param clientIdString - "teamN" client name
      * @param problemID - problem id
      * @param languageID - CLICS language id
      * @param entry_point - entry point, null if default or none
      * @param mainFile - main file name
-     * @param auxFiles - other submittted files 
+     * @param auxFiles - other submittted files
      * @param overrideTimeMS - override submission time in MS
      * @param overrideRunId - override run id
+     * @throws Exception
      */
-    public void submitRun(String clientIdString, String problemID, String languageID, String entry_point, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) {
+    public void submitRun(String clientIdString, String problemID, String languageID, String entry_point, IFile mainFile, List<IFile> auxFiles, long overrideTimeMS, long overrideRunId) throws Exception {
 
         isEmptyString(clientIdString, "ClientId parameter is null");
         isEmptyString(problemID, "Parameter problemID is null or empty");
@@ -108,7 +109,7 @@ public class RemoteRunSubmitter {
         if (language == null){
             language = getLanguageByName(contest, languageID);
         }
-        
+
 
         isEmpty(language, "Parameter languageID does not match any pc2 language: '" + languageID + "'");
 
@@ -137,8 +138,8 @@ public class RemoteRunSubmitter {
         }
         return outLang;
     }
-    
-    
+
+
     private Language getLanguageByCLICSID(IInternalContest contest2, String languageName) {
         Language outLang = null;
         Language[] languages = contest.getLanguages();
@@ -149,7 +150,7 @@ public class RemoteRunSubmitter {
         }
         return outLang;
     }
-    
+
     private Problem getProblemByName(IInternalContest contest2, String problemName) {
         Problem outProblem = null;
         Problem[] problems = contest.getProblems();
@@ -163,10 +164,10 @@ public class RemoteRunSubmitter {
 
     /**
      * Return account for input client id.
-     * 
+     *
      * Searches local site's accounts first, then all site's accounts.
      * Will prepend "team" onto client id if client id string not found.
-     * 
+     *
      * @param contest2
      * @param clientIdString
      * @return null if no account found, else the account.


### PR DESCRIPTION
### Description of what the PR does
Add throttling to submissions accepted by the CLICS API via `IInternalController.submitRun()`.  This submission path was omitted by PR #1053 and must be added.   The [NAC2025-RC4](https://github.com/johnbrvc/pc2v9/tree/NAC2025-RC4) branch from @johnbrvc, which is running the _NAC2025 Online Practice_ session already has these commits in it.  These should have been part of #1053.  

When #1053 was made, only` IInternalController.submitJudgedRun() `was updated to use throttling.  `submitRun() `should also have been updated.

### Issue which the PR addresses
Completes #764 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Window 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

Ubuntu 24.04 (contest image):
openjdk version "21.0.4" 2024-07-16
OpenJDK Runtime Environment (build 21.0.4+7-Ubuntu-1ubuntu224.04)
OpenJDK 64-Bit Server VM (build 21.0.4+7-Ubuntu-1ubuntu224.04, mixed mode, sharing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Use the same procedure as described in #1053 except instead of using the browser to make submissions using the WTI, use the command line python utility `pc2submit`. (See also #1064 on how to use pc2submit).