### PR TITLE
i_1091 format contest_time correctly for long contests

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202003/JSONTool.java
+++ b/src/edu/csus/ecs/pc2/clics/API202003/JSONTool.java
@@ -175,12 +175,12 @@ public class JSONTool implements IJSONTool {
             element.put("text", clarificationAnswers[lastAnswer].getAnswer());
             String time = Utilities.getIso8601formatterWithMS().format(clarificationAnswers[lastAnswer].getDate());
             element.put("time", time);
-            element.put("contest_time", ContestTime.formatTimeMS(clarificationAnswers[lastAnswer].getElapsedMS()));
+            element.put("contest_time", Utilities.formatDuration(clarificationAnswers[lastAnswer].getElapsedMS()));
         } else {
             element.put("text", clarification.getQuestion());
             String time = Utilities.getIso8601formatterWithMS().format(clarification.getCreateDate());
             element.put("time", time);
-            element.put("contest_time", ContestTime.formatTimeMS(clarification.getElapsedMS()));
+            element.put("contest_time", Utilities.formatDuration(clarification.getElapsedMS()));
         }
         return element;
     }
@@ -417,7 +417,7 @@ public class JSONTool implements IJSONTool {
         element.put("submission_id", IJSONTool.getSubmissionId(submission));
         // SOMEDAY this is suppose to be when the judge retrieves it, not the submission time.
         element.put("start_time", Utilities.getIso8601formatterWithMS().format(submission.getCreateDate()));
-        element.put("start_contest_time", ContestTime.formatTimeMS(submission.getElapsedMS()));
+        element.put("start_contest_time", Utilities.formatDuration(submission.getElapsedMS()));
         if (submission.isJudged()) {
 
             JudgementRecord judgementRecord = submission.getJudgementRecord();
@@ -434,7 +434,7 @@ public class JSONTool implements IJSONTool {
                     element.put("end_time", Utilities.getIso8601formatter().format(wallElapsed.getTime()));
                 } // is null if there are no elapsedMinutes in the contest
                   // when judged is in minutes convert to milliseconds
-                element.put("end_contest_time", ContestTime.formatTimeMS(judgementRecord.getWhenJudgedTime() * 60000));
+                element.put("end_contest_time", Utilities.formatDuration(judgementRecord.getWhenJudgedTime() * 60000));
             }
         }
 
@@ -471,7 +471,7 @@ public class JSONTool implements IJSONTool {
         // SOMEDAY get the time from the server instead of the judge
         element.put("time", Utilities.getIso8601formatterWithMS().format(run.getDate().getTime()));
         // note this is the contest_time as seen on the judge
-        element.put("contest_time", ContestTime.formatTimeMS(run.getContestTimeMS()));
+        element.put("contest_time", Utilities.formatDuration(run.getContestTimeMS()));
         return element;
     }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSClarification.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSClarification.java
@@ -13,7 +13,6 @@ import edu.csus.ecs.pc2.core.model.Clarification;
 import edu.csus.ecs.pc2.core.model.ClarificationAnswer;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
-import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.ElementId;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -161,13 +160,13 @@ public class CLICSClarification {
             }
             text = clarAns.getAnswer();
             time = Utilities.getIso8601formatterWithMS().format(clarAns.getDate());
-            contest_time = ContestTime.formatTimeMS(clarAns.getElapsedMS());
+            contest_time = Utilities.formatDuration(clarAns.getElapsedMS());
         } else {
             // the request goes to a judge not a team, so to_team_id and reply_to_id is null
             // fill in question and time fields
             text = clar.getQuestion();
             time = Utilities.getIso8601formatterWithMS().format(clar.getCreateDate());
-            contest_time = ContestTime.formatTimeMS(clar.getElapsedMS());
+            contest_time = Utilities.formatDuration(clar.getElapsedMS());
         }
         // if not a general clar and it's not a special category clar, then we need to supply the problem id.
         if (!clar.getProblemId().equals(model.getGeneralProblem().getElementId()) && model.getCategory(clar.getProblemId()) == null) {

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSCommentary.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSCommentary.java
@@ -88,7 +88,7 @@ public class CLICSCommentary {
         ContestInformation ci = model.getContestInformation();
         ContestTime ct = model.getContestTime();
         if (ct.isContestStarted()) {
-            contest_time = ContestTime.formatTimeMS(ct.getElapsedMS());
+            contest_time = Utilities.formatDuration(ct.getElapsedMS());
         } else {
             contest_time = getScheduledTimeClockText(ci);
         }

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestState.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestState.java
@@ -91,7 +91,7 @@ public class CLICSContestState {
                 }
             }
 
-            contest_time = ContestTime.formatTimeMS(ct.getElapsedMS());
+            contest_time = Utilities.formatDuration(ct.getElapsedMS());
             if(ct.isContestRunning() == false) {
                 if(ended == null) {
                     // This means the contest was paused - can't pause a contest if it is ended... so ended must be null

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSJudgement.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSJudgement.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
-import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.JudgementRecord;
 import edu.csus.ecs.pc2.core.model.Run;
@@ -115,10 +114,10 @@ public class CLICSJudgement {
                 } else {
                     contestStartDate = contestStartTime.getTime();
                 }
-                start_contest_time = ContestTime.formatTimeMS(judgeDate.getTime() - contestStartDate.getTime());
+                start_contest_time = Utilities.formatDuration(judgeDate.getTime() - contestStartDate.getTime());
 
                 end_time = Utilities.getIso8601formatterWithMS().format(judgementRecord.getDate());
-                end_contest_time = ContestTime.formatTimeMS(judgementRecord.getDate().getTime() - contestStartDate.getTime());
+                end_contest_time = Utilities.formatDuration(judgementRecord.getDate().getTime() - contestStartDate.getTime());
                 max_run_time = (judgementRecord.getExecuteMS())/1000.;
             } else {
                 // Filter out max_run_time from serialization
@@ -126,7 +125,7 @@ public class CLICSJudgement {
             }
         } else if(startJudgeDate != null) {
             start_time = Utilities.getIso8601formatterWithMS().format(startJudgeDate);
-            start_contest_time = ContestTime.formatTimeMS(startJudgeDate.getTime() - model.getContestTime().getContestStartTime().getTime().getTime());
+            start_contest_time = Utilities.formatDuration(startJudgeDate.getTime() - model.getContestTime().getContestStartTime().getTime().getTime());
         }
         // else not much to do here if no start date.
     }

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSTestCase.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSTestCase.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.csus.ecs.pc2.core.Utilities;
-import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.RunTestCase;
 import edu.csus.ecs.pc2.core.util.IJSONTool;
@@ -59,7 +58,7 @@ public class CLICSTestCase {
         // SOMEDAY get the time from the server instead of the judge
         time = Utilities.getIso8601formatterWithMS().format(testCase.getDate().getTime());
         // note this is the contest_time as seen on the judge
-        contest_time = ContestTime.formatTimeMS(testCase.getContestTimeMS());
+        contest_time = Utilities.formatDuration(testCase.getContestTimeMS());
         run_time = (testCase.getElapsedMS())/1000.;
     }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/ClarificationService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ClarificationService.java
@@ -37,7 +37,6 @@ import edu.csus.ecs.pc2.core.model.ClarificationAnswer;
 import edu.csus.ecs.pc2.core.model.ClarificationEvent;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
-import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.ElementId;
 import edu.csus.ecs.pc2.core.model.IClarificationListener;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -319,11 +318,11 @@ public class ClarificationService implements Feature {
                 if(clarificationAnswer != null) {
                     clar.setId(clarificationAnswer.getElementId().toString());
                     clar.setTime(Utilities.getIso8601formatterWithMS().format(clarificationAnswer.getDate()));
-                    clar.setContest_time(ContestTime.formatTimeMS(clarificationAnswer.getElapsedMS()));
+                    clar.setContest_time(Utilities.formatDuration(clarificationAnswer.getElapsedMS()));
                 } else {
                     clar.setId(clarResponse.getElementId().toString());
                     clar.setTime(Utilities.getIso8601formatterWithMS().format(clarResponse.getCreateDate()));
-                    clar.setContest_time(ContestTime.formatTimeMS(clarResponse.getElapsedMS()));
+                    clar.setContest_time(Utilities.formatDuration(clarResponse.getElapsedMS()));
                 }
                 try {
                     ObjectMapper mapper = JSONUtilities.getObjectMapper();


### PR DESCRIPTION
### Description of what the PR does
For some CLICS API endpoints (and notifications), `contest_time`'s were formatted to `HH:MM:SS.sss`, forcing the hours field to only be 2 digits (the hour within the day).  This is because `ContestTime.formatMS()` was used, when `Utilities.formatDuration() `should have been used.  All `contest_time `fields should be formatted using `formatDuration()`.  This commit makes those changes.

### Issue which the PR addresses
Fixes #1091 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ubuntu 24.04
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Load up a contest that spans more than 24 hours, such as the [GNY2024-Practice[.zip]](https://drive.google.com/file/d/12-_skc0PWhii1Yt52CfVEVQ5IddsDlHe/view?usp=drive_link) on the Sysops Drive.
2. Start a feeder1 event feed client
3. Start feeding the 2023-06 feed in the feeder client
4. Using a web browser, navigate to: [https://administrator1:administrator1@localhost:50443/contests/Default-2163315106932261855/state](https://administrator1:administrator1@localhost:50443/contests/Default-2163315106932261855/state)
5. Note the contest_time has a value for hours > 23.

```
{
"started": "2024-10-26T21:40:00.002-04",
"frozen": "2024-11-09T09:57:24.002-05",
"ended": "2024-11-09T09:58:24.002-05",
"thawed": null,
"finalized": null,
"end_of_updates": null,
"paused": null,
"resumed": "2024-11-09T09:23:27.796-05",
"contest_time": "325:18:24.656"
}
```
6. In the browser, navigate to the judgements endpoint: [https://administrator1:administrator1@localhost:50443/contests/Default-2163315106932261855/judgements](https://administrator1:administrator1@localhost:50443/contests/Default-2163315106932261855/judgements)
7. Observe some of the `start_contest_time` and `end_contest_time `fields and notice there are some > 23 hours:
```
{
"id": "Run--7067397102623678313",
"submission_id": "248",
"judgement_type_id": "WA",
"start_time": "2024-11-08T19:27:08.950-05",
"start_contest_time": "310:47:08.948",
"end_time": "2024-11-08T19:27:11.177-05",
"end_contest_time": "310:47:11.175",
"max_run_time": 0.084
},
{
"id": "Run--8101016784925030103",
"submission_id": "265",
"judgement_type_id": "CE",
"start_time": "2024-11-08T23:22:26.169-05",
"start_contest_time": "314:42:26.167",
"end_time": "2024-11-08T23:22:27.001-05",
"end_contest_time": "314:42:26.999",
"max_run_time": 0
},
```
