### PR TITLE
I1099 pass1 wti scoreboard problem details

### DIFF
--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,7 +1,7 @@
 <div class='filter-table-container'>
 
     <div class='table-container'>
-        <table style="border-collapse: separate; border-spacing: 2px;" >
+		<table style="border-collapse: separate; border-spacing: 0 2px;">
             <tr>
                 <th>Rank</th>
                 <th>Team</th>
@@ -17,7 +17,7 @@
                 <td>{{ team.teamName }}</td>
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
- 				<td style="text-align: center; border: 1px solid black; border-radius: 8px; padding: 8px;" *ngFor= 'let problem of team.problemSummaryInfo' 
+ 				<td style="text-align: center; " *ngFor= 'let problem of team.problemSummaryInfo' 
  					[ngClass]="{'yes' : problem.isSolved, 
  								'no' : !problem.isSolved && problem.attempts>0 && !problem.isPending,
  								'pending' : !problem.isSolved && problem.isPending

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -17,15 +17,17 @@
                 <td>{{ team.teamName }}</td>
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
-                <td style="text-align: center" *ngFor= 'let problem of team.problemSummaryInfo' >
-                	<ng-container *ngIf="problem.isSolved; else notSolved"> 
-                		{{problem.attempts}}/{{problem.solutionTime}}
-                	</ng-container>
+ 				<td *ngFor= 'let problem of team.problemSummaryInfo' 
+ 					[ngClass]="{'yes':problem.isSolved, 'no':!problem.isSolved}">
+
+      				<ng-container *ngIf="problem.isSolved; else notSolved">
+        				{{problem.attempts}}/{{problem.solutionTime}}
+      				</ng-container>
+
                 	<ng-template #notSolved>
                 		{{problem.attempts}}/--
                 	</ng-template>
-                </td>
-
+                	
                 <td style="text-align: center">{{ team.solved }}</td>
                 <td style="text-align: center">{{ team.points }}</td>
             </tr>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,7 +1,7 @@
 <div class='filter-table-container'>
 
     <div class='table-container'>
-        <table>
+        <table style="border-collapse: separate; border-spacing: 2px;" >
             <tr>
                 <th>Rank</th>
                 <th>Team</th>
@@ -17,8 +17,11 @@
                 <td>{{ team.teamName }}</td>
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
- 				<td *ngFor= 'let problem of team.problemSummaryInfo' 
- 					[ngClass]="{'yes':problem.isSolved, 'no':!problem.isSolved}">
+ 				<td style="text-align: center; border: 1px solid black; border-radius: 8px; padding: 8px;" *ngFor= 'let problem of team.problemSummaryInfo' 
+ 					[ngClass]="{'yes' : problem.isSolved, 
+ 								'no' : !problem.isSolved && problem.attempts>0 && !problem.isPending,
+ 								'pending' : !problem.isSolved && problem.isPending
+ 								}">
 
       				<ng-container *ngIf="problem.isSolved; else notSolved">
         				{{problem.attempts}}/{{problem.solutionTime}}

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -17,8 +17,8 @@
                 <td>{{ team.teamName }}</td>
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
-                <td *ngFor= 'let problem of team.problemSummaryInfo' >
-                	<ng-container style="text-align: center" *ngIf="problem.isSolved; else notSolved"> 
+                <td style="text-align: center" *ngFor= 'let problem of team.problemSummaryInfo' >
+                	<ng-container *ngIf="problem.isSolved; else notSolved"> 
                 		{{problem.attempts}}/{{problem.solutionTime}}
                 	</ng-container>
                 	<ng-template #notSolved>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -5,6 +5,9 @@
             <tr>
                 <th>Rank</th>
                 <th>Team</th>
+                <th *ngFor= "let letter of problemLetters.slice(0,numProblems)" >
+                	{{letter}}
+                </th>
                 <th>Solved</th>
                 <th>Score</th>
                 <th></th>
@@ -12,6 +15,17 @@
             <tr *ngFor= 'let team of teamStandings' >
                 <td>{{ team.rank }}</td>
                 <td>{{ team.teamName }}</td>
+                
+                <!-- Display results for each problem: submission count plus solution time if solved -->
+                <td *ngFor= 'let problem of team.problemSummaryInfo' >
+                	<ng-container *ngIf='problem.isSolved; else notSolved'>
+                		{{problem.attempts}}/{{problem.solutionTime}}
+                	</ng-container>
+                	<ng-template #notSolved>
+                		{{problem.attempts}}/--
+                	</ng-template>
+                </td>
+
                 <td>{{ team.solved }}</td>
                 <td>{{ team.points }}</td>
             </tr>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -18,7 +18,7 @@
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
                 <td *ngFor= 'let problem of team.problemSummaryInfo' >
-                	<ng-container [ngStyle]="{'background-color': problem.isSolved ? 'green' : 'red'}" *ngIf='problem.isSolved; else notSolved'>
+                	<ng-container *ngIf="problem.isSolved; else notSolved"> 
                 		{{problem.attempts}}/{{problem.solutionTime}}
                 	</ng-container>
                 	<ng-template #notSolved>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,6 +1,6 @@
 <div class='filter-table-container'>
 
-    <div class='table-container'>
+    <div class='table-container scoreboard-table'>
 		<table style="border-collapse: separate; border-spacing: 6px 6px;">
             <tr>
                 <th>Rank</th>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,7 +1,7 @@
 <div class='filter-table-container'>
 
     <div class='table-container'>
-		<table style="border-collapse: separate; border-spacing: 2 0px;">
+		<table style="border-collapse: separate; border-spacing: 4 4px;">
             <tr>
                 <th>Rank</th>
                 <th>Team</th>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -5,20 +5,20 @@
             <tr>
                 <th>Rank</th>
                 <th>Team</th>
-                <th *ngFor= "let letter of problemLetters.slice(0,numProblems)" >
+                <th style="text-align: center" *ngFor= "let letter of problemLetters.slice(0,numProblems)" >
                 	{{letter}}
                 </th>
-                <th>Solved</th>
-                <th>Score</th>
+                <th style="text-align: center">Solved</th>
+                <th style="text-align: center">Score</th>
                 <th></th>
             </tr>
             <tr *ngFor= 'let team of teamStandings' >
-                <td>{{ team.rank }}</td>
+                <td style="text-align: center">{{ team.rank }}</td>
                 <td>{{ team.teamName }}</td>
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
                 <td *ngFor= 'let problem of team.problemSummaryInfo' >
-                	<ng-container *ngIf="problem.isSolved; else notSolved"> 
+                	<ng-container style="text-align: center" *ngIf="problem.isSolved; else notSolved"> 
                 		{{problem.attempts}}/{{problem.solutionTime}}
                 	</ng-container>
                 	<ng-template #notSolved>
@@ -26,8 +26,8 @@
                 	</ng-template>
                 </td>
 
-                <td>{{ team.solved }}</td>
-                <td>{{ team.points }}</td>
+                <td style="text-align: center">{{ team.solved }}</td>
+                <td style="text-align: center">{{ team.points }}</td>
             </tr>
         </table>
     </div>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,11 +1,11 @@
 <div class='filter-table-container'>
 
     <div class='table-container'>
-		<table style="border-collapse: separate; border-spacing: 4 4px;">
+		<table style="border-collapse: separate; border-spacing: 6px 6px;">
             <tr>
                 <th>Rank</th>
                 <th>Team</th>
-                <th style="text-align: center" *ngFor= "let letter of problemLetters.slice(0,numProblems)" >
+                <th style="text-align: center; padding:2px 2px" *ngFor= "let letter of problemLetters.slice(0,numProblems)" >
                 	{{letter}}
                 </th>
                 <th style="text-align: center">Solved</th>
@@ -17,7 +17,7 @@
                 <td>{{ team.teamName }}</td>
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
- 				<td style="text-align: center; " *ngFor= 'let problem of team.problemSummaryInfo' 
+ 				<td style="text-align: center; white-space: nowrap; " *ngFor= 'let problem of team.problemSummaryInfo' 
  					[ngClass]="{'yes' : problem.isSolved, 
  								'no' : !problem.isSolved && problem.attempts>0 && !problem.isPending,
  								'pending' : !problem.isSolved && problem.isPending

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,7 +1,7 @@
 <div class='filter-table-container'>
 
     <div class='table-container'>
-		<table style="border-collapse: separate; border-spacing: 0 2px;">
+		<table style="border-collapse: separate; border-spacing: 2 0px;">
             <tr>
                 <th>Rank</th>
                 <th>Team</th>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -18,7 +18,7 @@
                 
                 <!-- Display results for each problem: submission count plus solution time if solved -->
                 <td *ngFor= 'let problem of team.problemSummaryInfo' >
-                	<ng-container *ngIf='problem.isSolved; else notSolved'>
+                	<ng-container [ngStyle]="{'background-color': problem.isSolved ? 'green' : 'red'}" *ngIf='problem.isSolved; else notSolved'>
                 		{{problem.attempts}}/{{problem.solutionTime}}
                 	</ng-container>
                 	<ng-template #notSolved>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -6,14 +6,30 @@
   flex: 1;
 }
 
+td, th {
+  padding: 2px 4px;
+  text-align: center;
+  vertical-align: middle;
+}
+
+%submission-common-style {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  line-height: 1.2;
+}
 .yes {
+	@extend %submission-common-style;
 	background-color: #7fFF7f;
 }
 
 .no {
+	@extend %submission-common-style;
 	background-color: #FF3f3f;
 }
 
 .pending {
+	@extend %submission-common-style;
 	background-color: yellow;
 }

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -9,7 +9,7 @@
 %submission-common-style {
   padding: 2px 4px;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: 8px;
 }
 
 .yes {

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -29,5 +29,5 @@
 
 .pending {
 	@extend %submission-common-style;
-	background-color: yellow;
+	background-color: #3E9AE9;
 }

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -7,9 +7,13 @@
 }
 
 .yes {
-	background-color: #00FF00;
+	background-color: #7fFF7f;
 }
 
 .no {
-	background-color: #FF0000;
+	background-color: #FF3f3f;
+}
+
+.pending {
+	background-color: yellow;
 }

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -5,3 +5,11 @@
   flex-direction: column;
   flex: 1;
 }
+
+.yes {
+	background-color: #00FF00;
+}
+
+.no {
+	background-color: #FF0000;
+}

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -6,19 +6,13 @@
   flex: 1;
 }
 
-td, th {
-  padding: 2px 4px;
-  text-align: center;
-  vertical-align: middle;
-}
-
 %submission-common-style {
   border: 1px solid #ccc;
-  border-radius: 8px;
+  border-radius: 4px;
   font-family: Arial, sans-serif;
   font-size: 12px;
-  line-height: 1.2;
 }
+
 .yes {
 	@extend %submission-common-style;
 	background-color: #7fFF7f;

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -7,10 +7,9 @@
 }
 
 %submission-common-style {
+  padding: 2px 4px;
   border: 1px solid #ccc;
   border-radius: 4px;
-  font-family: Arial, sans-serif;
-  font-size: 12px;
 }
 
 .yes {

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -6,8 +6,13 @@
   flex: 1;
 }
 
+.scoreboard-table {
+	td, th {
+  		padding: 2px 4px !important;		
+	}
+}
+
 %submission-common-style {
-  padding: 2px 4px;
   border: 1px solid #ccc;
   border-radius: 8px;
 }
@@ -19,7 +24,7 @@
 
 .no {
 	@extend %submission-common-style;
-	background-color: #FF3f3f;
+	background-color: #FF6060;
 }
 
 .pending {

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
@@ -15,6 +15,11 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	
 	private _unsubscribe = new Subject<void>();
 	teamStandings: any = [];
+	numProblems: number = 0;
+	
+	//TODO: provide support for more than 26 problems
+	//TODO: provide support for the possibility that problems are not listed in alphabetical order
+	problemLetters = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z'];
 
 	constructor(
 		private _contestService: IContestService,
@@ -71,6 +76,7 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 				//console.log("standings string:");
 				//console.log(standings);
 				this.teamStandings = this.getTeamStandingsArray(standings);
+				this.numProblems = this.getNumProblems(standings);
 			});
 	}
 
@@ -95,10 +101,27 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 			tempArray.push(temp);
 		}
 		
-		//console.log("Individual Team Standings:");
-		//console.log(tempArray);
+		console.log("Individual Team Standings:");
+		console.log(tempArray);
 		
 		return tempArray;
 	}
 
+	/**
+	 * Returns the problem count from the specified JSON standings.
+	 */
+	private getNumProblems(standings: any) : number {
+
+		const contest = standings.contestStandings ;
+		console.log("getNumProblems(): ContestStandings element:");
+		console.log(contest);
+		
+		const header = contest.standingsHeader ;
+		console.log("getNumProblems(): StandingsHeader elements:");
+		console.log(header);
+		
+		const problemCount = header.problemCount;
+		console.log ("getNumProblems(): problemCount = ", problemCount)
+		return problemCount;
+	}
 }

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
@@ -101,8 +101,8 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 			tempArray.push(temp);
 		}
 		
-		console.log("Individual Team Standings:");
-		console.log(tempArray);
+//		console.log("Individual Team Standings:");
+//		console.log(tempArray);
 		
 		return tempArray;
 	}
@@ -113,15 +113,15 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	private getNumProblems(standings: any) : number {
 
 		const contest = standings.contestStandings ;
-		console.log("getNumProblems(): ContestStandings element:");
-		console.log(contest);
+//		console.log("getNumProblems(): ContestStandings element:");
+//		console.log(contest);
 		
 		const header = contest.standingsHeader ;
-		console.log("getNumProblems(): StandingsHeader elements:");
-		console.log(header);
+//		console.log("getNumProblems(): StandingsHeader elements:");
+//		console.log(header);
 		
 		const problemCount = header.problemCount;
-		console.log ("getNumProblems(): problemCount = ", problemCount)
+//		console.log ("getNumProblems(): problemCount = ", problemCount)
 		return problemCount;
 	}
 }


### PR DESCRIPTION
### Description of what the PR does
Reconstucts the changes which were used in the NAC25 contest related to showing "Problem Details" on the WTI scoreboard.

By way of explanation:

A number of commits were made against Issue #1099 prior to NAC25; those commits were reflected in PR #1102, which had multiple approvals and was used at NAC25.  However, there was not time to complete all the intended functionality of Issue #1099 prior to NAC25.  What _should_ have been done at that point was to merge what had been completed and approved into Develop, and spin the remaining "incompleted" items off onto a second (new) Issue.  

However, that didn't happen; rather, additional work continued on the Issue #1099 branch even after it had been approved and used at the NAC25 contest. Further, the work which was done under PR #1102 was never merged.   (These were errors on the author's part.)

What THIS PR does is correct this situation by extending Develop (as it existed for NAC25) with JUST the changes from PR #1102 which were approved and used at NAC25 -- giving us a record of what was used at that contest.  This PR thus effectively _replaces_ PR #1102, which will be closed without merging.  Instead, THIS PR should be approved and merged, as it completes the basic functionality of displaying problem details on the WTI scoreboard as used in NAC25.  A _new_ issue (Issue #1124) has been created to encapsulate the additional changes which have been made to complete the work originally intended to be part of Issue #1099, and a new PR (#1125) has been submitted with separate steps for testing (just) those additional features.

### Issue which the PR addresses
Resolves #1099.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11;  Eclipse Version: 2020-12 (4.18.0); Java version "1.8.0_271"

### Precise steps for _testing_ the PR

- Start a PC2 server using --load tenprobs to load the sample contest that has 10 problems.
- Start a PC2 Admin.
- Optional configuration changes (not required, but may make testing easier):
  - Select the Admin Problems tab. Observe that the last two problems are (sort of) incorrectly named `Sumit a`, whereas logically they should be named `Sumit i` and `Sumit j` for consistency with the rest of the problem set naming. Edit these two problems and change the name if you like (it isn't strictly necessary, but it will avoid the confusion of having three identically-name problems when you start submitting runs...).
  - Select the Admin Settings tab. Scroll down to the "Team Settings" box. Observe that the configured "Team Scoreboard Display Format" is quite cumbersome (it's confusing when you look at it on the scoreboard). Recommend changing it to (something like) `{:clientnumber}  {:teamname} Group {:groupid}:{:groupname}`. This gives a reasonably long yet still readable display. Change the text and then click Update.
- Unzip the WTI distribution (in the projects folder), then go into the resulting WebTeamInterface-1.2 folder and start the WTI Server, using the command `./bin/pc2wti`.
- Open a browser. If you have previously used this browser to connect to PC2, clear the browser's data cache (or, use "incognito" mode).
- Connect to the PC2 WTI Server from the browser and login as a team.
- Click the Scoreboard menu item. Observe that every team is displayed and includes a column for each problem (A-J) showing entries `0/--` in all problem fields. (This means "zero submissions/no-solution-time" and is identical to the format used on the standard PC2 HTML scoreboard).
- Click on the "Runs" menu and submit an incorrect run for one of the problems (submit any program written in the language you select as long as the program is NOT a correct solution for the "Sumit" problem).
- Click on the WTI "Scoreboard" menu and observe that the count of submissions for that team for that problem has increased by one, and that the text for the problem is `1/--` (one submission, no solution time) and that the background color of the cell is blue (for "Pending").
- Start a PC2 Judge and log in as "judge6" (this is the first judge configured to AutoJudge all the problems).
- Click on the Scoreboard menu item and observe that the cell color for the submission has changed from blue to red (because the submission was not a correct solution).
- Submit a correct run for the same problem. (Note that the only languages configured in this contest are Java and Python, so you'll need a solution for the Sumit problem written in one of those two languages (or else you'll need to add a language). Since _all_ problems are the standard "Sumit" problem, you can find a correct solution in the PC2 samps/src folder: either `ISumit.java` or `isumit.py`. You'll also need to have a compiler on your machine for the chosen language).
- Observe on the Scoreboard that (1) the count of submissions for that team for that problem has increased;  (2) the `--` under the problem has been updated to the time (number of minutes) at which the correct solution was submitted;  (3) the cell background color has changed to green;  (4) the `Solved` column now shows one solution; and  (5) the `Score` column shows the correct score for the team.
- Try submitting various correct and incorrect runs for other problems; verify that the entries under the corresponding problem, and the Solved and Score entries, update as expected.
- Try logging in as a different team and submitting various correct and incorrect runs; verify that the entries under the problems, and the Solved and Score values, update as expected.



