### PR TITLE
i_1135 fix WTI package build for correct zip/gz file names

### DIFF
--- a/projects/WTI-API/packageWTI.xml
+++ b/projects/WTI-API/packageWTI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<project name="package-WTI" default="archives" basedir=".">
+<project name="package-WTI" default="archives" basedir="." xmlns:if="ant:if" xmlns:unless="ant:unless" >
 	
     <property environment="env"/>
     <condition property="exists.GITHUB_RUN_NUMBER">
@@ -66,16 +66,33 @@
 	</target>
 
     <target name="-execgit" unless="exists.GITHUB_RUN_NUMBER">
-        <exec executable="git" outputproperty="repo.version" failifexecutionfails="false" errorproperty="">
+        <!-- make sure git_hash is set, this will probably always be HEAD for this non-github target -->
+        <condition property="git_hash" value="${env.GIT_COMMIT}" else="HEAD" >
+            <isset property="env.GIT_COMMIT"/>
+        </condition>
+        <exec executable="git" outputproperty="repo.version1" failifexecutionfails="false" errorproperty="genv.error">
             <arg value="rev-list"/>
             <arg value="${git_hash}"/>
             <arg value="--count"/>
         </exec>
-        <!-- if above failed, set the repo.version to 0 -->
-        <condition property="repo.version" value="0">
+        <!-- genv.error wont be set if the exec failed so set it to empty -->
+        <condition property="genv.error" value="" >
             <not>
-               <isset property="repo.version"/>
+                <isset property="genv.error" />
             </not>
+        </condition>
+        <!-- Show error, for example, if there are git errors, bad hash, credentials, etc. -->
+        <echo unless:blank="${genv.error}" message="Git Error: ${genv.error}" />
+        
+        <!-- if above exec failed, set the repo.version to 0 -->
+        <!-- note that if the git fails, repo.version1 will likely be set to "" -->
+        <condition property="repo.version" value="0" else="${repo.version1}" >
+            <or>
+                <not>
+                    <isset property="repo.version1"/>
+                </not>
+                <equals arg1="${repo.version1}" arg2="" />
+            </or>
         </condition>
     </target>
     <target name="-getenv" if="exists.GITHUB_RUN_NUMBER">
@@ -84,7 +101,15 @@
 TODO consider switching back to this at 9.8.0/9.9build
         <property name="repo.version0" value="${env.GITHUB_RUN_NUMBER}"/>
 -->
-        <condition property="version.add" value="~${env.GITHUB_REF_NAME}" else="">
+        <!-- PRs have pr#/merge as the GITHUB_REF_NAME, use GITHUB_HEAD_REF instead -->
+        <condition property="version.add0" value="pr${env.GITHUB_HEAD_REF}" else="${env.GITHUB_REF_NAME}">
+            <and>
+                <isset property="env.GITHUB_HEAD_REF" />
+                <matches string="${env.GITHUB_REF_NAME}" pattern="^.+/merge$$" />
+            </and>
+        </condition>
+
+        <condition property="version.add" value="~${version.add0}" else="">
            <not>
                <equals arg1="${env.GITHUB_REF_NAME}" arg2="master"/>
            </not>


### PR DESCRIPTION
### Description of what the PR does
Distribution files for the WTI were improperly named for local (non-github) builds and for PR triggered workflow builds.
For non-github package builds, the WTI project distribution files are now named:
`WebTeamInterface-1.2-7784.zip` and `WebTeamInterface-1.2-7784.tar.gz` instead of
`WebTeamInterface-1.2-.zip` and `WebTeamInterface-1.2-.tar.gz`
In addition, for github PR triggered workflow builds, the distribution files are now in the project's `dist `folder named
`WebTeamInterface-1.2-7784~pri1135_fix_pr_build_artifacts.zip` and` WebTeamInterface-1.2-7784~pri1135_fix_pr_build_artifacts.tar.gz` instead of
`WebTeamInterface-1.2-7784~1136/merge.zip` and `WebTeamInterface-1.2-7784~1136/merge.tar.gz`

This _should_ also have the side effect of including the `projects/WebTeamInterface-1.2-7784~~pri1135_fix_pr_build_artifacts.zip` in the Github workflow artifact `build.zip` file.  Previously it was not included since it was named improperly (`merge.zip`) in a subfolder.


### Issue which the PR addresses
Fixes #1135 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ant 1.10.12
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Perform a package build from Eclipse.
2. Check the `projects/dist` folder and verify the name of the WebTeamInterface zip and gz files are as described above.
3. Check the `dist/pc2-9.11build-XXXX.zip` file and see that it contains `projects/WebTeamInterface-1.2-XXXX.zip`

To check the Github artifacts, find the Workflow run for this PR and examine the `merge.zip` artifact it produced.  It should contain a `pc2-9.11build-7261~1136/merge.zip/pc2-9.11build/projects/WebTeamInterface-1.2-7261~pri1135_fix_pr_build_artifacts.zip` WTI installation zip.

Note: these changes should NOT affect the nomenclature for develop and master merges.