### PR TITLE
i_604 CLICSValidator produces result string returned to user

### DIFF
--- a/src/edu/csus/ecs/pc2/validator/clicsValidator/ClicsValidator.java
+++ b/src/edu/csus/ecs/pc2/validator/clicsValidator/ClicsValidator.java
@@ -1,6 +1,6 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 /**
- * 
+ *
  */
 package edu.csus.ecs.pc2.validator.clicsValidator;
 
@@ -17,7 +17,7 @@ import java.io.UnsupportedEncodingException;
 
 /**
  * This class implements the ICPC "CLICS Validator", which
- * expects to receive on its standard input stream the output of the execution of 
+ * expects to receive on its standard input stream the output of the execution of
  * a team program on a given data set, and returns an indication of whether the team output is "valid".
  * <P>
  * The CLICS Validator can be invoked in one of two ways: as a stand-alone main program, or by instantiating
@@ -28,66 +28,66 @@ import java.io.UnsupportedEncodingException;
  * If invoked by instantiation and then calling {@link ClicsValidator#validate()}, the {@link #validate()}
  * method returns these same values (42 for success or 43 for failure).
  * <p>
- * The validator requires arguments (either on the command line if invoked via main() 
+ * The validator requires arguments (either on the command line if invoked via main()
  * or as constructor arguments if invoked via instantiation) as follows:
  * <ul>
  *   <li> judge_data -- the judge's input data for a single test case
  *   <li> judge_answer  -- the judge's answer file corresponding to the specified judge_data
- *   <li> feedback_dir -- the name of a "feedback directory" in which the validator can produce "feedback files" 
- *      in order to report additional information on the validation of the team output. 
- *      The feedback_dir must end with a path separator ('/' or '\' depending on operating system), 
+ *   <li> feedback_dir -- the name of a "feedback directory" in which the validator can produce "feedback files"
+ *      in order to report additional information on the validation of the team output.
+ *      The feedback_dir must end with a path separator ('/' or '\' depending on operating system),
  *      so that simply appending a filename to feedback_dir gives the path to a file in the feedback directory.
  * </ul>
- * 
+ *
  * <P>
  * Following the above required arguments the validator can accept up to four optional arguments, as follows:
  * <ul>
  *   <li> "case_sensitive" -- indicates that string comparisons should be case-sensitive
  *          (by default, case is ignored)
- *   <li> "space_change_sensitive" -- indicates that changes in the amount of whitespace should be rejected 
+ *   <li> "space_change_sensitive" -- indicates that changes in the amount of whitespace should be rejected
  *          (the default is that any sequence of 1 or more whitespace characters are equivalent)
  *   <li> "float_absolute_tolerance E" -- indicates that floating-point tokens should be accepted if they are within absolute error {@literal <=} E
  *   <li> "float_relative_tolerance E" -- indicates that floating-point tokens should be accepted if they are within relative error {@literal <=} E
  *   <li> "float_tolerance E" -- this string is a short-hand for applying E as both relative and absolute tolerance
  * </ul>
  * <P>
- * When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the 
- * two tolerances. When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating 
- * point tokens. So for instance if a token in the judge_answer file says 0.0314, a token of 3.14000000e-2 in the team output would be accepted. 
+ * When supplying both a relative and an absolute tolerance, the semantics are that a token is accepted if it is within either of the
+ * two tolerances. When a floating-point tolerance has been set, any valid formatting of floating point numbers is accepted for floating
+ * point tokens. So for instance if a token in the judge_answer file says 0.0314, a token of 3.14000000e-2 in the team output would be accepted.
  * If no floating point tolerance has been set, floating point tokens are treated just like any other token and must match exactly.
  * <P>
- * Optional arguments may also be constructed using hyphens ("-") instead of underscores ("_"), as long as the same character 
+ * Optional arguments may also be constructed using hyphens ("-") instead of underscores ("_"), as long as the same character
  * is used throughout a given option string (for example, "space-change-sensitive" is equivalent to "space_change_sensitive").
  * <P>
  * Whether the validator is invoked via the main() method or by instantiation, the class expects the team output to be provided on the
  * standard input stream.
  * <p>
- * To understand the meanings of the float_absolute_tolerance and float_relative_tolerance options, the following description 
+ * To understand the meanings of the float_absolute_tolerance and float_relative_tolerance options, the following description
  * (based on http://stackoverflow.com/questions/8961844/relative-and-absolute-tolerance-definitions-in-matlab-solver) may help.
  * <p>
- * There are two ways to measure the amount by which two values differ: relative difference (i.e. % change), and absolute difference.  
- * It makes a lot of sense to check for relative change, since a difference of 5 means something very different when the correct answer is around 1 
+ * There are two ways to measure the amount by which two values differ: relative difference (i.e. % change), and absolute difference.
+ * It makes a lot of sense to check for relative change, since a difference of 5 means something very different when the correct answer is around 1
  * than when it is around 100000.  Relative tolerance is defined as the percentage of allowable difference;
- * checking relative difference between the judge's answer "j" and the team's answer "t" means checking whether 
+ * checking relative difference between the judge's answer "j" and the team's answer "t" means checking whether
  * {@literal abs(j-t)/j)<=relTol}, or equivalently whether {@literal abs(j-t)<=relTol*j}, where "relTol" is a percentage (fraction).
- * In other words, this checks by what fraction the team solution differs from the judge's solution. 
- * <P>  
+ * In other words, this checks by what fraction the team solution differs from the judge's solution.
+ * <P>
  *  Relative tolerance, however, becomes problematic when the correct answer is very small, since as the correct answer tends toward zero
- *  the value {@literal abs(j-t)/j} grows toward infinity (because x/0 is undefined). 
- *  Thus, it makes sense to also look at the absolute change in value, and accept an answer when {@literal abs(j-t)<absTol}. 
- *  If you choose absTol small enough, it will only be relTol (percent difference) that counts for large values, 
- *  while absTol only becomes relevant if the correct answer tends to lie around 0.  
+ *  the value {@literal abs(j-t)/j} grows toward infinity (because x/0 is undefined).
+ *  Thus, it makes sense to also look at the absolute change in value, and accept an answer when {@literal abs(j-t)<absTol}.
+ *  If you choose absTol small enough, it will only be relTol (percent difference) that counts for large values,
+ *  while absTol only becomes relevant if the correct answer tends to lie around 0.
  *  <P>
- *  Since the validator stops when either of the two criterion is fulfilled, how close the team gets to a correct answer 
- *  is determined by absTol or relTol. For example, if relTol is 10% (0.1), the team will have to get within 10% of the judge's answer, 
+ *  Since the validator stops when either of the two criterion is fulfilled, how close the team gets to a correct answer
+ *  is determined by absTol or relTol. For example, if relTol is 10% (0.1), the team will have to get within 10% of the judge's answer,
  *  unless the answer is very small, in which case the absTol criterion (of, say, 0.0001) is satisfied before the relTol criterion.
- *  
- *  The validator writes a judgement message to a file in the specified feedback_Dir; the name of the file is defined by the 
- *  constant {@link #CLICS_JUDGEMENT_FEEDBACK_FILE_NAME}.  
+ *
+ *  The validator writes a judgement message to a file in the specified feedback_Dir; the name of the file is defined by the
+ *  constant {@link #CLICS_JUDGEMENT_FEEDBACK_FILE_NAME}.
  *  If the result of the validation is failure (that is, the submission is being judged "no"), the validator also writes a
  *  "judgement details" message to a file in the feedback_Dir; the name of the details file is defined by the
  *  constant {@link #CLICS_JUDGEMENT_DETAILS_FEEDBACK_FILE_NAME}.
- * 
+ *
  * @author John@pc2.ecs.csus.edu
  *
  */
@@ -96,34 +96,37 @@ public class ClicsValidator {
     public static final int CLICS_VALIDATOR_JUDGED_RUN_SUCCESS_EXIT_CODE = 42;
     public static final int CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE = 43;
     public static final int CLICS_VALIDATOR_ERROR_EXIT_CODE = -39;
-    
+
     //the judgement messages which can be returned in the judgement feedback file in the feedback directory
-    public static final String CLICS_INCOMPLETE_OUTPUT_MSG = "Incomplete output";
-    public static final String CLICS_EXCESSIVE_OUTPUT_MSG = "Excessive output";
-    public static final String CLICS_INCORRECT_OUTPUT_FORMAT_MSG = "Incorrect output format";
+//    public static final String CLICS_INCOMPLETE_OUTPUT_MSG = "Incomplete output";
+//    public static final String CLICS_EXCESSIVE_OUTPUT_MSG = "Excessive output";
+//    public static final String CLICS_INCORRECT_OUTPUT_FORMAT_MSG = "Incorrect output format";
+    public static final String CLICS_INCOMPLETE_OUTPUT_MSG = "Wrong Answer";
+    public static final String CLICS_EXCESSIVE_OUTPUT_MSG = "Wrong Answer";
+    public static final String CLICS_INCORRECT_OUTPUT_FORMAT_MSG = "Wrong Answer";
     public static final String CLICS_WRONG_ANSWER_MSG = "Wrong Answer";
     public static final String CLICS_RUNTIME_ERROR_MSG = "Runtime Error";
     public static final String CLICS_CORRECT_ANSWER_MSG = "accepted";
-    
+
     public static final String CLICS_JUDGEMENT_FEEDBACK_FILE_NAME = "judgement.txt";
     public static final String CLICS_JUDGEMENT_DETAILS_FEEDBACK_FILE_NAME = "judgementdetails.txt";
-    
+
     public static final String PC2_RUNTIME_ERROR_EXITCODE_FILE_NAME = "EXITCODE.TXT";
-    
+
     public static final int EOF = -1;
-    
+
     private String judgeDataFile = null;
     private String judgeAnswerFile = null;
     private String feedbackDirName = null;
     private String judgementFileBaseName = null;
-    
+
     private boolean isCaseSensitive = false;
     private boolean isSpaceSensitive = false;
     private boolean useFloatTolerance = false;
     private double floatAbsTolerance = ClicsValidatorSettings.CLICS_DEFAULT_FLOAT_ABSOLUTE_TOLERANCE;
     private double floatRelTolerance = ClicsValidatorSettings.CLICS_DEFAULT_FLOAT_RELATIVE_TOLERANCE;
-    
-    
+
+
     public ClicsValidator(String inJudgeDataFile, String inJudgeAnswerFile, String inFeedbackDirName, String... options ) {
 
         //grab file arguments
@@ -143,9 +146,9 @@ public class ClicsValidator {
             usage();
             throw new RuntimeException("ClicsValidator received invalid file or directory name(s)");
         }
-        
+
 //        dumpOptions(options);
-        
+
         //grab optional arguments (if any)
         for (int i=0; i<options.length; i++) {
 
@@ -172,9 +175,9 @@ public class ClicsValidator {
                     System.err.println ("ClicsValidator: " + "Missing tolerance value following '" + ClicsValidatorSettings.CLICS_VTOKEN_FLOAT_ABSOLUTE_TOLERANCE + "' option");
                     usage();
                     throw new RuntimeException("Missing tolerance value following '" + ClicsValidatorSettings.CLICS_VTOKEN_FLOAT_ABSOLUTE_TOLERANCE + "' option");
-                    
+
                 }
-                
+
             } else if (ClicsValidatorSettings.CLICS_VTOKEN_FLOAT_RELATIVE_TOLERANCE.equals(options[i]) || "float-relative-tolerance".equals(options[i])) {
                 if (i<options.length-1) {
                     i++;
@@ -194,7 +197,7 @@ public class ClicsValidator {
                     usage();
                     throw new RuntimeException("Missing tolerance value following '" + ClicsValidatorSettings.CLICS_VTOKEN_FLOAT_RELATIVE_TOLERANCE + "' option");
                 }
-                
+
             } else if ("float_tolerance".equals(options[i]) || "float-tolerance".equals(options[i])) {
                 if (i<options.length-1) {
                     i++;
@@ -215,34 +218,34 @@ public class ClicsValidator {
                     usage();
                     throw new RuntimeException("Missing tolerance value following 'float_tolerance' option");
                 }
-                
+
             } else {
 
                 // check for empty option argument (to allow accepting null or "" as a valid -- if ignored -- argument)
                 if (options[i] != null && options[i].trim().length() > 0) {
-                    // got a non-empty-string option -> unknown 
+                    // got a non-empty-string option -> unknown
                     System.err.println ("Clics Validator received unknown option: '" + options[i] + "'");
                 }
             }
-            
+
         }//end grab option arguments (if any)
-        
+
         //if we didn't find an option defining the judgement file base name, use the default
         if (judgementFileBaseName==null) {
             judgementFileBaseName = CLICS_JUDGEMENT_FEEDBACK_FILE_NAME;
         }
-        
+
     }//end constructor
-    
+
     /**
      * Causes this ClicsValidator to evaluate the team output (received on System.in)
      * using the data values configured via the constructor, and return either success or failure as defined by
      * the static class constants.
-     * 
+     *
      * @return an int indicating success or failure, or an error code if an error occurred
      */
-    public int validate() {   
-        
+    public int validate() {
+
         //check first whether there was a runtime error during execution (as denoted by the presence of file "EXITCODE.TXT")
         String judgement = "";
         String judgementDetails = "";
@@ -253,13 +256,13 @@ public class ClicsValidator {
                 judgementDetails = "Runtime Error code = '" + getRuntimeErrorExitCodeFromFile(PC2_RUNTIME_ERROR_EXITCODE_FILE_NAME) + "'";
                 outputFailure(judgement, judgementDetails);
                 return CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE ;
-            } 
+            }
         } catch (IOException e1) {
             System.err.println("Error reading exit code file '" + PC2_RUNTIME_ERROR_EXITCODE_FILE_NAME + "'");
             e1.printStackTrace(System.err);
         }
 
-        
+
         //get input stream for reading judge's answer
         InputStream judgeAnswerIS=null;
         try {
@@ -268,7 +271,7 @@ public class ClicsValidator {
             System.err.println ("ClicsValidator: " + "Judge's answer file '" + judgeAnswerFile + "': file not found");
             return CLICS_VALIDATOR_ERROR_EXIT_CODE;
         }
-        
+
         //the following code can be uncommented to run the validator stand-alone against a specified team output file
 //        try {
 //            System.setIn(new FileInputStream(new File("teamoutput.0.txt")));
@@ -278,14 +281,14 @@ public class ClicsValidator {
 
         return validate(judgeAnswerIS, System.in);
     }
-    
+
     /**
      * Reads and returns a line from the specified file, expected to contain a runtime error exit code.
-     * 
+     *
      * @param exitcodeFileName the name of the file containing the runtime error exit code
      * @return a String containing the first line of the specified file
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     private String getRuntimeErrorExitCodeFromFile(String exitcodeFileName) throws FileNotFoundException, IOException {
         BufferedReader bufferedReader = new BufferedReader (new FileReader(exitcodeFileName));
@@ -296,66 +299,66 @@ public class ClicsValidator {
 
     /**
      * Causes this ClicsValidator to evaluate the team output (received on the specified input stream)
-     * against the judge's answer (received on the specified input stream), 
+     * against the judge's answer (received on the specified input stream),
      * and return either success or failure as defined by the static class constants.
-     * 
+     *
      * @param judgeAnswerIS an InputStream containing the values in the judge's answer file
-     * @param teamOutputIS an InputStream containing the values in the team's output file 
-     * 
+     * @param teamOutputIS an InputStream containing the values in the team's output file
+     *
      * @return an int indicating success or failure, or an error code if an error occurred
      */
     private int validate(InputStream judgeAnswerIS, InputStream teamOutputIS) {
-        
+
         //we need a pushback stream so we can mimic "peek()" on the judge's answer file stream
         PushbackInputStream judgeAnswerPushbackIS = new PushbackInputStream(judgeAnswerIS);
-        
+
         //input stream for reading team output
         // (note the assumption that the team's output is provided on "stdin")
         PushbackInputStream teamOutputPushbackIS = new PushbackInputStream(teamOutputIS);
-        
+
         //vars to hold bytes from judge and team input streams
         byte judgeByte;
         byte teamByte;
-        
-        //loop until judge's answer is exhausted (the loop breaks out when judge's answer is exhausted; 
+
+        //loop until judge's answer is exhausted (the loop breaks out when judge's answer is exhausted;
         // it exits with a failure code if team output fails to match)
         while (true) {
 
             //if space sensitive, skip over equal whitespace in judge answer and team output
             if (isSpaceSensitive) {
-                
+
                 try {
                     //while judge's answer file has whitespace, see if team output file has matching whitespace
                     while (isWhiteSpace(peek(judgeAnswerPushbackIS))) {
-                        
+
                         //judge has whitespace byte; get next bytes from judge and team
                         judgeByte = (byte) judgeAnswerPushbackIS.read();
                         teamByte = (byte) teamOutputPushbackIS.read();
-                        
+
                         //if the team byte doesn't match the judge's whitespace char, team has failed (since we're in "isSpaceSensitive" mode)
                         if (teamByte!=judgeByte) {
                             //exit with mismatched whitespace error
                             try {
-                                outputFailure(CLICS_INCORRECT_OUTPUT_FORMAT_MSG, "Space change error: judge's answer contains '" + printableString(judgeByte) 
+                                outputFailure(CLICS_INCORRECT_OUTPUT_FORMAT_MSG, "Space change error: judge's answer contains '" + printableString(judgeByte)
                                     + "' but team's output contains '" + printableString(teamByte) + "'");
                             } catch (Exception e) {
                                 System.err.println ("ClicsValidator: " + "Error outputing validator feedback answer file");
-                                return CLICS_VALIDATOR_ERROR_EXIT_CODE;                                                                            
+                                return CLICS_VALIDATOR_ERROR_EXIT_CODE;
                             }
                             return CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE;
                         }
                     }
-                    
-                    //we've skipped over matching whitespace to the first thing AFTER whitespace in the judge; 
+
+                    //we've skipped over matching whitespace to the first thing AFTER whitespace in the judge;
                     // make sure the team doesn't have MORE whitespace
                     if (isWhiteSpace(peek(teamOutputPushbackIS))) {
                         //exit with mismatched whitespace error
                         try {
-                            outputFailure(CLICS_INCORRECT_OUTPUT_FORMAT_MSG, "Space change error: team's output contains extra whitespace char '" 
+                            outputFailure(CLICS_INCORRECT_OUTPUT_FORMAT_MSG, "Space change error: team's output contains extra whitespace char '"
                                     + printableString((byte)teamOutputPushbackIS.read()) + "'");
                         } catch (Exception e) {
                             System.err.println ("ClicsValidator: " + "Error outputing validator feedback answer file");
-                            return CLICS_VALIDATOR_ERROR_EXIT_CODE;                                            
+                            return CLICS_VALIDATOR_ERROR_EXIT_CODE;
                         }
                         return CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE;
 
@@ -365,23 +368,23 @@ public class ClicsValidator {
                     return CLICS_VALIDATOR_ERROR_EXIT_CODE;
                 }
             } //end if isSpaceSensitive
-                    
+
             //if we get here, either we're not in space-sensitive mode, or we are but the above code has stripped matching leading whitespace
             // from both the judge's answer and the team's output streams; in either case we're ready to compare the next things in the streams.
-            
+
             //make sure the judge isn't at EOF (because if so there's nothing left to compare)
             if (peek(judgeAnswerPushbackIS) == EOF) {
                 //judge is at EOF; exit loop and check if team is also at EOF
                 break ;
             }
-                        
+
             //judge not at EOF, check if team IS at EOF
             if (peek(teamOutputPushbackIS) == EOF) {
-                            
+
                 //team is at EOF when judge is not, so team is missing output
-                
+
                 //check if judge has no more tokens
-                String nextJudgeToken = getNextToken(judgeAnswerPushbackIS); 
+                String nextJudgeToken = getNextToken(judgeAnswerPushbackIS);
                 if (nextJudgeToken.equals("")) {
                     break;
                 } else {
@@ -393,15 +396,15 @@ public class ClicsValidator {
                     return CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE;
                 }
             }
-                    
-            
-            //if we get here we know that neither the judge nor the team streams are at EOF, and are positioned after any matching 
+
+
+            //if we get here we know that neither the judge nor the team streams are at EOF, and are positioned after any matching
             // whitespace (in case-sensitive mode) or at the start of the next whitespace (in non-case-sensitive mode)
-            
+
             //get next tokens from the streams (note that getNextToken() skips leading whitespace, if any...)
-            String nextJudgeToken = getNextToken(judgeAnswerPushbackIS);    
+            String nextJudgeToken = getNextToken(judgeAnswerPushbackIS);
             String nextTeamToken = getNextToken(teamOutputPushbackIS);
-            
+
             //we have both a judge token and a team token which are not null and not zero length; compare them
             // (note that method areEquivalent() handles calling outputWrongAnswer() for various conditions if necessary)
             try {
@@ -412,11 +415,11 @@ public class ClicsValidator {
                 System.err.println ("ClicsValidator: " + "Error checking areEquivalent(" + nextJudgeToken + "," + nextTeamToken + ")");
                 return CLICS_VALIDATOR_ERROR_EXIT_CODE;
             }
-            
+
             //go back and skip the next whitespace (if not in space-sensitive mode), then process the next token
-            
-        }//end while(true) 
-        
+
+        }//end while(true)
+
         //we get here when there's no more input in the judge's answer stream;
         //check if the team is also at EOF
         if (peek(teamOutputPushbackIS) != EOF) {
@@ -446,12 +449,12 @@ public class ClicsValidator {
                     }
                     return CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE;
 
-                    
+
                 }
             }
         }
 
-        
+
         //if we get here then both the team and judge streams are at EOF and the team output has correctly matched the judge's answer
         try {
             outputSuccess(CLICS_CORRECT_ANSWER_MSG);
@@ -460,20 +463,20 @@ public class ClicsValidator {
                     + CLICS_JUDGEMENT_FEEDBACK_FILE_NAME + "' in feedback directory '" + feedbackDirName + "'");
             return CLICS_VALIDATOR_ERROR_EXIT_CODE;
         }
-        return CLICS_VALIDATOR_JUDGED_RUN_SUCCESS_EXIT_CODE;  
+        return CLICS_VALIDATOR_JUDGED_RUN_SUCCESS_EXIT_CODE;
     }//end method validate()
-    
+
     /**
      * Returns an int containing the next byte in the specified input stream while leaving the input stream unchanged.
      * Note that the return value contains the byte value (0-255) in the lower bits of the returned
-     * 16-bit int, or contains -1 if there was no byte available in the input stream (i.e. the 
+     * 16-bit int, or contains -1 if there was no byte available in the input stream (i.e. the
      * stream was at EOF).  This conforms to the way in which {@link InputStream#read()} returns data.
-     * 
+     *
      * @param inStream - the PushbackInputStream to be peeked at
      * @return - an int containing the byte at the head of the input stream, or -1
      */
     private int peek(PushbackInputStream inStream) {
-        
+
         int nextByte = EOF;  //yes, it's an int named nextByte; see the javadoc for InputStream.read() to understand why
         try {
             nextByte = inStream.read();
@@ -483,17 +486,17 @@ public class ClicsValidator {
         } catch (IOException e) {
             System.err.println ("ClicsValidator: " + "Internal error in ClicsValidator.peek()");
             e.printStackTrace();
-        } 
-        
+        }
+
         return nextByte;
     }
-    
+
     /**
      * Checks whether the received integer contains a representation of a whitespace character.
      * Note that the received integer is assumed to contain a byte read from an input stream,
      * or else the value -1 if the input stream had been at EOF.
      * If the received integer is equal to -1 then the method returns false (EOF is not whitespace).
-     * Determination of whitespace for values not equal to -1 is done using 
+     * Determination of whitespace for values not equal to -1 is done using
      * {@link Character#isWhitespace(int)}.
      * @param byteVal - an int containing a byte value in the lower 8 bits, or else the value -1
      * @return true if the received integer is not equal to -1 and is a whitespace character
@@ -506,13 +509,13 @@ public class ClicsValidator {
             return Character.isWhitespace(byteVal);
         }
     }
-    
+
     /**
      * Returns a printable string containing a representation of the specified byte.
      * Recognized control characters are converted to strings such as "<tab> for the byte 0x08 (tab);
      * other control characters are converted to "<?>".
      * Non-control characters are converted to a string containing their character representation.
-     * 
+     *
      * @param theByte a byte representing a character
      * @return a string representation of the character represented by theByte
      */
@@ -567,7 +570,7 @@ public class ClicsValidator {
      * at the first character after the end of the returned token (that is, either at
      * the beginning of the trailing whitespace delimiting the token or at the end of the
      * stream if there is no more data in the stream).
-     * 
+     *
      * @param inStream -- the pushback stream from which a token is to be extracted
      * @return a String containing the next whitespace-delimited token, or the empty string
      *          if the stream has no more non-whitespace tokens
@@ -585,16 +588,16 @@ public class ClicsValidator {
             e.printStackTrace();
             return "ClicsValidator.getNextToken(): error reading stream";
         }
-        
+
         //if at EOF then there were no non-whitespace chars left in the stream
         if (peek(inStream) == EOF) {
             return "";
         }
-        
+
         //there must be at least one non-whitespace char in the stream; pull out consecutive non-whitespace chars
         StringBuffer buf = new StringBuffer();
         try {
-            
+
             // get all non-whitespace chars preceeding whitespace or EOF
             while (!(peek(inStream) == EOF)) {
 
@@ -609,17 +612,17 @@ public class ClicsValidator {
             e.printStackTrace();
             return "ClicsValidator.getNextToken(): error reading stream";
         }
-        
+
         //return the stream characters as the next token
         String retString = new String(buf);
-                
+
         return retString;
     }//end method getNextToken()
-    
+
     /**
-     * Returns an indication of whether the two received strings, representing tokens from the judge and 
-     * team streams, are "equivalent" according to the current validator settings. 
-     * Float values are equivalent if they are within either the specified relative or absolute tolerance; 
+     * Returns an indication of whether the two received strings, representing tokens from the judge and
+     * team streams, are "equivalent" according to the current validator settings.
+     * Float values are equivalent if they are within either the specified relative or absolute tolerance;
      * strings are equivalent if they are exactly the same (that is, String.equals() returns true) if in
      * "case-sensitive" mode) or are the same ignoring case when not in case-sensitive mode.
      * <P>
@@ -628,25 +631,25 @@ public class ClicsValidator {
      * Returns true if the specified tokens are equivalent according to the current settings.
      * If false is returned it is guaranteed to be preceded by outputting a failure message to the
      * feedback directory, using {@link #outputFailure(String, String)}.
-     * 
+     *
      * @param judgeToken
      *            -- a token from the judge's answer input stream
      * @param teamToken
      *            -- a token from the team output stream
      * @return true if the two tokens are equivalent under the current validator settings
-     * 
+     *
      * @throws IOException if any error occurs while attempting to write output feedback files
      */
     private boolean areEquivalent(String judgeToken, String teamToken) throws IOException {
-        
+
         if (judgeToken==null || teamToken==null) {
             try {
-                outputFailure(CLICS_WRONG_ANSWER_MSG, "Attempted to compare incompatible tokens: team token = '" + teamToken 
+                outputFailure(CLICS_WRONG_ANSWER_MSG, "Attempted to compare incompatible tokens: team token = '" + teamToken
                         + "'; judge token = '" + judgeToken + "'");
             } catch (Exception e) {
                 System.err.println ("ClicsValidator: " + "Error outputting validator failed run feedback files: " + e.getMessage());
-                throw e;                                            
-            }            
+                throw e;
+            }
             return false;
         }
 
@@ -658,7 +661,7 @@ public class ClicsValidator {
                     outputFailure(CLICS_WRONG_ANSWER_MSG, "Expected float in team output, got '" + teamToken + "'");
                 } catch (Exception e) {
                     System.err.println ("ClicsValidator: " + "Error outputting validator failed run feedback files: " + e.getMessage());
-                    throw e;                                            
+                    throw e;
                 }
                 return false;
             } else {
@@ -673,7 +676,7 @@ public class ClicsValidator {
                                         + "; difference = " + diff + " (abs tol = " + floatAbsTolerance + "; rel tol = " + floatRelTolerance + ")");
                     } catch (Exception e) {
                         System.err.println ("ClicsValidator: " + "Error outputting validator failed run feedback files: " + e.getMessage());
-                        throw e;                                            
+                        throw e;
                     }
                     return false;
                 }
@@ -685,11 +688,11 @@ public class ClicsValidator {
                 return true;
             } else {
                 try {
-                    outputFailure(CLICS_WRONG_ANSWER_MSG, "String token mismatch (case-sensitive): judge token = '" 
+                    outputFailure(CLICS_WRONG_ANSWER_MSG, "String token mismatch (case-sensitive): judge token = '"
                                                                     + judgeToken + "'; team token = '" + teamToken + "'");
                 } catch (Exception e) {
                     System.err.println ("ClicsValidator: " + "Error outputting validator failed run feedback files: " + e.getMessage());
-                    throw e;                    
+                    throw e;
                 }
                 return false;
             }
@@ -699,7 +702,7 @@ public class ClicsValidator {
             return true;
         } else {
             try {
-                outputFailure(CLICS_WRONG_ANSWER_MSG, "String tokens mismatch (ignoring case): judge token = '" 
+                outputFailure(CLICS_WRONG_ANSWER_MSG, "String tokens mismatch (ignoring case): judge token = '"
                                                                 + judgeToken + "'; team token = '" + teamToken + "'");
             } catch (Exception e) {
                 System.err.println ("ClicsValidator: " + "Error outputting validator failed run feedback files: " + e.getMessage());
@@ -708,11 +711,11 @@ public class ClicsValidator {
             return false;
         }
     }//end method areEquivalent()
-    
+
     /**
      * Checks whether the two received values are within either (or both) the currently specified
      * absolute and relative tolerances.
-     * 
+     *
      * @param jVal, tval -- the two values to be compared
      * @return true if the two values are within either the relative or absolute tolerance
      */
@@ -723,19 +726,19 @@ public class ClicsValidator {
         }
         return true;
     }
-    
+
     /**
-     * Returns an indication of whether the specified string contains a valid description of a 
+     * Returns an indication of whether the specified string contains a valid description of a
      * floating-point number.
      * The determination of whether the String contains a valid float is made by invoking
      * Double.parseDouble(str); if this succeeds then the number is deemed to be a valid
      * floating-point number.
-     * 
+     *
      * @param str - the string to be examined
      * @return true if the string represents a floating-point number
      */
     private boolean isFloat(String str) {
-        
+
         try {
             Double.parseDouble(str);
             return true;
@@ -743,10 +746,10 @@ public class ClicsValidator {
             return false;
         }
     }
-    
+
     /**
      * Returns the double value represented by the received string.
-     * 
+     *
      * @param str -- the string to be parsed
      * @return the double value represented by the string
      * @throws RuntimeException if the received string is not a valid representation of a double
@@ -760,64 +763,64 @@ public class ClicsValidator {
             throw new RuntimeException("getDoubleValue() received a string which is not a valid double value: '" + str + "' "+ e.getMessage());
         }
     }
-    
+
     private void outputFailure (String judgement, String details) throws FileNotFoundException, UnsupportedEncodingException {
         outputJudgementFile(judgement);
         outputDetailsFile(details);
     }
-    
+
     private void outputSuccess (String message) throws FileNotFoundException, UnsupportedEncodingException {
         outputJudgementFile(message);
     }
-    
+
     /**
      * Writes the specified judgement text into the feedback judgement file in the feedback directory, using "UTF-8" encoding.
      * The name of the file into which the text is written is defined by the static constant {@link #CLICS_JUDGEMENT_FEEDBACK_FILE_NAME}.
-     * 
+     *
      * Note that this method assumes that the global "feedback directory" name already has a File.separator appended to it (this is
      * handled in the constructor which receives the feedback directory name).
-     * 
+     *
      * @throws UnsupportedEncodingException if UTF-8 encoding for files is not supported
      * @throws FileNotFoundException if the method is unable to create a judgement feedback file in the feedback directory
      */
     private void outputJudgementFile(String judgement) throws FileNotFoundException, UnsupportedEncodingException {
         String feedbackFileName = feedbackDirName + CLICS_JUDGEMENT_FEEDBACK_FILE_NAME;
-        
+
         System.out.println ("CLICS Validator outputing judgement '" + judgement + "' to feedback file '" + feedbackFileName + "'");
-        
+
         PrintWriter writer = new PrintWriter(feedbackFileName, "UTF-8");
         writer.println(judgement);
         writer.close();
     }
-    
+
     /**
      * Writes the specified details text into the judgement details file in the feedback directory, using "UTF-8" encoding.
      * The name of the file into which the text is written is defined by the static constant {@link #CLICS_JUDGEMENT_DETAILS_FEEDBACK_FILE_NAME}.
-     * 
+     *
      * Note that this method assumes that the global "feedback directory" name already has a File.separator appended to it (this is
      * handled in the constructor which receives the feedback directory name).
-     * 
+     *
      * @throws UnsupportedEncodingException if UTF-8 encoding for files is not supported
      * @throws FileNotFoundException if the method is unable to create a judgement details feedback file in the feedback directory
      */
     private void outputDetailsFile(String details) throws FileNotFoundException, UnsupportedEncodingException {
         String detailsFileName = feedbackDirName + CLICS_JUDGEMENT_DETAILS_FEEDBACK_FILE_NAME;
-        
+
         System.out.println ("CLICS Validator outputing judgement details '" + details + "' to feedback details file '" + detailsFileName + "'");
-        
+
         PrintWriter writer = new PrintWriter(detailsFileName, "UTF-8");
         writer.println(details);
         writer.close();
     }
-    
+
 
     /**
-     * Checks the judgesDataFile, judgesAnswerFile, and feedbackDirName to make sure they exist and are 
+     * Checks the judgesDataFile, judgesAnswerFile, and feedbackDirName to make sure they exist and are
      * accessible as required.
      * @return true if all files/folders are accessible; false otherwise
      */
     private boolean validateFiles() {
-        
+
         if (judgeDataFile==null || judgeAnswerFile==null || feedbackDirName==null) {
             String errStr = "";
             if (judgeDataFile==null) {
@@ -838,7 +841,7 @@ public class ClicsValidator {
             System.err.println ("ClicsValidator received null file name(s) for: " + errStr);
             return false;
         }
-        
+
         //pc2 passes in "-" if {:infile} is empty (i.e. the problem has no data file); ignore it
         if (!judgeDataFile.trim().equals("-")) {
             //there is some kind of data file name; verify the file exists
@@ -848,29 +851,29 @@ public class ClicsValidator {
                 return false;
             }
         }
-        
+
         File answerFile = new File(judgeAnswerFile);
         if (!answerFile.exists() || !answerFile.canRead()) {
             System.err.println ("ClicsValidator: " + "judge answer file '" + judgeAnswerFile + "' doesn't exist or isn't readable");
             return false;
         }
-        
+
         File feedbackDir = new File(feedbackDirName);
         if (!feedbackDir.exists() || !feedbackDir.isDirectory() || !feedbackDir.canRead() || !feedbackDir.canWrite()) {
             System.err.println ("ClicsValidator: " + "feedback dir '" + feedbackDirName + "' doesn't exist, isn't a directory, or isn't readable and writeable");
             return false;
         }
-        
+
         return true;
     }
-    
+
     @SuppressWarnings("unused")
     private void dumpOptions(String [] options) {
         for (int i=0; i<options.length; i++) {
             System.out.println ("Option " + i + ": '" + options[i] + "'");
         }
     }
-    
+
     /**
      * The main entry point to the ClicsValidator when running as a stand-alone program.
      * The main program constructs a ClicsValidator object passing to its constructor the arguments received
@@ -878,23 +881,23 @@ public class ClicsValidator {
      * {@link #validate()} is then used as the main program exit code.
      * <P>
      * The validator expects the output of the team program (that is, the data being validated by comparing
-     * against the specified judge's answer file) to be provided on the standard input channel. 
-     * 
+     * against the specified judge's answer file) to be provided on the standard input channel.
+     *
      * @param args: {@literal judgeDataFile judgeAnswerFile feedbackDir [options]}
      */
     public static void main(String[] args) {
-        
+
         if (args.length < 3) {
             usage();
             System.exit(CLICS_VALIDATOR_ERROR_EXIT_CODE);
         }
-                
+
         //copy any options into an array for passing to the constructor as a vararg
         String [] options = new String[args.length-3];
         for (int i=3; i<args.length; i++) {
             options[i-3] = args[i];
         }
-        
+
         ClicsValidator validator = null;
         try {
             validator = new ClicsValidator(args[0], args[1], args[2], options);
@@ -903,13 +906,13 @@ public class ClicsValidator {
             e.printStackTrace();
             System.exit (CLICS_VALIDATOR_ERROR_EXIT_CODE);
         }
-        
+
         int result = validator.validate();
-                
+
         System.out.println ("Exiting Clics Validator main() with exit code " + result);
-        
+
         System.exit(result);
-        
+
     }
 
     public static void usage() {
@@ -921,7 +924,7 @@ public class ClicsValidator {
         System.err.println ("    " + ClicsValidatorSettings.CLICS_VTOKEN_SPACE_CHANGE_SENSITIVE);
         System.err.println ("    " + ClicsValidatorSettings.CLICS_VTOKEN_FLOAT_ABSOLUTE_TOLERANCE + " E");
         System.err.println ("    " + ClicsValidatorSettings.CLICS_VTOKEN_FLOAT_RELATIVE_TOLERANCE + " E");
-        System.err.println ("    float_tolerance E   (shorthand for setting both absolute and relative tolerance)");  
+        System.err.println ("    float_tolerance E   (shorthand for setting both absolute and relative tolerance)");
         System.err.println ("    <judgementResultsFileBaseName> -- the base name of the files in the specified feedbackdir to which judgement results are written ");
         System.err.println ("\n    where E is a float number in either decimal or scientific notation.");
         System.err.println ("\n If the optional <judgementResultsBaseFileName> is specified, then judgement feedback is written to a file of that name with "


### PR DESCRIPTION
### Description of what the PR does
This was a fix to accommodate WF and NAC rules of only returning "_Wrong Answer_" on things such as _Incomplete output_, Excessive _output_ and _Output format error_.  Before this patch, the actual details of the validator were returned to the user causing confusion (IE "_Incomplete Output_" instead of "_Wrong Answer_").  A more permanent and configurable fix is needed for this.  This patch was successfully used at NAC2025.

### Issue which the PR addresses
Partial fix for #604 
This is more of a temporary fix until we rework the way the internal CLICS validator maps error returns.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ubuntu 24.04
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
This patch was already tested at NAC2025.
**Note that only one file changed and there are 100's of differences.  Just about all of them are related to extra spaces on lines.  The only lines of interest are: 1 and 101-106 where 3 lines were commented out and 3 lines added to replace them.
To not show white space differences in the git web interface:
On the **Files Changed** tab, select the gear icon next to **Jump To**
Click the **Hide whitespace** check box.
Press the **Apply and reload** button
**
<img width="575" alt="image" src="https://github.com/user-attachments/assets/39abc824-2e3b-431c-b231-8e366f832a94" />

1. Start a contest such as sumithello
2. Configure one of the problems to use the built-in CLICS validator
3. Start an autojudge that judges the problems in the contest
4. Start the WTI
5. Make a submission that generates excessive output using the WTI
6. Notice the judgment producedand returned to team client.  It should say _Wrong answer_ as opposed to _Excessive output_.

## Additional note to testers
If you test using the PC2 code prior to this PR fix being applied and you use the "sumithello" contest and submit a program which produces excessive output for the "hello" problem, you will get a "Wrong Answer" response (not "Excessive Output").  This is due to an issue with the way the CLICS Validator handles the "hello.ans" file associated with the "sumithello" sample contest, the result of which is that submitting a program that produces "excessive output" will actually return a "Wrong Answer" result (a separate issue will be filed for that).  A recommended test, if you are trying to verify the existence of the issue prior to verifying that the PR fixes the issue, is to submit a program that generates "incomplete output" (for example, a modified version of the samps/src/hello.java program which writes its output to stderr instead of stdout).  With the previous PC2 code, this should produce an "Incomplete Output" result, whereas with the code with the PR included it should produce "Wrong Answer".  
