### PR TITLE
i_1117 Teams can not fetch their own submission source code using API

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -279,7 +279,7 @@ public class SubmissionService implements Feature {
         if(clientId != null) {
             account = model.getAccount(clientId);
         }
-        // only admin and analyst are authorized to access this endpoint, and analyst is restricted in that
+        // admins and analysts are authorized to access this endpoint, and analyst is restricted in that
         // they can't see it during freeze period.
         boolean allowed = sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) ||
             sc.isUserInRole(WebServer.WEBAPI_ROLE_JUDGE) ||
@@ -287,9 +287,12 @@ public class SubmissionService implements Feature {
                 Utilities.getFreezeTime(model) > model.getContestTime().getElapsedSecs() &&
                 !model.getContestInformation().isUnfrozen());
 
+        // only teams with a real account can fetch their runs
+        boolean isTeam = sc.isUserInRole(WebServer.WEBAPI_ROLE_TEAM) && (account != null);
+
         // In order to get source code for a run, the user role must be allowed AND if it's
         // a pc2 account, the account has to have permission to fetch the run.
-        if (!allowed || (account != null && !account.isAllowed(Permission.Type.ALLOWED_TO_FETCH_RUN))) {
+        if ((!allowed && !isTeam) || (account != null && !account.isAllowed(Permission.Type.ALLOWED_TO_FETCH_RUN))) {
             return Response.status(Status.UNAUTHORIZED).build();
         }
         // get the submissions from the contest
@@ -300,6 +303,9 @@ public class SubmissionService implements Feature {
             Run submission = runs[i];
             if (IJSONTool.getSubmissionId(submission).equals(submissionId)) {
 
+                if(isTeam && !submission.getSubmitter().equals(clientId)) {
+                    return Response.status(Response.Status.FORBIDDEN).build();
+                }
                 //we found the requested Submission ID in the list of runs returned from the model; try to get the runfiles for Submission
                 runFiles = null;
                 try {


### PR DESCRIPTION
### Description of what the PR does
The ICPC information access policy currently states that teams can access their own submissions' data.  The **SubmissionService** for the CLICS 2023-06 version of the API did not allow this.  This fix allows a team to pull their own source code.

### Issue which the PR addresses
Fixes #1117 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Start up a contest where a team has made a submission
2. Make sure the team that made the submission has the **ALLOWED_TO_FETCH_RUN** and **VIEW_EVENT_FEED** permissions.
3. Start up an event feeder for API version 2023-06
4. Make sure the event feeder account has SHADOW_PROXY_TEAM permission set.
5. Request the source code (files) for the submission the team made.  For example, if the submission # was 123:
    `curl -k https://team1:team1@localhost:50443/contests/CONTESTID/submissions/123/files`
6. The source file, 123.zip, should be returned.
