### PR TITLE
i1103: display order of runs and clarifications are changed to descending order

### DIFF
--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -84,7 +84,14 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
     this._contestService.getClarifications()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((data: Clarification[]) => {
-        this.clarifications = data.sort((x: Clarification, y: Clarification) => y.time - x.time);
+        this.clarifications = data.sort((x: Clarification, y: Clarification) => 
+        {
+	      if (y.time !== x.time) {
+        	return y.time - x.time;//sort by descending order of time
+	      } else {
+	        return y.id.localeCompare(x.id); //if times are same sort by the id in descending order
+	      }
+    });
         this.filterClarifications();
       }, (error: any) => {
         console.error('error loading clarifications!');

--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
@@ -98,7 +98,14 @@ export class RunsPageComponent implements OnInit, OnDestroy {
     this._teamService.getRuns()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((data: Run[]) => {
-        this.runs = data.sort((x: Run, y: Run) => y.time - x.time);
+        this.runs = data.sort((x: Run, y: Run) => 
+        {
+	      if (y.time !== x.time) {
+        	return y.time - x.time;//sort by descending order of time
+	      } else {
+	        return y.id.localeCompare(x.id); //if times are same sort by the id in descending order
+	      }
+    });
         this.filterData();
       });
   }


### PR DESCRIPTION
### Description of what the PR does
The runs and clarifications are now in descending order by time. If the time is equal it is sorted by the id (descending).  Before if the runs or clarifications were sent at the same minute, they would be sorted in ascending order of id. 

### Issue which the PR addresses
#1103 fixes.
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows11 Eclipse, Java 1.8

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Log in as a team.
Send couple of clarifications within the same minute,
They should be ordered in descending order.
Log in as a judge and respond to these clarifications. 
They should be ordered right. 

Do the same action for runs. 
