### PR TITLE
Fix missing state information in scoreboard JSON report

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestState.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestState.java
@@ -4,6 +4,7 @@ package edu.csus.ecs.pc2.clics.API202306;
 import java.util.Calendar;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,6 +67,14 @@ public class CLICSContestState {
      */
     @JsonProperty
     private String contest_time;
+
+    /**
+     * Provide empty constructor for Jackson deserialization
+     */
+    @JsonCreator
+    public CLICSContestState() {
+
+    }
 
     /**
      * Fill in properties for contest state as per 2023-06 spec

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSProblemScore.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSProblemScore.java
@@ -3,6 +3,7 @@ package edu.csus.ecs.pc2.clics.API202306;
 
 import java.util.HashMap;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.csus.ecs.pc2.core.StringUtilities;
@@ -40,6 +41,14 @@ public class CLICSProblemScore {
     private int time;
 
     /**
+     * Provide empty constructor for Jackson deserialization
+     */
+    @JsonCreator
+    public CLICSProblemScore() {
+
+    }
+
+    /**
      * Fill in API problem score information properties (for scoreboard endpoint)
      *
      * @param probEleToShort hashmap for mapping problem elementid to shortname
@@ -73,5 +82,29 @@ public class CLICSProblemScore {
         } catch (Exception e) {
             return defaultBool;
         }
+    }
+
+    public String getProblem_id() {
+        return problem_id;
+    }
+
+    public int getNum_judged() {
+        return num_judged;
+    }
+
+    public int getNum_pending() {
+        return num_pending;
+    }
+
+    public boolean isSolved() {
+        return solved;
+    }
+
+    public int getTime() {
+        return time;
+    }
+
+    public void setTime(int time) {
+        this.time = time;
     }
 }

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSScore.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSScore.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.standings.TeamStanding;
 
@@ -43,13 +42,14 @@ public class CLICSScore {
      * Fill in the properties for a team's score
      *
      * @param teamStanding The team's scoring information
+     * @throws NumberFormatException if bad scores are in the standings
      */
     public CLICSScore(TeamStanding teamStanding) {
         num_solved = Utilities.nullSafeToInt(teamStanding.getSolved(), 0);
-        total_time = Utilities.nullSafeToInt(teamStanding.getPoints(), 0);
+        total_time = Integer.parseInt(teamStanding.getPoints());
         if(num_solved > 0) {
             // Problem solution time is in minutes.
-            time = StringUtilities.getIntegerValue(teamStanding.getLastSolved(), 0);
+            time = Integer.parseInt(teamStanding.getLastSolved());
         }
     }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSScore.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSScore.java
@@ -1,9 +1,11 @@
 // Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.standings.TeamStanding;
 
@@ -27,7 +29,15 @@ public class CLICSScore {
 //    private int score;
 
     @JsonProperty
-    private String time;
+    private int time;
+
+    /**
+     * Provide empty constructor for Jackson deserialization
+     */
+    @JsonCreator
+    public CLICSScore() {
+
+    }
 
     /**
      * Fill in the properties for a team's score
@@ -39,8 +49,20 @@ public class CLICSScore {
         total_time = Utilities.nullSafeToInt(teamStanding.getPoints(), 0);
         if(num_solved > 0) {
             // Problem solution time is in minutes.
-            time = teamStanding.getLastSolved();
+            time = StringUtilities.getIntegerValue(teamStanding.getLastSolved(), 0);
         }
+    }
+
+    public int getNum_solved() {
+        return num_solved;
+    }
+
+    public int getTotal_time() {
+        return total_time;
+    }
+
+    public int getTime() {
+        return time;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSScoreboard.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSScoreboard.java
@@ -6,17 +6,18 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 
 import javax.xml.bind.JAXBException;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.Group;
@@ -50,10 +51,18 @@ public class CLICSScoreboard {
     private CLICSScoreboardRow [] rows;
 
     /**
+     * Provide empty constructor for Jackson deserialization
+     */
+    @JsonCreator
+    public CLICSScoreboard() {
+
+    }
+
+    /**
      * Fill in the scoreboard information
      *
      */
-    public CLICSScoreboard(IInternalContest model, IInternalController controller, Group group, Integer division)  throws IllegalContestState, JAXBException, IOException {
+    public CLICSScoreboard(IInternalContest model, Group group, Integer division)  throws IllegalContestState, JAXBException, IOException {
 
         DefaultScoringAlgorithm scoringAlgorithm = new DefaultScoringAlgorithm();
 
@@ -114,6 +123,15 @@ public class CLICSScoreboard {
         } else {
             rows = new CLICSScoreboardRow[0];
         }
+    }
+
+    /**
+     * Get the per-team scoreboard rows as a List
+     *
+     * @return List of scoreboard rows
+     */
+    public List<CLICSScoreboardRow> getRows() {
+        return Arrays.asList(rows);
     }
 
     public String toJSON() {

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSScoreboardRow.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSScoreboardRow.java
@@ -2,8 +2,11 @@
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -34,6 +37,14 @@ public class CLICSScoreboardRow {
     private CLICSProblemScore [] problems;
 
     /**
+     * Provide empty constructor for Jackson deserialization
+     */
+    @JsonCreator
+    public CLICSScoreboardRow() {
+
+    }
+
+    /**
      * Fill in API scoreboard row information properties (for scoreboard endpoint)
      *
      * @param probEleToShortName hashmap for mapping problem elementid to shortname
@@ -50,5 +61,21 @@ public class CLICSScoreboardRow {
             pslist.add(new CLICSProblemScore(probEleToShortName, psi));
         }
         problems = pslist.toArray(new CLICSProblemScore[0]);
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public String getTeam_id() {
+        return team_id;
+    }
+
+    public CLICSScore getScore() {
+        return score;
+    }
+
+    public List<CLICSProblemScore> getProblems() {
+        return Arrays.asList(problems);
     }
 }

--- a/src/edu/csus/ecs/pc2/clics/API202306/ScoreboardService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ScoreboardService.java
@@ -104,7 +104,7 @@ public class ScoreboardService implements Feature {
 
                 // ok to return scoreboard
                 try {
-                    CLICSScoreboard scoreboard = new CLICSScoreboard(model, controller, specificGroup, divNumber);
+                    CLICSScoreboard scoreboard = new CLICSScoreboard(model, specificGroup, divNumber);
                     return Response.ok(scoreboard.toJSON(), MediaType.APPLICATION_JSON).build();
                 } catch (IllegalContestState | JAXBException | IOException e) {
                     controller.getLog().log(Log.WARNING, "Exception creating PC2 scoreboard JSON: " + e.getMessage(), e);

--- a/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/ExportFilesUtilities.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
+import edu.csus.ecs.pc2.clics.API202306.CLICSScoreboard;
 import edu.csus.ecs.pc2.clics.API202306.EventFeedJSON;
 import edu.csus.ecs.pc2.clics.API202306.JSONTool;
 import edu.csus.ecs.pc2.core.Constants;
@@ -16,11 +17,8 @@ import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.ExecuteUtilities;
 import edu.csus.ecs.pc2.core.imports.clics.CLICSAward;
 import edu.csus.ecs.pc2.core.imports.clics.CLICSAwardUtilities;
-import edu.csus.ecs.pc2.core.imports.clics.CLICSScoreboard;
 import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
 
 public class ExportFilesUtilities {
@@ -64,9 +62,8 @@ public class ExportFilesUtilities {
         }
 
         try {
-            ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
-            CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contestStandings);
-            String json = clicsScoreboard.toString();
+            CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contest, null, null);
+            String json = clicsScoreboard.toJSON();
             String[] sa = { json };
             FileUtilities.writeFileContents(scoreboardJsonFilename, sa);
 

--- a/src/edu/csus/ecs/pc2/core/report/FileComparisonUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/report/FileComparisonUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.File;
@@ -16,16 +16,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+import edu.csus.ecs.pc2.clics.API202306.CLICSProblemScore;
+import edu.csus.ecs.pc2.clics.API202306.CLICSScoreboard;
+import edu.csus.ecs.pc2.clics.API202306.CLICSScoreboardRow;
 import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.execute.ExecuteUtilities;
 import edu.csus.ecs.pc2.core.imports.clics.CLICSAward;
-import edu.csus.ecs.pc2.core.imports.clics.CLICSScoreboard;
 import edu.csus.ecs.pc2.core.imports.clics.FieldCompareRecord;
 import edu.csus.ecs.pc2.core.imports.clics.FileComparison;
 import edu.csus.ecs.pc2.core.log.StaticLog;
-import edu.csus.ecs.pc2.core.standings.json.ProblemScoreRow;
 import edu.csus.ecs.pc2.core.standings.json.TeamScoreRow;
 import edu.csus.ecs.pc2.services.core.JSONUtilities;
 
@@ -60,7 +61,7 @@ public class FileComparisonUtilities {
         if(checkFilesExist(fileComparison, firstFilename, secondFilename)) {
             try {
 
-                List<TeamScoreRow> firstTeamScoreRows = null;
+                List<CLICSScoreboardRow> firstTeamScoreRows = null;
                 try {
                     firstTeamScoreRows = FileComparisonUtilities.loadTeamRows(fileComparison.getFirstFilename());
                 } catch (JsonMappingException e) {
@@ -68,7 +69,7 @@ public class FileComparisonUtilities {
                     ExecuteUtilities.rethrow(rte);
                 }
 
-                List<TeamScoreRow> secondTeamScoreRows = null;
+                List<CLICSScoreboardRow> secondTeamScoreRows = null;
                 try {
                     secondTeamScoreRows = FileComparisonUtilities.loadTeamRows(fileComparison.getSecondFilename());
                 } catch (JsonMappingException e) {
@@ -84,8 +85,8 @@ public class FileComparisonUtilities {
                 numberRows += minLines;
 
                 for (int rowNum = 0; rowNum < minLines; rowNum++) {
-                    TeamScoreRow firstRow = firstTeamScoreRows.get(rowNum);
-                    TeamScoreRow secondScoreRow = secondTeamScoreRows.get(rowNum);
+                    CLICSScoreboardRow firstRow = firstTeamScoreRows.get(rowNum);
+                    CLICSScoreboardRow secondScoreRow = secondTeamScoreRows.get(rowNum);
                     String rowString = "[" + rowNum + "]";
 
                     String fieldName = "rank";
@@ -107,16 +108,16 @@ public class FileComparisonUtilities {
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
 
                     fieldName = "team_id";
-                    valueOne = Long.toString(firstRow.getTeam_id());
-                    valueTwo = Long.toString(secondScoreRow.getTeam_id());
+                    valueOne = firstRow.getTeam_id();
+                    valueTwo = secondScoreRow.getTeam_id();
                     fieldCompareRecord = new FieldCompareRecord(fieldName, valueOne, valueTwo, null, rowString);
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
 
                     // compare problems
-                    List<ProblemScoreRow> probs1 = firstRow.getProblems();
-                    List<ProblemScoreRow> probs2 = secondScoreRow.getProblems();
+                    List<CLICSProblemScore> probs1 = firstRow.getProblems();
+                    List<CLICSProblemScore> probs2 = secondScoreRow.getProblems();
                     if(probs1 != null && probs2 != null) {
-                        ProblemScoreRow p1, p2;
+                        CLICSProblemScore p1, p2;
                         int ptime1, ptime2;
                         String probString, probId;
                         boolean foundProblem;
@@ -231,7 +232,7 @@ public class FileComparisonUtilities {
                 }
 
                 for (int rowNum = minLines; rowNum < firstTeamScoreRows.size(); rowNum++) {
-                    TeamScoreRow firstRow = firstTeamScoreRows.get(rowNum);
+                    CLICSScoreboardRow firstRow = firstTeamScoreRows.get(rowNum);
                     String rowString = "[" + rowNum + "]";
 
                     numberRows ++;
@@ -254,7 +255,7 @@ public class FileComparisonUtilities {
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
 
                     fieldName = "team_id";
-                    valueOne = Long.toString(firstRow.getTeam_id());
+                    valueOne = firstRow.getTeam_id();
                     fieldCompareRecord = new FieldCompareRecord(fieldName, valueOne, valueTwo, null, rowString);
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
 
@@ -270,7 +271,7 @@ public class FileComparisonUtilities {
 
                     numberRows ++;
 
-                    TeamScoreRow teamScoreRow = secondTeamScoreRows.get(rowNum);
+                    CLICSScoreboardRow teamScoreRow = secondTeamScoreRows.get(rowNum);
 
                     String valueOne = null;
 
@@ -291,7 +292,7 @@ public class FileComparisonUtilities {
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
 
                     fieldName = "team_id";
-                    valueTwo = Long.toString(teamScoreRow.getTeam_id());
+                    valueTwo = teamScoreRow.getTeam_id();
                     fieldCompareRecord = new FieldCompareRecord(fieldName, valueOne, valueTwo, null, rowString);
                     fileComparison.addfieldCompareRecord(fieldCompareRecord);
 
@@ -712,9 +713,9 @@ public class FileComparisonUtilities {
         }
     }
 
-    public static  List<TeamScoreRow> loadTeamRows(String scoreboardJSONFilename) throws IOException {
+    public static  List<CLICSScoreboardRow> loadTeamRows(String scoreboardJSONFilename) throws IOException {
 
-        List<TeamScoreRow> rows = new ArrayList<TeamScoreRow>();
+        List<CLICSScoreboardRow> rows = null;
 
         String[] lines = Utilities.loadFile(scoreboardJSONFilename);
         String firstLineString = String.join(" ", lines);
@@ -724,6 +725,9 @@ public class FileComparisonUtilities {
         if (clicsScoreboard != null)
         {
             rows = clicsScoreboard.getRows();
+        } else {
+            rows = new ArrayList<CLICSScoreboardRow>();
+
         }
 
         return rows;

--- a/src/edu/csus/ecs/pc2/core/report/ScoreboardJSONReport.java
+++ b/src/edu/csus/ecs/pc2/core/report/ScoreboardJSONReport.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.report;
 
 import java.io.FileOutputStream;
@@ -7,18 +7,16 @@ import java.io.PrintWriter;
 import java.util.GregorianCalendar;
 
 import edu.csus.ecs.pc2.VersionInfo;
+import edu.csus.ecs.pc2.clics.API202306.CLICSScoreboard;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
-import edu.csus.ecs.pc2.core.imports.clics.CLICSScoreboard;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Filter;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
-import edu.csus.ecs.pc2.core.standings.ContestStandings;
-import edu.csus.ecs.pc2.core.standings.ScoreboardUtilities;
 
 /**
  * Print CLICS API Scoreboard JSON
- * 
+ *
  * @author Douglas A. Lane <pc2@ecs.csus.edu>
  */
 public class ScoreboardJSONReport implements IReport {
@@ -44,14 +42,16 @@ public class ScoreboardJSONReport implements IReport {
         }
     }
 
+    @Override
     public void writeReport(PrintWriter printWriter) {
         String[] ouputArray = createReport(filter);
         for (String line : ouputArray) {
-            printWriter.print(line);   
+            printWriter.print(line);
         }
-        
+
     }
 
+    @Override
     public void printHeader(PrintWriter printWriter) {
         printWriter.println(new VersionInfo().getSystemName());
         printWriter.println("Date: " + Utilities.getL10nDateTime());
@@ -63,11 +63,13 @@ public class ScoreboardJSONReport implements IReport {
         printWriter.println();
     }
 
+    @Override
     public void printFooter(PrintWriter printWriter) {
         printWriter.println();
         printWriter.println("end report");
     }
 
+    @Override
     public void createReportFile(String filename, Filter inFilter) throws IOException {
 
         PrintWriter printWriter = new PrintWriter(new FileOutputStream(filename, false), true);
@@ -95,11 +97,11 @@ public class ScoreboardJSONReport implements IReport {
         }
     }
 
+    @Override
     public String[] createReport(Filter inFilter) {
         try {
-            ContestStandings contestStandings = ScoreboardUtilities.createContestStandings(contest);
-            CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contestStandings);
-            String json = clicsScoreboard.toString();
+            CLICSScoreboard clicsScoreboard = new CLICSScoreboard(contest, null, null);
+            String json = clicsScoreboard.toJSON();
             String[] sa = { json };
             return sa;
         } catch (Exception e) {
@@ -107,28 +109,34 @@ public class ScoreboardJSONReport implements IReport {
         }
     }
 
+    @Override
     public String createReportXML(Filter inFilter) throws IOException {
         return Reports.notImplementedXML(this);
     }
 
+    @Override
     public String getReportTitle() {
         return "Scoreboard JSON";
     }
 
+    @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         this.contest = inContest;
         this.controller = inController;
         log = controller.getLog();
     }
 
+    @Override
     public String getPluginTitle() {
         return "Scoreboard JSON Report";
     }
 
+    @Override
     public Filter getFilter() {
         return filter;
     }
 
+    @Override
     public void setFilter(Filter filter) {
         this.filter = filter;
     }

--- a/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
+++ b/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -54,6 +54,9 @@ public class ResultsComparePane extends JPanePlugin {
 
     private static final boolean DEFAULT_IGNORE_EMPTY_AWARDS = true;
 
+    private static final String CCS_SHADOW_DIR = "shadow";
+    private static final String CCS_PRIMARY_DIR = "primary";
+
     private static final long serialVersionUID = -2726716271169661000L;
 
     private JTextField pc2ResultsDirectoryTextField;
@@ -90,8 +93,8 @@ public class ResultsComparePane extends JPanePlugin {
         });
         primaryCCSResultsDirectoryTextField.setColumns(40);
 
-        JLabel prmaryCCSLabel = new JLabel("Primary CCS Results Directory");
-        primarySourcePanel.add(prmaryCCSLabel);
+        JLabel primaryCCSLabel = new JLabel("Primary CCS Results Directory");
+        primarySourcePanel.add(primaryCCSLabel);
         primarySourcePanel.add(primaryCCSResultsDirectoryTextField);
 
         JButton selectPrimaryCCSResultsDirectoryButton = new JButton("Select...");
@@ -266,14 +269,39 @@ public class ResultsComparePane extends JPanePlugin {
         });
     }
 
+    /**
+     * Attempt to find the cdp results folder so we can prepopulate the
+     * primary/shadow results paths so it saves time during EOC
+     *
+     * @param ccs "shadow" or "primary"
+     * @return The results folder for the primary/shadow
+     */
+    private String guessResultsDirectory(String ccs)
+    {
+        File resultsDir = new File("current" + File.separator + "results" + File.separator + ccs);
+        String resName = "";
+        if(resultsDir.isDirectory()) {
+            resName = resultsDir.getAbsolutePath();
+        }
+        return(resName);
+    }
+
     protected void populateGUI() {
 
         ClientSettings clientSet = getClientSettings(getContest());
         String exportDir = clientSet.getProperty(ClientSettings.PC2_RESULTS_DIR);
+        exportDir = ""; // JB TEST
+        if(exportDir.isEmpty()) {
+            exportDir = guessResultsDirectory(CCS_SHADOW_DIR);
+        }
         pc2ResultsDirectoryTextField.setText(exportDir);
         exportDirectoryLabel.setToolTipText(exportDir);
 
         String primaryResultsDir = clientSet.getProperty(ClientSettings.PRIMARY_CCS_RESULTS_DIR);
+        primaryResultsDir = ""; // JB TEST
+        if(primaryResultsDir.isEmpty()) {
+            primaryResultsDir = guessResultsDirectory(CCS_PRIMARY_DIR);
+        }
         primaryCCSResultsDirectoryTextField.setText(primaryResultsDir);
 
         textArea.removeAll();

--- a/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
+++ b/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
@@ -290,7 +290,6 @@ public class ResultsComparePane extends JPanePlugin {
 
         ClientSettings clientSet = getClientSettings(getContest());
         String exportDir = clientSet.getProperty(ClientSettings.PC2_RESULTS_DIR);
-        exportDir = ""; // JB TEST
         if(exportDir.isEmpty()) {
             exportDir = guessResultsDirectory(CCS_SHADOW_DIR);
         }
@@ -298,7 +297,6 @@ public class ResultsComparePane extends JPanePlugin {
         exportDirectoryLabel.setToolTipText(exportDir);
 
         String primaryResultsDir = clientSet.getProperty(ClientSettings.PRIMARY_CCS_RESULTS_DIR);
-        primaryResultsDir = ""; // JB TEST
         if(primaryResultsDir.isEmpty()) {
             primaryResultsDir = guessResultsDirectory(CCS_PRIMARY_DIR);
         }

--- a/test/edu/csus/ecs/pc2/core/report/FileComparisonUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/report/FileComparisonUtilitiesTest.java
@@ -6,12 +6,12 @@ import java.util.List;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.csus.ecs.pc2.clics.API202306.CLICSScoreboardRow;
 import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.imports.clics.CLICSAward;
 import edu.csus.ecs.pc2.core.imports.clics.FieldCompareRecord;
 import edu.csus.ecs.pc2.core.imports.clics.FileComparison;
-import edu.csus.ecs.pc2.core.standings.json.TeamScoreRow;
 import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 import edu.csus.ecs.pc2.exports.ccs.ResultsFile;
 import edu.csus.ecs.pc2.services.core.JSONUtilities;
@@ -110,10 +110,10 @@ public class FileComparisonUtilitiesTest extends AbstractTestCase {
         //        editFile(comp.getSecondFilename());
         //        editFile(comp.getFirstFilename());
 
-        List<TeamScoreRow> firstTeamScoreRows = FileComparisonUtilities.loadTeamRows(comp.getFirstFilename());
+        List<CLICSScoreboardRow> firstTeamScoreRows = FileComparisonUtilities.loadTeamRows(comp.getFirstFilename());
         assertEquals("Expecting team score rows in " + comp.getFirstFilename(), 124, firstTeamScoreRows.size());
 
-        List<TeamScoreRow> secondTeamScoreRows = FileComparisonUtilities.loadTeamRows(comp.getSecondFilename());
+        List<CLICSScoreboardRow> secondTeamScoreRows = FileComparisonUtilities.loadTeamRows(comp.getSecondFilename());
         assertEquals("Expecting team score rows in " + comp.getSecondFilename(), 124, secondTeamScoreRows.size());
     }
 


### PR DESCRIPTION
### Description of what the PR does
The incorrect **CLICS** routine was being called to generate the JSON scoreboard report.  We should be using the newest **CLICS API** Scoreboard objects (2023-06). This fix involved adding Jackson deserialization capability to several of the CLICS **API202306** classes (an empty constructor and getter methods). The **FileComparisonUtilities** had to be changed to use the correct CLICS API class names.
CI: Removed unused argument "**controller**" from `API202306.CLICSScoreboard`
CI: Fix datatype error for the "**time**" property in` API202306.CLICSScore`
CI: Attempt to populate the primary and shadow results folders to speed up EOC procedures (no longer should be necessary to track down the results folder using an explorer window).

This bug was found during NAC when the shadow (DOMjudge) noticed we didn't include state information in the scoreboard JSON.  The CLICS API Endpoint returned the correct data, but the reports did not.

This is an easy PR to review.  Many of the changes are adding _getter_ methods to some classes as well as default constructors.

### Issue which the PR addresses
Fixes #1109 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR 

1. Load a completed contest, or at the very least, a contest that has several correct submissions.
2. From an administrator client generate the: "**Results Export File**s" report.
3. Verify that the `scoreboard.json` produced is correct (contains a correct state object instead of all empty strings)
4. From an administrator client generate the: "**Scoreboard JSON**" report and save it someplace.
5. Open the saved file and notice that the state object in the JSON contains valid information as opposed to empty strings.

To test the CI regarding populating the _Primary_ and _Shadow_ folder edit fields:
Load a completed contest, such as **NAC2025**  or a contest that has a `results` folder in the CDP base folder (same level as the `config `folder).
From an administrator client, on the **Run Contest** tab, choose the **Results Compare** tab.
Notice that the folders for _Primary_ and _PC2_ are filled in.

It should be noted that the nomenclature chosen for the results folders should read _Primary_ and _Shadow_ as opposed to _Primary_ and _PC2_.  PC2 can be the primary and some other CCS can be the shadow.  These should be fixed at some point someday.