### PR TITLE
i_841 Deal with kotlin lower case source file names

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.BufferedInputStream;

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2826,6 +2826,11 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             executionData.setCompileStderr(new SerializedFile(prefixExecuteDirname(COMPILER_STDERR_FILENAME)));
 
             program = new File(prefixExecuteDirname(programName));
+            // Ugh.  Kotlin allows you to specify a lowercase source file, but munges the output to start with upper case
+            // If it's kotlin and the source starts with a lower case, create a new File for the Uppercase name
+            if(language.getID().equals(Language.CLICS_LANGID_KOTLIN) && Character.isLowerCase(programName.charAt(0))) {
+                program = new File(prefixExecuteDirname(programName.substring(0,1).toUpperCase() + programName.substring(1)));
+            }
             File programWithPackage = program;
             if (packagePath.length() > 0) {
                 // if there is a packagePath and javac was invoked with `-d .` it will place the class
@@ -3071,7 +3076,12 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 }
                 newString = replaceString(newString, "{:mainfile}", runFiles.getMainFile().getName());
                 newString = replaceString(newString, Constants.CMDSUB_FILES_VARNAME, ExecuteUtilities.getAllSubmittedFilenames(runFiles));
-                newString = replaceString(newString, Constants.CMDSUB_BASENAME_VARNAME, removeExtension(runFiles.getMainFile().getName()));
+                // Because Kotlin changes any lower case starting letter to upper case
+                String baseName = removeExtension(runFiles.getMainFile().getName());
+                if(language.getID().equals(Language.CLICS_LANGID_KOTLIN) && Character.isLowerCase(baseName.charAt(0))) {
+                    baseName = baseName.substring(0, 1).toUpperCase() + baseName.substring(1);
+                }
+                newString = replaceString(newString, Constants.CMDSUB_BASENAME_VARNAME, baseName);
             }
             newString = replaceString(newString, "{:package}", packageName);
 


### PR DESCRIPTION
### Description of what the PR does
When kotlin compiles a file that starts with a lower case letter, it produces a class file that starts with an upper case letter.  As a result, the PC2 routine to check if the compile worked failed because, for example, `testprogKt.class` != `TestprogKt.class`.   This PR checks the compile result filename for this condition, and then uses the correct name when executing the result.


### Issue which the PR addresses
Fixes #841 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Ubuntu 24.04
Build:
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)
Execute:
openjdk version "21.0.4" 2024-07-16
OpenJDK Runtime Environment (build 21.0.4+7-Ubuntu-1ubuntu224.04)
OpenJDK 64-Bit Server VM (build 21.0.4+7-Ubuntu-1ubuntu224.04, mixed mode, sharing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Make a Kotlin submission using a Kotlin source file that starts with a lower case letter.  You can use this file, and rename the extension to ".kt": [columbo_finn.txt](https://github.com/user-attachments/files/20195149/columbo_finn.txt)
The submission should be accepted and not generate a compile error.  Previously a compile error would result.
It will almost certainly generate a **WA** result for whatever problem you submit it as, but that is fine - it means the program successfully executed, but produced the wrong answer.  If you get an **RTE**, it means it probably didn't execute properly.
