### PR TITLE
i_971 Add options to not count CE/SV submissions

### DIFF
--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.scoring;
 
 import java.io.IOException;
@@ -74,6 +74,10 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
 
     public static final String POINTS_PER_NO_SECURITY_VIOLATION = "Points per Security Violation";
 
+    public static final String IGNORE_COMPILATION_ERROR = "Ignore Compilation Error";
+
+    public static final String IGNORE_SECURITY_VIOLATION = "Ignore Security Violation";
+
     /**
      * Non-frozen scoreboard output directory key
      */
@@ -90,8 +94,9 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
      * key=name, value=default_value, type, min, max (colon delimited)
      */
     private static String[][] propList = { { POINTS_PER_NO, "20:Integer" }, { POINTS_PER_YES_MINUTE, "1:Integer" }, { BASE_POINTS_PER_YES, "0:Integer" },
-            { POINTS_PER_NO_COMPILATION_ERROR, "0:Integer" }, { POINTS_PER_NO_SECURITY_VIOLATION, "0:Integer" }, { JUDGE_OUTPUT_DIR, "html:String" },
-            { PUBLIC_OUTPUT_DIR, "public_html:String" } };
+            { POINTS_PER_NO_COMPILATION_ERROR, "0:Integer" }, { IGNORE_COMPILATION_ERROR, "true:Boolean" },
+            { POINTS_PER_NO_SECURITY_VIOLATION, "0:Integer" }, { IGNORE_SECURITY_VIOLATION, "false:Boolean" },
+            { JUDGE_OUTPUT_DIR, "html:String" }, { PUBLIC_OUTPUT_DIR, "public_html:String" } };
 
     private Properties props = new Properties();
 
@@ -151,6 +156,7 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
             String value = propList[i][1];
             int colon = value.indexOf(":");
             String defaultValue = value.substring(0, colon);
+            // apparently, the "type" portion of the string is ignored (stuff after the colonr) - JB
             props.put(key, defaultValue);
         }
         // props.put(POINTS_PER_NO, "20");
@@ -180,10 +186,12 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
         ProblemSummaryInfo problemSummaryInfo = new ProblemSummaryInfo();
         int score = 0;
         int attempts = 0;
+        int penalty = 0;
         ElementId problemId = null;
         long solutionTime = -1;
         boolean solved = false;
         boolean unJudgedRun = false;
+        boolean ignoreSub = false;
 
         if (treeMap.isEmpty()) {
             problemSummaryInfo = null; // ProblemScoreData must have ProblemId to be valid
@@ -198,7 +206,6 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
                 if (run.isDeleted()) {
                     continue;
                 }
-                attempts++;
                 problemId = run.getProblemId();
                 // added isValidJudgement to check and obey preliminary results
                 if (run.isSolved() && isValidJudgement(run)) {
@@ -208,20 +215,30 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
                     solved = true;
                     solutionTime = run.getElapsedMins();
                     score += solutionTime * getPenaltyPointsPerYesMinute() + getBasePointsPerYes();
+                    attempts++;
                     break;
                 } else {
+                    ignoreSub = false;
                     // we should really only do this if it's been judged
                     if (isValidJudgement(run)) {
                         String response = theContest.getJudgement(run.getJudgementRecord().getJudgementId()).getAcronym();
                         if(response.equals(Judgement.ACRONYM_COMPILATION_ERROR)) {
-                            score += getPenaltyPointsPerNoCompilationError();
+                            penalty = getPenaltyPointsPerNoCompilationError();
+                            ignoreSub = (penalty == 0 && ignoreCompilationError());
                         } else if(response.equals(Judgement.ACRONYM_SECURITY_VIOLATION)) {
-                            score += getPenaltyPointsPerNoSecurityViolation();
+                            penalty = getPenaltyPointsPerNoSecurityViolation();
+                            ignoreSub = (penalty == 0 && ignoreSecurityViolation());
                         } else {
-                            score += getPenaltyPointsPerNo();
+                            penalty = getPenaltyPointsPerNo();
                         }
                     } else {
                         unJudgedRun = true;
+                    }
+                    // only count it if we're not ignoring it. Optionally some types of
+                    // non-yes submissions may be ignored if the penalty is 0.
+                    if(!ignoreSub) {
+                        attempts++;
+                        score += penalty;
                     }
                 }
             }
@@ -241,14 +258,25 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
     }
 
     /**
-     * @param key
-     *            property to lookup
-     * @return
+     * Look up a property's integer value
+     * @param key property to look up
+     * @return property integer value
      */
     private int getPropIntValue(String key) {
         String s = props.getProperty(key);
         Integer i = Integer.parseInt(s);
         return (i.intValue());
+    }
+
+    /**
+     * Look up a property's boolean value
+     * @param key property to look up
+     * @return property boolean value
+     */
+    private boolean getPropBooleanValue(String key) {
+        String s = props.getProperty(key);
+        Boolean b = Boolean.parseBoolean(s);
+        return (b.booleanValue());
     }
 
     /**
@@ -269,8 +297,16 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
         return (getPropIntValue(POINTS_PER_NO_COMPILATION_ERROR));
     }
 
+    private boolean ignoreCompilationError() {
+        return(getPropBooleanValue(IGNORE_COMPILATION_ERROR));
+    }
+
     private int getPenaltyPointsPerNoSecurityViolation() {
         return (getPropIntValue(POINTS_PER_NO_SECURITY_VIOLATION));
+    }
+
+    private boolean ignoreSecurityViolation() {
+        return(getPropBooleanValue(IGNORE_SECURITY_VIOLATION));
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -156,7 +156,7 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
             String value = propList[i][1];
             int colon = value.indexOf(":");
             String defaultValue = value.substring(0, colon);
-            // apparently, the "type" portion of the string is ignored (stuff after the colonr) - JB
+            // apparently, the "type" portion of the string is ignored (stuff after the colon) - JB
             props.put(key, defaultValue);
         }
         // props.put(POINTS_PER_NO, "20");

--- a/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
@@ -688,6 +688,12 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         return (i.intValue());
     }
 
+    private boolean getPropBooleanValue(Properties inProperties, String key) {
+        String s = inProperties.getProperty(key);
+        Boolean b = Boolean.parseBoolean(s);
+        return (b.booleanValue());
+    }
+
     private int getNoPenalty(Properties properties) {
         // private static String[][] propList = { { POINTS_PER_NO, "20:Integer" }, { POINTS_PER_YES_MINUTE, "1:Integer" }, {
         // BASE_POINTS_PER_YES, "0:Integer" } };
@@ -719,6 +725,8 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
 
         int numberJudged = 0;
 
+        boolean ignoreSub = false;
+
         Arrays.sort(runs, new RunCompartorByElapsed());
 
         for (Run run : runs) {
@@ -726,9 +734,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
                 continue;
             }
 
-            numberSubmissions++;
-
-//            System.out.println(numberSubmissions + " "+run.getElapsedMins()+ " "+run);
+            ignoreSub = false;
 
             if (run.isJudged()) {
                 numberJudged++;
@@ -752,12 +758,24 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
 
                 if (Judgement.ACRONYM_COMPILATION_ERROR.equals(judgment.getAcronym())) {
                     compilationErrorsBeforeYes++;
+                    if(isCEIgnore(properties)) {
+                        ignoreSub = true;
+                    }
                 } else if (Judgement.ACRONYM_SECURITY_VIOLATION.equals(judgment.getAcronym())) {
                     securityViolationBeforeYes++;
+                    if(isSVIgnore(properties)) {
+                        ignoreSub = true;
+                    }
                 } else {
                     submissionsBeforeYes++;
                 }
             }
+
+            if(!ignoreSub) {
+                numberSubmissions++;
+            }
+
+//          System.out.println(numberSubmissions + " "+run.getElapsedMins()+ " "+run);
         }
 
         if (solved) {
@@ -777,6 +795,16 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
 
     private int getSVPenalty(Properties properties) {
         return getPropIntValue(properties, DefaultScoringAlgorithm.POINTS_PER_NO_SECURITY_VIOLATION, "0");
+    }
+
+    private boolean isCEIgnore(Properties properties) {
+        return(getPropBooleanValue(properties, DefaultScoringAlgorithm.IGNORE_COMPILATION_ERROR) &&
+               getCEPenalty(properties) == 0);
+    }
+
+    private boolean isSVIgnore(Properties properties) {
+        return(getPropBooleanValue(properties, DefaultScoringAlgorithm.IGNORE_SECURITY_VIOLATION) &&
+               getSVPenalty(properties) == 0);
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/standings/ScoringGroup.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ScoringGroup.java
@@ -6,6 +6,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
 @XmlRootElement(name = "group")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ScoringGroup {

--- a/src/edu/csus/ecs/pc2/exports/ccs/StandingsJSON.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/StandingsJSON.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.exports.ccs;
 
 import java.util.ArrayList;
@@ -33,7 +33,6 @@ public class StandingsJSON {
             return "[]";
         }
 
-        boolean needCommaSep = false;
         NewScoringAlgorithm scoringAlgorithm = new NewScoringAlgorithm();
         scoringAlgorithm.setContest(contest);
 
@@ -52,12 +51,7 @@ public class StandingsJSON {
         StringBuffer buffer = new StringBuffer();
 
         for (StandingsRecord sr : standingsRecords) {
-            if(needCommaSep) {
-                buffer.append(",{");
-            } else {
-                buffer.append('{');
-                needCommaSep = true;
-            }
+            buffer.append('{');
             ClientId clientId = sr.getClientId();
             Account account = contest.getAccount(clientId);
             String universityName = account.getDisplayName();

--- a/src/edu/csus/ecs/pc2/exports/ccs/StandingsJSON.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/StandingsJSON.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.exports.ccs;
 
 import java.util.ArrayList;
@@ -33,6 +33,7 @@ public class StandingsJSON {
             return "[]";
         }
 
+        boolean needCommaSep = false;
         NewScoringAlgorithm scoringAlgorithm = new NewScoringAlgorithm();
         scoringAlgorithm.setContest(contest);
 
@@ -51,7 +52,12 @@ public class StandingsJSON {
         StringBuffer buffer = new StringBuffer();
 
         for (StandingsRecord sr : standingsRecords) {
-            buffer.append('{');
+            if(needCommaSep) {
+                buffer.append(",{");
+            } else {
+                buffer.append('{');
+                needCommaSep = true;
+            }
             ClientId clientId = sr.getClientId();
             Account account = contest.getAccount(clientId);
             String universityName = account.getDisplayName();


### PR DESCRIPTION
### Description of what the PR does
Other CCS's do not count CE (if its penalty is 0) or SV (if its penalty is 0).  PC2 always counted these as submissions. There are now two new options in the `ContestInformationSettings` (and `ContestInformationPane`) for controlling whether or not to count CE or SV as submissions (if their respective penalties are 0).
Changes to DSA and NSA to support this.
CI: fix bug in older JSON Standings report where it didn't put a comma between array records (it NEVER worked).


### Issue which the PR addresses
Fixes #971 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Create a contest (use one of the samples).
2. Make a CE submission.
3. Run a scoreboard client.
4. Look at the scoreboard; notice there are no submissions recorded.
5. You can also generate a **JSON Standings** report, a **Results Export Files** report or a **Scoreboard JSON** report and look at the output.
6. You can control the setting of the option from the Settings tab in the Scoring Properties section:
<img width="365" alt="image" src="https://github.com/user-attachments/assets/1f5fd82d-0f2d-4cdf-b62f-2c310ed538ea" />

### Other Information
Below is a diff of the NAC2025 Scoreboard JSON report with the **Ignore Compilation Error** option disabled (left arrow) and option enabled (right arrow).

```
50c50
<                "num_judged" : 2,
---
>                "num_judged" : 1,
1321c1321
<                "num_judged" : 1,
---
>                "num_judged" : 0,
2691c2691
<                "num_judged" : 12,
---
>                "num_judged" : 11,

```