### PR TITLE
i_1114 Put correct version of pc2sandbox_interactive.sh in repo

### DIFF
--- a/scripts/pc2sandbox_interactive.sh
+++ b/scripts/pc2sandbox_interactive.sh
@@ -604,22 +604,29 @@ do
 		REPORT_DEBUG Validator finishes with exit code $wstat
 		if test "$contestant_done" -eq 0
 		then
-			REPORT_DEBUG Waiting for submission pid $submissionpid to finish...
-			# Wait for child to finish - it has to, one way or the other (TLE or just finish)
-			wait -n "$submissionpid"
-			COMMAND_EXIT_CODE=$?
-
-			GetSandboxStats
-
-			if test $COMMAND_EXIT_CODE -eq 127
+			# Added this test 04/30/2025 - apparently it was missing.  We will only kill the submission if this
+			# flag is 1, as per the comment at the top of this script.
+			if test ${KILL_WA_VALIDATOR} -eq 0
 			then
-				REPORT_DEBUG No more children found.  Setting submission exit code to 0
-				COMMAND_EXIT_CODE=0
+				REPORT_DEBUG Waiting for submission pid $submissionpid to finish...
+				# Wait for child to finish - it has to, one way or the other (TLE or just finish)
+				wait -n "$submissionpid"
+				COMMAND_EXIT_CODE=$?
+	
+				GetSandboxStats
+	
+				if test $COMMAND_EXIT_CODE -eq 127
+				then
+					REPORT_DEBUG No more children found.  Setting submission exit code to 0
+					COMMAND_EXIT_CODE=0
+				else
+					FormatExitCode $COMMAND_EXIT_CODE
+					REPORT_DEBUG Contestant PID $submissionpid finished with exit code $result but after the validator
+				fi
+				ShowStats ${cputime} ${TIMELIMIT_US} ${walltime} ${peakmem} $((MEMLIMIT*1024*1024))
 			else
-				FormatExitCode $COMMAND_EXIT_CODE
-				REPORT_DEBUG Contestant PID $submissionpid finished with exit code $result but after the validator
+				REPORT_DEBUG Killing child submission pid $submissionpid since it is still running "(KILL_WA_VALIDATOR=1)"
 			fi
-			ShowStats ${cputime} ${TIMELIMIT_US} ${walltime} ${peakmem} $((MEMLIMIT*1024*1024))
 		fi
 
 		KillChildProcs
@@ -649,9 +656,9 @@ do
 				# If validator created a feedback file, put the last line in the judgement
 				if test -s "$feedbackfile"
 				then
-					GenXML "No - Wrong answer" `head -n 1 $feedbackfile`
+					GenXML "wrong answer" `head -n 1 $feedbackfile`
 				else
-					GenXML "No - Wrong answer" "No feedback file"
+					GenXML "wrong answer" "No feedback file"
 				fi
 				COMMAND_EXIT_CODE=0
 			fi


### PR DESCRIPTION
### Description of what the PR does
Update repo with correct version of the interactive sandbox script.  A test was missing to kill a submission if the interactive validator finishes first.  Without this fix, we would sometimes notice JE (judging errors) or other judgment mismatches when comparing with a primary or shadow.  This fixes the so-called "DOMjudge" mode of interactive problem validation.

In addition, the judgment string was changed to the CLICS compatible "wrong answer" instead of "No - Wrong answer".

### Issue which the PR addresses
Fixes #1114 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Ubuntu 24.04 (Linux systems only)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
The git diff included with this PR shows the missing code, however, it is better to look at the diff shown in the Issue #1114 since that diff ignores the different indenting levels.  The git diff shows the indenting differences, making it harder to read.

The version of `pc2sandbox_interactive.sh` included in this PR was used for all contests related to the NAC2025 (online, systests, dress and actual contest).