### PR TITLE
i1030: correct naming issues in merge of PR #1041 for i1030.

### DIFF
--- a/projects/WTI-API/src/main/controllers/ContestController.java
+++ b/projects/WTI-API/src/main/controllers/ContestController.java
@@ -491,7 +491,7 @@ public class ContestController extends MainController {
 										
 					//retrieve the relevant fields from the PC2 contest clock
 					boolean isRunning = contestClock.isContestClockRunning();
-					long contestLengthInSecs = contestClock.getContestLengthSecs();
+					long contestLengthSecs = contestClock.getContestLengthSecs();
 					long elapsedSecs = contestClock.getElapsedSecs();
 					long wallClockStartTime ;
 					//"contest start time" is a Calendar object and might be null if the contest has never been started
@@ -503,7 +503,7 @@ public class ContestController extends MainController {
 					}
 					
 					//construct a ContestClock containing the PC2 Server clock values
-					returnableContestClock = new ContestClockModel(isRunning,contestLengthInSecs, elapsedSecs, wallClockStartTime);
+					returnableContestClock = new ContestClockModel(isRunning,contestLengthSecs, elapsedSecs, wallClockStartTime);
 										
 				}
 				catch(NotLoggedInException e) {

--- a/projects/WTI-API/src/main/models/ContestClockModel.java
+++ b/projects/WTI-API/src/main/models/ContestClockModel.java
@@ -12,14 +12,14 @@ import edu.csus.ecs.pc2.core.model.ContestTime;
 public class ContestClockModel {
 
 	private boolean isRunning;
-	private long contestLengthInSecs;
+	private long contestLengthSecs;
 	private long elapsedSecs;  			//total time in seconds that the contest has been running -- does NOT include time during any "pauses" 
 	private long wallClockStartTime;	//unix timestamp when the contest actually started (msec since the Epoch),
 										// or zero if contest has not ever been started.  Does not change due to "pauses".
 	
-	public ContestClockModel(boolean isRunning, long contestLengthInSecs, long elapsedSecs, long wallClockStartTime) {
+	public ContestClockModel(boolean isRunning, long contestLengthSecs, long elapsedSecs, long wallClockStartTime) {
 			this.isRunning = isRunning;
-			this.contestLengthInSecs = contestLengthInSecs;
+			this.contestLengthSecs = contestLengthSecs;
 			this.elapsedSecs = elapsedSecs;
 			this.wallClockStartTime = wallClockStartTime;
 	}
@@ -30,8 +30,8 @@ public class ContestClockModel {
 		return isRunning;
 	}
 
-	public long getContestLengthInSecs() {
-		return contestLengthInSecs;
+	public long getContestLengthSecs() {
+		return contestLengthSecs;
 
 	}
 


### PR DESCRIPTION

### Description of what the PR does
  Fixes inconsistent variable naming between WTI-API and WTI-UI which resulted when PR #1041 was merged (or more specifically, when the conflicts with that merge were incorrectly resolved).

### Issue which the PR addresses
Fixes PR #1041; Fixes Issue #1030.  Specifically, fixes the issue that the Remaining time on the WTI client display was showing as `00:00:00` even when the contest was running with time remaining.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11; Eclipse 2021-12; java version "1.8.0_381"

### Precise steps for _testing_ the PR
- Load a contest that has a "scoreboard2" account and at least one team (e.g. "sumithello")
- Start the contest
- Start the WTI server
- Start a browser.  If you've used this browser to connect to PC2/WTI previously, clear the browser's data cache.
- Connect the browser to the WTI server (by default, `localhost:8080`).
- Verify that the "Remaining Time" displayed in the WTI header is white, and is counting down the proper remaining time.

