### PR TITLE
i456: update problem i & j problem titles in tenprobs sample contest

### DIFF
--- a/samps/contests/tenprobs/config/contest.yaml
+++ b/samps/contests/tenprobs/config/contest.yaml
@@ -61,7 +61,7 @@ accounts:
 
   - account: SCOREBOARD
     site: 1
-    count: 1
+    count: 2
 
   - account: FEEDER
     site: 1

--- a/samps/contests/tenprobs/config/i/problem_statement/problem.tex
+++ b/samps/contests/tenprobs/config/i/problem_statement/problem.tex
@@ -1,1 +1,1 @@
-\problemtitle{Sumit a}
+\problemtitle{Sumit i}

--- a/samps/contests/tenprobs/config/j/problem_statement/problem.tex
+++ b/samps/contests/tenprobs/config/j/problem_statement/problem.tex
@@ -1,1 +1,1 @@
-\problemtitle{Sumit a}
+\problemtitle{Sumit j}


### PR DESCRIPTION
### Description of what the PR does
Updates the `problemtitle` entries for problems `i` and `j` in the `tenprobs` sample contest.
Also adds a Continuous Improvement (CI) step of updating the tenprobs `contest.yaml` file to generate _two_ scoreboard accounts; this makes it much more convenient to use `tenprobs` with the WTI.

### Issue which the PR addresses
Fixes #456

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, java version "11.0.16.1" 2022-08-18 LTS

### Precise steps for _testing_ the PR 
- Start a server using `--load tenprobs`.
- Start a PC2 Admin
- Verify that the last two problems have problem names "Sumit i" and "Sumit j"
- Verify that there are TWO "scoreboard" accounts generated: SB1 and SB2.


