### PR TITLE
i1104: change run-submission error message.

### DIFF
--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -141,7 +141,7 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	        this._teamService.runsUpdated.next();
 	    },
 	    error: (error: any) => {
-	      this._uiHelper.alertError('Error submitting problem! Check console for details');
+	      this._uiHelper.alertError('Not accepting submissions at this time');
 	        console.error(error);
 	    },
 	    complete: () => {


### PR DESCRIPTION
### Description of what the PR does

Changes the error message displayed when a run is submitted after the contest has ended.  

Note: this also changes the error message displayed if a legitimate "Bad Request" occurs _during_ the contest.  This is a temporary fix applied for running NAC 2025; the issue needs to be fully addressed later.

### Issue which the PR addresses

Partial fix for Issue #1104.     Does not actually address the documented issue; rather, this push changes the error message displayed so that it's less confusing for the user.   Still need to develop code to actually fix the underlying problem described in the Issue.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)

Windows 11, java version "11.0.16.1" 2022-08-18 LTS

### Precise steps for _testing_ the PR

Follow the instructions in Issue #1104 for "Reproducing the issue"; verify that the error message returned from submitting a run after the contest has ended is "Not accepting submissions at this time".
