### PR TITLE
i1097: keep clar Submit button disabled until text AND problem selected

### DIFF
--- a/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.ts
@@ -60,7 +60,7 @@ export class NewClarificationComponent implements OnInit, OnDestroy {
 
   private buildForm(): void {
     this.newClarificationForm = this._formBuilder.group({
-      problem: [undefined, []],
+      problem: [undefined, [Validators.required]],
       content: [undefined, [Validators.required]]
     });
   }


### PR DESCRIPTION

### Description of what the PR does

  Adds `Validators.required` to the `problem` entry in the WTI `new-clarification.component`'s `buildForm()` method.  The effect of this is to keep the `Submit` button on that form disabled until both clarification text has been entered AND a problem has been selected.

  Further details:  `newClarificationForm` is defined as a `FormGroup` in `new-clarification.component.ts`.  `new-clarification.component.html` selects this formGroup, assigns method `submitNewClarification()` as the action handler for the `Submit` button, and marks the button as disabled until the form state becomes `valid`.  The `content` field in the form (the text box) was already annotated as `content: [undefined, [Validators.required]]`.  All this PR does is add that same Validation requirement to the Problem drop-down.  (In other words, the PR now keeps the `Submit` button disabled until BOTH some text has been entered AND a problem has been selected.

### Issue which the PR addresses
Fixes #1097 

Note:  the PR does not actually "fix" the error message which was being generated; what it does is eliminate the underlying cause of the error message.  The Server will still return `BAD REQUEST` if (somehow) the user figures out a way to bypass form validation (e.g. by hacking the browser's JavaScript at run time...)

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse 2021-12, java version "1.8.0_381"

### Precise steps for _testing_ the PR

- Start a PC2 server, loading a contest with at least one team and one problem (e.g. `sumithello`)
- Start the contest.
- Start a WTI Server.
- Open a browser; if you've previously used this browser to connect to PC2 then _clear the browser's data cache_.
- Connect the browser to the WTI Server
- Login as a team.
- Select "Clarifications", then "New Clarification".
- Enter some text in the text box, but do NOT select a problem.
- Verify that the "Submit" button is disabled.
- Select a problem.
- Verify that the Submit button becomes enabled.
- Submit the clar; verify that what comes back is a green "Clar Submitted" message.
