### PR TITLE
i_1119 Add missing code to send comments on CLICS 2023-06 event feed

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CommentaryService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CommentaryService.java
@@ -50,6 +50,10 @@ public class CommentaryService implements Feature {
 
     private IInternalController controller;
 
+    // TODO: create a commentary listener, but since commentary is not integrated into the
+    // pc2 models yet, we will do it directly.
+    private EventFeedService eventFeedService = null;
+
     public CommentaryService(IInternalContest inContest, IInternalController inController) {
         super();
         this.model = inContest;
@@ -223,7 +227,11 @@ public class CommentaryService implements Feature {
             if(commentaryEntries != null) {
                 commentaryEntries.writeCommentary(json + JSON202306Utilities.NL);
             }
-            return Response.created(uriBuilder.build()).entity(json).build();
+            Response reply = Response.created(uriBuilder.build()).entity(json).build();
+            if(reply != null && eventFeedService != null) {
+                eventFeedService.commentaryAdded(json);
+            }
+            return reply;
         } catch (Exception e) {
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Error creating JSON for commentary " + e.getMessage()).build();
         }
@@ -239,6 +247,16 @@ public class CommentaryService implements Feature {
         return(sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) ||
                 !sc.isUserInRole(WebServer.WEBAPI_ROLE_JUDGE) ||
                 !sc.isUserInRole(WebServer.WEBAPI_ROLE_ANALYST));
+    }
+
+    /**
+     * Set the event feed service so we can deliver notifications of new commentary
+     * TODO: This will be removed when we add a commentary listener
+     *
+     * @param svc
+     */
+    public void SetEventFeedService(EventFeedService svc) {
+        eventFeedService = svc;
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedService.java
@@ -177,6 +177,18 @@ public class EventFeedService implements Feature {
     }
 
     /**
+     * Pass commentary along to the streamer, if it exists (that is, if someone is listening.
+     * TODO: This will be removed when EventFeedStreamer has a commentary listener.
+     *
+     * @param json
+     */
+    public void commentaryAdded(String json) {
+        if(eventFeedStreamer != null) {
+            eventFeedStreamer.commentaryAdded(json);
+        }
+    }
+
+    /**
      * Create a snapshot of the JSON event feed.
      *
      * @param contest

--- a/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/EventFeedStreamer.java
@@ -1098,6 +1098,16 @@ public class EventFeedStreamer extends JSON202306Utilities implements Runnable, 
     }
 
     /**
+     * Send commentary to the event feed.
+     * TODO: This will be a method in the commentary listener class when that gets added.
+     *
+     * @param json
+     */
+    public void commentaryAdded(String json) {
+        sendJSON(getJSONEvent(COMMENTARY_KEY, getNextEventId(), null, json) + NL);
+    }
+
+    /**
      * Implementation of IEventFeedStreamer for those needing just the full event feed. eg reports, etc.
      * Currently, this is called from the ui.WebServerPane.viewJSONEventFeed
      *

--- a/src/edu/csus/ecs/pc2/clics/API202306/JSON202306Utilities.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/JSON202306Utilities.java
@@ -43,6 +43,8 @@ public class JSON202306Utilities extends JSONUtilities {
 
     public static final String ORGANIZATION_KEY = "organizations";
 
+    public static final String COMMENTARY_KEY = "commentary";
+
     public static final String JSON_ANNOTATION_INTERFACE = ".JsonProperty";
 
     /**

--- a/src/edu/csus/ecs/pc2/clics/API202306/ResourceConfig202306.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ResourceConfig202306.java
@@ -74,7 +74,8 @@ public class ResourceConfig202306 implements ICLICSResourceConfig {
             showStartingMessage("judgements web service");
             resConfig.register(new RunService(getContest(), getController()));
             showStartingMessage("runs web service");
-            resConfig.register(new EventFeedService(getContest(), getController()));
+            EventFeedService eventFeedService = new EventFeedService(getContest(), getController());
+            resConfig.register(eventFeedService);
             showStartingMessage("event-feed web service");
             resConfig.register(new StateService(getContest(), getController()));
             showStartingMessage("state web service");
@@ -82,7 +83,9 @@ public class ResourceConfig202306 implements ICLICSResourceConfig {
             showStartingMessage("awards web service");
             resConfig.register(new VersionService(getContest(), getController()));
             showStartingMessage("commentary web service");
-            resConfig.register(new CommentaryService(getContest(), getController()));
+            CommentaryService commentaryService = new CommentaryService(getContest(), getController());
+            resConfig.register(commentaryService);
+            commentaryService.SetEventFeedService(eventFeedService);
             showStartingMessage("results (extension) web service");
             resConfig.register(new ResultsService(getContest(), getController()));
             showMessage("Starting / endpoint for version web service");


### PR DESCRIPTION
### Description of what the PR does
Code was inadvertently left out of the pervious commit to PR #1085.  This code will arrange to have any added commentary sent out as notifications on the event feed.

### Issue which the PR addresses
Fixes #1119 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Start a contest
2. Start an event feeder thick client feeding the CLICS 2023-06 API
3. Start a remote consumer of the event feed, eg. curl -k http://admin:admin@localhost:50443/contests/XXXXX/event-feed
4. Post a new comment using the POST facility on the commentary endpoint (note that this is an extension to 2023-06, but will officially 
5. The commentary notification should appear on the event feed.
