### PR TITLE
i_1122 Create a catalog file during execution

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2770,7 +2770,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             // create submission catalog file
             BufferedWriter catlog = new BufferedWriter(new FileWriter(prefixExecuteDirname(SOURCE_CATALOG_FILENAME)));
             if(runFiles != null) {
-                runFiles.createCatalogJSON(catlog);
+                runFiles.createCatalogJSON(catlog, log);
                 catlog.flush();
             }
             BufferedOutputStream stdoutlog = new BufferedOutputStream(new FileOutputStream(prefixExecuteDirname(COMPILER_STDOUT_FILENAME), false));

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -4,11 +4,13 @@ package edu.csus.ecs.pc2.core.execute;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.FileAlreadyExistsException;
@@ -161,6 +163,11 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
      * Validator stderr filename.
      */
     public static final String VALIDATOR_STDERR_FILENAME = "vstderr.pc2";
+
+    /**
+     * Information about the submission source file
+     */
+    public static final String SOURCE_CATALOG_FILENAME = "src_catalog.json";
 
     /**
      * The default limit (in seconds) for validation of a single run (test case) of a submission.
@@ -2760,6 +2767,12 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             String cmdline = substituteAllStrings(run, language.getCompileCommandLine());
             log.log(Log.DEBUG, "after  substitution: " + cmdline);
 
+            // create submission catalog file
+            BufferedWriter catlog = new BufferedWriter(new FileWriter(prefixExecuteDirname(SOURCE_CATALOG_FILENAME)));
+            if(runFiles != null) {
+                runFiles.createCatalogJSON(catlog);
+                catlog.flush();
+            }
             BufferedOutputStream stdoutlog = new BufferedOutputStream(new FileOutputStream(prefixExecuteDirname(COMPILER_STDOUT_FILENAME), false));
             BufferedOutputStream stderrlog = new BufferedOutputStream(new FileOutputStream(prefixExecuteDirname(COMPILER_STDERR_FILENAME), false));
 

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -2768,10 +2768,10 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             log.log(Log.DEBUG, "after  substitution: " + cmdline);
 
             // create submission catalog file
-            BufferedWriter catlog = new BufferedWriter(new FileWriter(prefixExecuteDirname(SOURCE_CATALOG_FILENAME)));
             if(runFiles != null) {
+                BufferedWriter catlog = new BufferedWriter(new FileWriter(prefixExecuteDirname(SOURCE_CATALOG_FILENAME)));
                 runFiles.createCatalogJSON(catlog, log);
-                catlog.flush();
+                catlog.close();
             }
             BufferedOutputStream stdoutlog = new BufferedOutputStream(new FileOutputStream(prefixExecuteDirname(COMPILER_STDOUT_FILENAME), false));
             BufferedOutputStream stderrlog = new BufferedOutputStream(new FileOutputStream(prefixExecuteDirname(COMPILER_STDERR_FILENAME), false));

--- a/src/edu/csus/ecs/pc2/core/model/RunFiles.java
+++ b/src/edu/csus/ecs/pc2/core/model/RunFiles.java
@@ -207,24 +207,27 @@ public class RunFiles implements Serializable {
             if(mainFile != null) {
                 catlog.newLine();
                 catlog.write(" {\"mainfile\":");
-                catlog.write(serializedFileToJSON(mainFile));
-                catlog.write(" }");
+                catlog.write(serializedFileInfoToJSON(mainFile));
+                catlog.write("}");
                 needComma = true;
             }
             if(otherFiles != null && otherFiles.length > 0) {
-                boolean needComma2 = false;
                 if(needComma) {
                     catlog.write(',');
                 }
                 catlog.newLine();
                 catlog.write(" {\"otherfiles\": {");
+                boolean needComma2 = false;
                 for(SerializedFile f : otherFiles) {
-                    if(needComma) {
+                    // one per line
+                    if(needComma2) {
                         catlog.write(',');
                         catlog.newLine();
                     }
+                    // indent
                     catlog.write("  ");
-                    catlog.write(serializedFileToJSON(f));
+                    catlog.write(serializedFileInfoToJSON(f));
+                    needComma2 = true;
                 }
                 catlog.newLine();
                 catlog.write(" }");
@@ -249,7 +252,7 @@ public class RunFiles implements Serializable {
      * @param f the serialized file
      * @return JSON string representation of the detailed info
      */
-    private String serializedFileToJSON(SerializedFile f) {
+    private String serializedFileInfoToJSON(SerializedFile f) {
         StringBuilder str = new StringBuilder();
 
         str.append('{');

--- a/src/edu/csus/ecs/pc2/core/model/RunFiles.java
+++ b/src/edu/csus/ecs/pc2/core/model/RunFiles.java
@@ -1,11 +1,13 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
  * The files that were submitted with a Run.
- * 
+ *
  * @see Run
  * @author pc2@ecs.csus.edu
  * @version $Id$
@@ -15,10 +17,10 @@ import java.io.Serializable;
 public class RunFiles implements Serializable {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7676377417419464772L;
-    
+
     private Submission submission = null;
 
     /**
@@ -37,7 +39,7 @@ public class RunFiles implements Serializable {
     private SerializedFile mainFile;
 
     /**
-     * 
+     *
      */
     private SerializedFile[] otherFiles;
 
@@ -51,7 +53,7 @@ public class RunFiles implements Serializable {
         this.mainFile = new SerializedFile(filename);
         this.submission = run;
     }
-    
+
     /**
      * @param run
      * @param filename
@@ -62,7 +64,7 @@ public class RunFiles implements Serializable {
         this.mainFile = new SerializedFile(iFile);
         this.submission = run;
     }
-    
+
     public RunFiles(Run run, IFile mainFile, IFile[] auxFiles) {
         super();
         this.runId = run.getElementId();
@@ -72,7 +74,7 @@ public class RunFiles implements Serializable {
     }
 
     private SerializedFile[] createArray(IFile[] auxFiles) {
-        
+
         SerializedFile[] outArray = new SerializedFile[auxFiles.length];
         for (int i = 0; i < auxFiles.length; i++) {
             outArray[i] = new SerializedFile(auxFiles[i]);
@@ -95,7 +97,7 @@ public class RunFiles implements Serializable {
 
     /**
      * Unique identifier for this class.
-     * 
+     *
      * @return Returns the elementId.
      */
     public ElementId getElementId() {
@@ -122,15 +124,15 @@ public class RunFiles implements Serializable {
     public ElementId getRunId() {
         return runId;
     }
-    
+
     public void setSubmission(Submission submission) {
         this.submission = submission;
     }
-    
+
     public Submission getSubmission() {
         return submission;
     }
-    
+
     /**
      * Returns a String representation of this RunFiles object consisting of a list of the names of the files in the RunFiles object.
      * The returned string is in JSON format: an array containing two elements:  the MainFile and a sub-array containing the OtherFiles (if any;
@@ -139,9 +141,9 @@ public class RunFiles implements Serializable {
     @Override
     public String toString() {
         String retStr = "";
-        
+
         retStr += "[" + "\"MainFile\"" + ":" + "\"";
-        
+
         if (getMainFile()!=null) {
             String mainFileName = getMainFile().getName();
             if (mainFileName!=null) {
@@ -152,11 +154,11 @@ public class RunFiles implements Serializable {
         } else {
             retStr += "null";
         }
-        
+
         retStr += "\",";
-        
+
         retStr += "\"OtherFiles\":[" ;
-        
+
         if (getOtherFiles()!=null) {
             if (getOtherFiles().length>0) {
                 boolean first = true;
@@ -178,16 +180,89 @@ public class RunFiles implements Serializable {
                 }
 
             }
-            
-        } 
+
+        }
         //close OtherFiles list
-        retStr += "]";  
-        
+        retStr += "]";
+
         //close retStr object
         retStr += "]";
-        
+
         return retStr ;
-        
+
     }
 
+    /**
+     * createCatalogJSON - Generate detailed JSON information about the files submitted and it to the
+     * supplied BufferedWriter.  Similar to toString above, but supplies more details.
+     *
+     * @param catlog Where to send the detailed JSON about the submission files
+     */
+    public void createCatalogJSON(BufferedWriter catlog) {
+        try {
+            boolean needComma = false;
+            catlog.write("[");
+            if(mainFile != null) {
+                catlog.newLine();
+                catlog.write(" {\"mainfile\":");
+                catlog.write(serializedFileToJSON(mainFile));
+                catlog.write(" }");
+                needComma = true;
+            }
+            if(otherFiles != null && otherFiles.length > 0) {
+                boolean needComma2 = false;
+                if(needComma) {
+                    catlog.write(',');
+                }
+                catlog.newLine();
+                catlog.write(" {\"otherfiles\": {");
+                for(SerializedFile f : otherFiles) {
+                    if(needComma) {
+                        catlog.write(',');
+                        catlog.newLine();
+                    }
+                    catlog.write("  ");
+                    catlog.write(serializedFileToJSON(f));
+                }
+                catlog.newLine();
+                catlog.write(" }");
+                // in case we add more stuff to the array later
+                needComma = true;
+            }
+            catlog.write(']');
+            catlog.newLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    /**
+     * serializedFileToJSON - pick out the detailed info we want from the SerializedFile
+     *     and create a JSON string.  Ex.
+     *     { "absolutePath":"C:/home/icpc/pc2/current/config/atotientquotient/submissions/time_limit_exceeded/evouga-brute.cpp",
+     *       "name":"evouga-brute.cpp",
+     *       "fileType":2,
+     *       "externalFile":false
+     *     }
+     * @param f the serialized file
+     * @return JSON string representation of the detailed info
+     */
+    private String serializedFileToJSON(SerializedFile f) {
+        StringBuilder str = new StringBuilder();
+
+        str.append('{');
+        if(f != null) {
+            str.append("\"absolutePath\":\"");
+            str.append(f.getAbsolutePath().replace('\\', '/'));
+            str.append("\",\"name\":\"");
+            str.append(f.getName());
+            str.append("\",\"fileType\":");
+            str.append(f.getFileType());
+            str.append(",\"externalFile\":");
+            str.append(f.isExternalFile());
+        }
+        str.append('}');
+        return(str.toString());
+    }
 }

--- a/src/edu/csus/ecs/pc2/core/model/RunFiles.java
+++ b/src/edu/csus/ecs/pc2/core/model/RunFiles.java
@@ -5,6 +5,8 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Serializable;
 
+import edu.csus.ecs.pc2.core.log.Log;
+
 /**
  * The files that were submitted with a Run.
  *
@@ -193,12 +195,12 @@ public class RunFiles implements Serializable {
     }
 
     /**
-     * createCatalogJSON - Generate detailed JSON information about the files submitted and it to the
+     * createCatalogJSON - Generate detailed JSON information about the files submitted and write it to the
      * supplied BufferedWriter.  Similar to toString above, but supplies more details.
      *
      * @param catlog Where to send the detailed JSON about the submission files
      */
-    public void createCatalogJSON(BufferedWriter catlog) {
+    public void createCatalogJSON(BufferedWriter catlog, Log log) {
         try {
             boolean needComma = false;
             catlog.write("[");
@@ -232,9 +234,8 @@ public class RunFiles implements Serializable {
             catlog.write(']');
             catlog.newLine();
         } catch (IOException e) {
-            e.printStackTrace();
+            log.log(Log.WARNING, "Exception writing RunFiles catalog file for run " + getRunId().toString(), e);
         }
-
     }
 
     /**


### PR DESCRIPTION
### Description of what the PR does
The `src_catalog.json` file contains details about the contestant's source code, such as the original full path of the submission, whether the file is stored externally, etc. This is useful for generating specific web pages for the judge's submissions.  For example, one can look at the full path of the submission source and see if it's from the CDP (for example); if so, then we know they're judge's sample submissions.  

### Issue which the PR addresses
Fixes #1122 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Load a contest that has sample submissions from the judges in the CDP (ex. **NAC2025**)
2. Make sure the `pc2v9.ini` file has the `[admin].sampleSubmitPane` key set to true.  This will make the **Submit Samples** tab show up on the administrator's **Run Contest** tab.
3. Start the server.
4. Start an administrator.
5. Start the autojudges.
6. Start the contest.
7. Using the **Submit Samples** tab, filter by a single problem or two (so you don't have to wait for the system to judge all the judge's submissions.
8. Submit the judge's submissions and wait for them to be judged.
9. Look in the execute folder for one or more of the judgments (The execute folder will be named something like: `ex_6_A_atotientquotient_1_cpp_judge1`) for a file with the name `src_catalog.json`
10. It should contain detailed information about source file(s) for the submission.

