### PR TITLE
i_1006 Adjust JUnits for new TestDataGroups

### DIFF
--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -2783,7 +2783,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
     @Override
     public String getCCSDataFileDirectory(String yamlDirectory, String shortDirName) {
-        return yamlDirectory + File.separator + shortDirName + File.separator + "data" + File.separator + "secret";
+        return yamlDirectory + File.separator + shortDirName + File.separator + "data";
     }
 
     @Override

--- a/test/edu/csus/ecs/pc2/convert/LoadRunsTest.java
+++ b/test/edu/csus/ecs/pc2/convert/LoadRunsTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.convert;
 
 import java.io.File;
@@ -40,7 +40,7 @@ import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 
 /**
  * Unit Tests.
- * 
+ *
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
 public class LoadRunsTest extends AbstractTestCase {
@@ -55,6 +55,12 @@ public class LoadRunsTest extends AbstractTestCase {
 
     public LoadRunsTest(String name) {
         super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
     }
 
     public void testLoadCDP() throws Exception {
@@ -89,7 +95,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Load contest from contest.yaml.
-     * 
+     *
      * @param contest
      * @param configDir
      * @return
@@ -112,7 +118,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Test loading runs and EF runs content.
-     * 
+     *
      * @throws Exception
      */
     public void testLoadEFRuns() throws Exception {
@@ -164,7 +170,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Load contest runs based on yaml.
-     * 
+     *
      * @throws Exception
      */
     public void testLoadContestRuns() throws Exception {
@@ -235,7 +241,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Compare event feeds.
-     * 
+     *
      * @param inputEventFeed
      * @param outputEventFeedFilename
      * @throws ParserConfigurationException
@@ -338,7 +344,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Test loading runs into model but not from yaml.
-     * 
+     *
      * @throws Exception
      */
     public void testLoadRuns() throws Exception {
@@ -458,7 +464,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Load groups.tsv and teams.tsv files.
-     * 
+     *
      * @param contest
      * @param dir
      * @throws Exception
@@ -495,7 +501,7 @@ public class LoadRunsTest extends AbstractTestCase {
             /**
              * Update Groups
              */
-            Group[] updatedGroups = (Group[]) groupList.toArray(new Group[groupList.size()]);
+            Group[] updatedGroups = groupList.toArray(new Group[groupList.size()]);
             for (Group group : updatedGroups) {
                 // getController().updateGroup(group);
                 contest.updateGroup(group);
@@ -504,7 +510,7 @@ public class LoadRunsTest extends AbstractTestCase {
             /**
              * UpdateAccounts
              */
-            Account[] updatedAccounts = (Account[]) accountList.toArray(new Account[accountList.size()]);
+            Account[] updatedAccounts = accountList.toArray(new Account[accountList.size()]);
             // getController().updateAccounts(updatedAccounts);
             for (Account account : updatedAccounts) {
                 contest.updateAccount(account);
@@ -514,7 +520,7 @@ public class LoadRunsTest extends AbstractTestCase {
 
     /**
      * Lookup group by externalId
-     * 
+     *
      * @param contest2
      * @param externalId
      * @return

--- a/test/edu/csus/ecs/pc2/core/UtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/UtilitiesTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.File;
@@ -24,6 +24,12 @@ import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
  * Unit test.
  */
 public class UtilitiesTest extends AbstractTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
 
     public void testOne() {
         char[] array1 = null;
@@ -203,7 +209,7 @@ public class UtilitiesTest extends AbstractTestCase {
     }
 
     /**
-     * 
+     *
      * @throws Exception
      */
     public void testvalidateCDP() throws Exception {
@@ -220,7 +226,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
         // ContestYAMLLoader loader = new ContestYAMLLoader();
         IContestLoader loader = new ContestSnakeYAMLLoader();
-        
+
         IInternalContest contest = loader.fromYaml(null, testDirectory);
 
         Problem[] problems = contest.getProblems();
@@ -260,7 +266,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
     /**
      * test
-     * 
+     *
      * @throws Exception
      */
     public void testTestLocateFile() throws Exception {
@@ -294,7 +300,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
     /**
      * Test java.util.Arrays.equals.
-     * 
+     *
      * @throws Exception
      */
     public void testArrayCompare() throws Exception {
@@ -322,15 +328,15 @@ public class UtilitiesTest extends AbstractTestCase {
         problemNumber = 26;
         actual = Utilities.getProblemLetter(problemNumber);
         assertEquals("Expect letter for " + problemNumber, "Z", actual);
-        
+
         problemNumber = 27;
         actual = Utilities.getProblemLetter(problemNumber);
         assertEquals("Expect letter for " + problemNumber, "AA", actual);
-        
+
         problemNumber = 28;
         actual = Utilities.getProblemLetter(problemNumber);
         assertEquals("Expect letter for " + problemNumber, "AB", actual);
-        
+
         problemNumber = 55;
         actual = Utilities.getProblemLetter(problemNumber);
         assertEquals("Expect letter for " + problemNumber, "BC", actual);
@@ -358,26 +364,26 @@ public class UtilitiesTest extends AbstractTestCase {
         expected = 0;
         assertEquals("Expeting number " + expected + " for problem " + probMissing, expected, actual2);
     }
-    
+
     public void testUnixify() throws Exception {
-        
+
         String input = ".\\testout\\ExportYAMLTest\\testOne\\sumit\\data\\secret\\sumit.dat";
         String expected = "./testout/ExportYAMLTest/testOne/sumit/data/secret/sumit.dat";
-        
+
         String actual = Utilities.unixifyPath(input);
-        
+
         assertEquals(expected, actual);
-        
-        
+
+
     }
-    
+
     /**
      * Test OS Type.
      */
     public void testGetGetOSType() {
-        
+
         OSType type = Utilities.getOSType();
-        
+
         switch (type) {
             case UNCLASSIFIED:
                 /**
@@ -385,32 +391,32 @@ public class UtilitiesTest extends AbstractTestCase {
                  */
                 fail ("Expecting OS Type to not be "+OSType.UNCLASSIFIED);
                 break;
-                
+
             case UNDEFINED:
                 /**
                  * OS type must not be undefined.
                  */
                 fail ("Expecting OS Type to not be "+OSType.UNDEFINED);
                 break;
-                
+
             default:
                 break;
         }
-        
+
         /**
          * Tests for when running unit test on Windows
          */
         debugPrint("OS Type is: "+type);
-        
+
 //        assertEquals("Windows", type.toString());
 //        assertEquals(OSType.WINDOWS, type);
-        
-        
+
+
     }
-    
+
     /**
      * Test for files that are considered executable.
-     * 
+     *
      * @throws Exception
      */
     public void testisExecutableExtension() throws Exception {
@@ -435,7 +441,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
     /**
      * Test for files that are not considered executable.
-     * 
+     *
      * @throws Exception
      */
     public void testTwo() throws Exception {
@@ -481,43 +487,43 @@ public class UtilitiesTest extends AbstractTestCase {
             assertEquals("Expected basename ", expected, actual);
         }
     }
-    
+
     /**
      * Test loadFile(String, long);
-     * 
+     *
      * @throws Exception
      */
     public void testloadFileWithNum() throws Exception {
-        
+
         String filename = "samps/pc2v9.ini";
-        
+
         int num = 10;
-        
+
         String[] lines = Utilities.loadFile(filename, num);
         assertEquals("Expecting "+num+" lines", num, lines.length);
-        
+
         num = 36;
         lines = Utilities.loadFile(filename, num);
         assertEquals("Expecting "+num+" lines", num, lines.length);
     }
-    
+
     /**
      * Test get data directory names.
-     * 
+     *
      * @throws Exception
      */
     public void testgetCDPDataDirectories() throws Exception {
         String dataFileBaseDirectory = "samps/contests/tenprobs/config";
         List<String> dataDirs = Utilities.getCDPDataDirectories(dataFileBaseDirectory);
         assertEquals("Expecting data dirs for under "+dataFileBaseDirectory, 10, dataDirs.size());
-        
+
         dataFileBaseDirectory = "samps/contests/sumithello/config";
         dataDirs = Utilities.getCDPDataDirectories(dataFileBaseDirectory);
         assertEquals("Expecting data dirs for under "+dataFileBaseDirectory, 2, dataDirs.size());
-        
-        
+
+
     }
-    
+
     /**
      * Test where both arrays are null.
      * @throws Exception
@@ -534,7 +540,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
     /**
      * Test where first array is null.
-     * 
+     *
      * @throws Exception
      */
     public void testCopyEmptyOneNull() throws Exception {
@@ -554,7 +560,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
     /**
      * Test where second array is null.
-     * 
+     *
      * @throws Exception
      */
     public void testCopyEmptyTwoNull() throws Exception {
@@ -586,7 +592,7 @@ public class UtilitiesTest extends AbstractTestCase {
 
     /**
      * Test copy non-empty arrays.
-     * 
+     *
      * @throws Exception
      */
     public void testCopyArrays() throws Exception {
@@ -621,26 +627,26 @@ public class UtilitiesTest extends AbstractTestCase {
 
     }
 
-    
-    
+
+
     public void testLocatingSampleFiles() throws Exception {
 
         IInternalContest contest = loadFullSampleContest(null, "mini");
         assertNotNull(contest);
-        
+
         ContestInformation info = contest.getContestInformation();
-        
+
         String judgeCDP = info.getJudgeCDPBasePath();
-        
+
         Problem[] problems = contest.getProblems();
-        
+
         int totFiles = 0;
         for (Problem problem : problems) {
             totFiles += problem.getNumberTestCases();
         }
-        
+
         assertEquals("Expecting total data and sample files",10, totFiles);
-        
+
         for (Problem problem : problems) {
 
             ProblemDataFiles problemDataFiles = contest.getProblemDataFile(problem);
@@ -653,7 +659,7 @@ public class UtilitiesTest extends AbstractTestCase {
             }
         }
     }
-    
+
     /**
      * Test whether fullJudgesDataFilenames finds data files, esp. samples.
      */

--- a/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
+++ b/test/edu/csus/ecs/pc2/core/execute/JudgementUtilitiesTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.util.List;
@@ -19,13 +19,20 @@ import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 
 /**
  * Unit test.
- * 
+ *
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
 public class JudgementUtilitiesTest extends AbstractTestCase {
-    
+
     private SampleContest sample = new SampleContest();
-//    
+
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
+
+    //
     public String getDefaultJudgementAcronym(IInternalContest contest){
 //        return contest.getJudgements()[1].getAcronym(); // CE
         return contest.getJudgements()[2].getAcronym(); // WA
@@ -33,75 +40,75 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
 
     /**
      * Test compile error.
-     * 
+     *
      * @throws Exception
      */
     public void testForCE() throws Exception {
 
         IInternalContest contest = createContest();
-        
+
         ExecutionData executionData = new ExecutionData();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         /**
          * Test Compilation error
          */
         executionData.setCompileSuccess(false);
         JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "Works for me");
-        
+
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals(Judgement.ACRONYM_COMPILATION_ERROR, judgmeent.getAcronym());
     }
-    
+
     /**
      * Test for execute.
-     * 
+     *
      * An exception is thrown during execute.
-     * 
+     *
      * @throws Exception
      */
     public void testForExec() throws Exception {
         IInternalContest contest = createContest();
-        
+
         ExecutionData executionData = new ExecutionData();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         /**
          * Test Execution Error
          */
         executionData.setCompileSuccess(true);
-        
+
         executionData.setExecutionException(new Exception("unit test M1"));
-        
+
         JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "Works for me");
-        
+
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
-        
+
         assertEquals(getDefaultJudgementAcronym(contest), judgmeent.getAcronym());
-        
+
         String expectedMessage = "Execption during execution unit test M1";
         assertEquals(expectedMessage, judgementRecord.getValidatorResultString());
     }
-    
+
     /**
      * Test for validator.
-     * 
+     *
      * Judgement matches judgement  in list.
-     * 
+     *
      * @throws Exception
      */
     public void testforValidatePositive() throws Exception {
         IInternalContest contest = createContest();
-        
+
         ExecutionData executionData = new ExecutionData();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         /**
          * Test compile ok, exec and validate not so much..
          */
@@ -111,30 +118,30 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
         Judgement judgement = contest.getJudgements()[4];
         String expected = judgement.getDisplayName();
         executionData.setValidationResults(expected);
-        
+
         JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, executionData.getValidationResults());
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals("WA2", judgmeent.getAcronym());
-        
+
         String expectedMessage = "You have no clue"; // this is the judgement!
         assertEquals(expectedMessage, judgementRecord.getValidatorResultString());
     }
-    
+
     /**
      * Test for validate.
-     * 
+     *
      * Where judgement does not match any contest judgement name.
      * @throws Exception
      */
     public void testforValidateNegative() throws Exception {
-        
+
         IInternalContest contest = createContest();
-        
+
         ExecutionData executionData = new ExecutionData();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         /**
          * Test compile ok, exec and validate not so much..
          */
@@ -144,62 +151,62 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
         Judgement judgement = contest.getJudgements()[4];
         String expected = judgement.getDisplayName();
         executionData.setValidationResults(expected);
-        
+
         JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "It's alright");
-        
+
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals(getDefaultJudgementAcronym(contest), judgmeent.getAcronym());
-        
+
         String expectedMessage = "Undetermined";
         assertEquals(expectedMessage, judgementRecord.getValidatorResultString());
 
     }
-    
+
     /**
      * Test when validate nor execute was successful.
-     * 
+     *
      * @throws Exception
      */
     public void testForNoExecuteNoValidate() throws Exception {
-        
+
         IInternalContest contest = createContest();
-        
+
         ExecutionData executionData = new ExecutionData();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         /**
          * Test compile ok, exec and validate not so much..
          */
         executionData.setCompileSuccess(true);
         executionData.setExecuteSucess(false);;
         executionData.setValidationSuccess(false);
-        
+
         JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "Works for me");
-        
+
         Judgement judgmeent = contest.getJudgement(judgementRecord.getJudgementId());
         assertEquals(getDefaultJudgementAcronym(contest), judgmeent.getAcronym());
-        
+
         String expectedMessage = "Undetermined";
         assertEquals(expectedMessage, judgementRecord.getValidatorResultString());
     }
-    
+
     /**
      * Test when judgement is Yes/solved.
-     * 
+     *
      * @throws Exception
      */
     public void testYes() throws Exception {
-        
-        
+
+
         IInternalContest contest = createContest();
-        
+
         ExecutionData executionData = new ExecutionData();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         /**
          * Test compile ok, exec and validate not so much..
          */
@@ -208,75 +215,75 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
         executionData.setValidationSuccess(true);
         Judgement judgement22 = contest.getJudgements()[0];
         executionData.setValidationResults("accepted");
-        
+
         JudgementRecord judgementRecord = JudgementUtilities.createJudgementRecord(contest, run, executionData, "accepted");
-        
+
         Judgement newJudgment = contest.getJudgement(judgementRecord.getJudgementId());
-        
+
         String expected = judgement22.getAcronym();
         String actual = newJudgment.getAcronym();
-        
+
         assertEquals(expected, actual);
-        
+
         String expectedMessage = "Yes.";
         assertEquals(expectedMessage, judgementRecord.getValidatorResultString());
 
     }
-    
+
 
     private IInternalContest createContest() {
         IInternalContest contest = sample.createStandardContest();
         return contest;
     }
-    
-    
+
+
     public void testgetLastTestCaseJudgementList() throws Exception {
 
         IInternalContest contest = createContest();
-        
+
         Run[] runs = sample.createRandomRuns(contest, 12, true, true, true);
         Run run = runs[0];
-        
+
         Judgement noJudgement = contest.getJudgements()[4];
-        
+
         Problem problem = contest.getProblem(run.getProblemId());
-        
+
         for (int i = 0; i < 8; i++) {
             problem.addTestCaseFilenames("sumit.dat", "sumit.ans");
         }
-        
+
         assertTrue("Expecting more than four test cases, got "+problem.getNumberTestCases(), problem.getNumberTestCases() > 4);
-        
+
         // Add all Yes judgements
         addAllTestCases(run, problem, sample.getYesJudgement(contest));
-        
+
         /**
          * Test case, base 1, to assign a NO judgement to.
          */
-        
+
         // add no judgement at test case 2
         addTestCases(run, problem, 2, noJudgement, sample.getYesJudgement(contest));
-        
+
         int noTestCaseNumber = 4;
         // Add all yes, except a No at noTestCaseNumber
         addTestCases(run, problem, noTestCaseNumber, noJudgement, sample.getYesJudgement(contest));
 
         List<Judgement> jList = JudgementUtilities.getLastTestCaseJudgementList(contest, run);
         assertNotNull (jList);
-        
+
         int tcn = problem.getNumberTestCases();
         assertEquals("test cases expected ", tcn, jList.size());
-        
+
         Judgement expectedNo = jList.get(noTestCaseNumber-1);
         assertEquals(noJudgement, expectedNo);
-        
+
         int yesCount = 0;
         for (Judgement judgement : jList) {
             if (Judgement.ACRONYM_ACCEPTED.equals(judgement.getAcronym())){
                 yesCount++;
             }
         }
-        
+
         assertEquals("Expected yes judgement count ", 7, yesCount);
     }
 
@@ -287,7 +294,7 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
      * @param judgement
      */
     private void addAllTestCases(Run run, Problem problem, Judgement judgement) {
-        
+
         for (int i = 0; i < problem.getNumberTestCases(); i++) {
             boolean passed = Judgement.ACRONYM_ACCEPTED.equals(judgement.getAcronym());
             ClientId judgerClientId = new ClientId(1, Type.JUDGE, 1);
@@ -295,12 +302,12 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
             RunTestCase runTestCaseResult = new RunTestCase(run, record, i, passed);
             run.addTestCase(runTestCaseResult);
         }
-        
+
     }
 
     /**
      * Add judgements to run, add single NO to list of judgements
-     * 
+     *
      * @param run
      * @param problem
      * @param testCaseNumberForNoJudgement test case number to assign judgement, base 1.
@@ -309,13 +316,13 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
      */
     private void addTestCases(Run run, Problem problem, int testCaseNumberForNoJudgement, Judgement noJudgement, Judgement yesJudgement) {
         for (int i = 0; i < problem.getNumberTestCases(); i++) {
-            
+
             Judgement judgement = yesJudgement;
-            
+
             if (i + 1 == testCaseNumberForNoJudgement){
                 judgement = noJudgement;
             }
-            
+
             boolean passed = Judgement.ACRONYM_ACCEPTED.equals(judgement.getAcronym());
             ClientId judgerClientId = new ClientId(1, Type.JUDGE, 1);
             JudgementRecord record  = new JudgementRecord(judgement.getElementId(), judgerClientId, passed, true);
@@ -326,9 +333,9 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
 
     /**
      * Test with sample contest/default judgements.
-     * 
+     *
      * By default will use the judgements from the current site (site number 3)
-     * 
+     *
      * @throws Exception
      */
     public void testgetSingleListofJudgements() throws Exception {
@@ -351,9 +358,9 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
 
     /**
      * Test to ensure that all judgements found are on site 1.
-     * 
+     *
      * When there are judgements from site 1, use those judgements.
-     * 
+     *
      * @throws Exception
      */
     public void testgetSingleListofJudgementsWithSite1Judgements() throws Exception {
@@ -426,7 +433,7 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
             addRunTestCase(contest, run, testCaseNum, acJudgement, judges[0].getClientId());
         }
         recs = JudgementUtilities.getLastTestCaseArray(contest, run);
-        
+
         assertEquals("Expected test cases ", 10, recs.length);
         // Add second set of test cases - all WA
         for (int testCaseNum = 1; testCaseNum <= problem.getNumberTestCases(); testCaseNum++) {
@@ -434,9 +441,9 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
         }
         assertEquals("Expected total test cases ", 20, run.getRunTestCases().length);
         recs = JudgementUtilities.getLastTestCaseArray(contest, run);
-        
+
         assertEquals("Expected test cases ", 10, recs.length);
-        
+
         // Test that all judgements are WA
         for (RunTestCase runTestCase : recs) {
             ElementId judgementId = runTestCase.getJudgementId();
@@ -485,5 +492,5 @@ public class JudgementUtilitiesTest extends AbstractTestCase {
         run.addTestCase(runTestCase);
     }
 
-    
+
 }

--- a/test/edu/csus/ecs/pc2/core/export/ExportYAMLTest.java
+++ b/test/edu/csus/ecs/pc2/core/export/ExportYAMLTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.export;
 
 import java.io.File;
@@ -30,6 +30,7 @@ public class ExportYAMLTest extends AbstractTestCase {
 
     @Override
     protected void setUp() throws Exception {
+        ensureStaticLog();
         super.setUp();
 
     }

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCDataTest.java
@@ -48,6 +48,7 @@ public class LoadICPCDataTest extends AbstractTestCase {
         accountList.generateNewAccounts(ClientType.Type.TEAM, 45 ,PasswordType.JOE, 1, true);
         accountList.generateNewAccounts(ClientType.Type.TEAM, 45 ,PasswordType.JOE, 2, true);
         ensureStaticLog();
+        super.setUp();
     }
 
     public void testOne() {

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCDataTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.imports;
 
 import java.io.File;
@@ -10,15 +10,14 @@ import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.Site;
+import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 import edu.csus.ecs.pc2.core.util.JUnitUtilities;
-
-import junit.framework.TestCase;
 
 /**
  * @author PC2
  *
  */
-public class LoadICPCDataTest extends TestCase {
+public class LoadICPCDataTest extends AbstractTestCase {
 
     private String loadDir = "testdata"+File.separator;
     private Site[] sites = new Site[2];
@@ -31,6 +30,7 @@ public class LoadICPCDataTest extends TestCase {
     public LoadICPCDataTest(String arg0) {
         super(arg0);
     }
+    @Override
     protected void setUp() throws Exception {
         String projectPath=JUnitUtilities.locate(loadDir);
         if (projectPath == null) {
@@ -47,6 +47,7 @@ public class LoadICPCDataTest extends TestCase {
         sites[1] = new Site("NORTH", 1);
         accountList.generateNewAccounts(ClientType.Type.TEAM, 45 ,PasswordType.JOE, 1, true);
         accountList.generateNewAccounts(ClientType.Type.TEAM, 45 ,PasswordType.JOE, 2, true);
+        ensureStaticLog();
     }
 
     public void testOne() {
@@ -92,7 +93,7 @@ public class LoadICPCDataTest extends TestCase {
                     break;
                 }
             }
-            
+
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue("exception", false);

--- a/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
+++ b/test/edu/csus/ecs/pc2/core/imports/LoadICPCTSVDataTest.java
@@ -27,6 +27,11 @@ import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 // $HeadURL$
 public class LoadICPCTSVDataTest extends AbstractTestCase {
 
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
 
     public void testCheckFiles() throws Exception {
         LoadICPCTSVData load = new LoadICPCTSVData();

--- a/test/edu/csus/ecs/pc2/exports/ccs/ResultsFileTest.java
+++ b/test/edu/csus/ecs/pc2/exports/ccs/ResultsFileTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.exports.ccs;
 
 import java.io.File;
@@ -15,7 +15,7 @@ import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 
 /**
  * Test ResultsFile class.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id: ResultsFileTest.java 193 2011-05-14 05:02:16Z laned $
  */
@@ -25,9 +25,15 @@ public class ResultsFileTest extends AbstractTestCase {
 
     private final boolean debugMode = false;
 
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
+
     /**
      * Sample Finalize Data.
-     * 
+     *
      * @param rank
      * @return
      */
@@ -57,33 +63,33 @@ public class ResultsFileTest extends AbstractTestCase {
 
     /**
      * Test for results file with no runs.
-     * 
+     *
      * @throws Exception
      */
     public void testcreateTSVFileLinesEmpty() throws Exception {
-        
+
         // If everybody solved 0 problems then they all should be Honorable
         String[] expectedResults = { //
-                "2020;;Honorable;0", // results 
-                "2021;;Honorable;0", // results 
-                "2022;;Honorable;0", // results 
-                "2023;;Honorable;0", // results 
-                "2024;;Honorable;0", // results 
-                "2025;;Honorable;0", // results 
-                "2026;;Honorable;0", // results 
-                "2027;;Honorable;0", // results 
-                "2028;;Honorable;0", // results 
-                "2029;;Honorable;0", // results 
-                "2030;;Honorable;0", // results 
-                "2031;;Honorable;0", // results 
-                "2032;;Honorable;0", // results 
-                "2033;;Honorable;0", // results 
-                "2034;;Honorable;0", // results 
-                "2035;;Honorable;0", // results 
-                "2036;;Honorable;0", // results 
-                "2037;;Honorable;0", // results 
-                "2038;;Honorable;0", // results 
-                "2039;;Honorable;0", // results 
+                "2020;;Honorable;0", // results
+                "2021;;Honorable;0", // results
+                "2022;;Honorable;0", // results
+                "2023;;Honorable;0", // results
+                "2024;;Honorable;0", // results
+                "2025;;Honorable;0", // results
+                "2026;;Honorable;0", // results
+                "2027;;Honorable;0", // results
+                "2028;;Honorable;0", // results
+                "2029;;Honorable;0", // results
+                "2030;;Honorable;0", // results
+                "2031;;Honorable;0", // results
+                "2032;;Honorable;0", // results
+                "2033;;Honorable;0", // results
+                "2034;;Honorable;0", // results
+                "2035;;Honorable;0", // results
+                "2036;;Honorable;0", // results
+                "2037;;Honorable;0", // results
+                "2038;;Honorable;0", // results
+                "2039;;Honorable;0", // results
         };
 
         ResultsFile resultsFile = new ResultsFile();
@@ -96,25 +102,25 @@ public class ResultsFileTest extends AbstractTestCase {
         IInternalContest contest = sample.createContest(1, 1, numTeams, 12, true);
 
         SampleContest.assignReservationIds(contest, 2020);
-        
+
         contest.setFinalizeData(finalizeData);
 
          String[] results = resultsFile.createTSVFileLines(contest); // using getStandingsRecords
 //        String[] results = resultsFile.createTSVFileLinesTwo(contest); // using XML
-         
+
         assertEquals("Number results file lines ", numTeams + 1, results.length);
 
         compareResults(results, expectedResults);
 
     }
-    
+
     /**
      * Bug 1156 - tests places
-     * 
+     *
      * Each team has its proper place (not individual rankings).
      */
     public void testPlaces() throws Exception {
-        
+
 
         String[] runsData = SampleContest.loadStringArrayFromCSV(getDataDirectory()+File.separator+"run_5_field.txt");
 
@@ -137,17 +143,17 @@ public class ResultsFileTest extends AbstractTestCase {
         if (judgements.length == 0) {
             // copied from InternalController.loadDefaultJudgements
             String[] judgementNames = { //
-                    "Yes", // 
-                    "No - Compilation Error", // 
-                    "No - Run-time Error", // 
-                    "No - Time Limit Exceeded", // 
-                    "No - Wrong Answer", // 
-                    "No - Excessive Output", // 
-                    "No - Output Format Error", // 
+                    "Yes", //
+                    "No - Compilation Error", //
+                    "No - Run-time Error", //
+                    "No - Time Limit Exceeded", //
+                    "No - Wrong Answer", //
+                    "No - Excessive Output", //
+                    "No - Output Format Error", //
                     "No - Other - Contact Staff" //
             };
             String [] judgementAcronyms = {
-                    Judgement.ACRONYM_ACCEPTED, // 
+                    Judgement.ACRONYM_ACCEPTED, //
                     Judgement.ACRONYM_COMPILATION_ERROR, //
                     Judgement.ACRONYM_RUN_TIME_ERROR, //
                     Judgement.ACRONYM_TIME_LIMIT_EXCEEDED, //
@@ -156,7 +162,7 @@ public class ResultsFileTest extends AbstractTestCase {
                     Judgement.ACRONYM_OUTPUT_FORMAT_ERROR, //
                     Judgement.ACRONYM_OTHER_CONTACT_STAFF, //
             };
-            
+
             int i = 0;
             for (String judgementName : judgementNames) {
                 Judgement judgement = new Judgement(judgementName, judgementAcronyms[i]);
@@ -166,7 +172,7 @@ public class ResultsFileTest extends AbstractTestCase {
         }
 
         addRuns(contest, runsData);
-        
+
         contest.setFinalizeData(finalizeData);
         ClientId clientId = new ClientId(1, Type.SCOREBOARD, 1);
         contest.setClientId(clientId);
@@ -177,15 +183,15 @@ public class ResultsFileTest extends AbstractTestCase {
 
             // printExpectedTestData(results);
         }
-        
+
         compareResults(results, expectedResults);
-    
-        
+
+
     }
 
     /**
      * Test with 27 or more runs.
-     * 
+     *
      * @throws Exception
      */
     public void testcreateTSVFileLinesComplex() throws Exception {
@@ -228,26 +234,26 @@ public class ResultsFileTest extends AbstractTestCase {
 
         // for medal ranks 4, 8, 12
         String[] expectedResults = { //
-                "2024;1;Gold Medal;2", // results 
-                "2031;2;Gold Medal;2", // results 
-                "2026;3;Gold Medal;2", // results 
-                "2038;4;Gold Medal;2", // results 
-                "2029;5;Silver Medal;1", // results 
-                "2020;6;Silver Medal;1", // results 
-                "2030;7;Silver Medal;1", // results 
-                "2021;8;Silver Medal;1", // results 
-                "2032;9;Bronze Medal;1", // results 
-                "2033;10;Bronze Medal;1", // results 
-                "2034;11;Bronze Medal;1", // results 
-                "2022;12;Bronze Medal;1", // results 
-                "2023;13;Ranked;1", // results 
-                "2025;;Honorable;0", // results 
-                "2027;;Honorable;0", // results 
-                "2028;;Honorable;0", // results 
-                "2035;;Honorable;0", // results 
-                "2036;;Honorable;0", // results 
-                "2037;;Honorable;0", // results 
-                "2039;;Honorable;0", // results 
+                "2024;1;Gold Medal;2", // results
+                "2031;2;Gold Medal;2", // results
+                "2026;3;Gold Medal;2", // results
+                "2038;4;Gold Medal;2", // results
+                "2029;5;Silver Medal;1", // results
+                "2020;6;Silver Medal;1", // results
+                "2030;7;Silver Medal;1", // results
+                "2021;8;Silver Medal;1", // results
+                "2032;9;Bronze Medal;1", // results
+                "2033;10;Bronze Medal;1", // results
+                "2034;11;Bronze Medal;1", // results
+                "2022;12;Bronze Medal;1", // results
+                "2023;13;Ranked;1", // results
+                "2025;;Honorable;0", // results
+                "2027;;Honorable;0", // results
+                "2028;;Honorable;0", // results
+                "2035;;Honorable;0", // results
+                "2036;;Honorable;0", // results
+                "2037;;Honorable;0", // results
+                "2039;;Honorable;0", // results
         };
 
         // for medal ranks 3, 6, 10
@@ -288,7 +294,7 @@ public class ResultsFileTest extends AbstractTestCase {
         SampleContest.assignReservationIds(contest, 2020);
 
         addRuns(contest, runsData);
-        
+
         contest.setFinalizeData(finalizeData);
 
         String[] results = resultsFile.createTSVFileLines(contest); // using getStandingsRecords
@@ -302,7 +308,7 @@ public class ResultsFileTest extends AbstractTestCase {
 
         compareResults(results, expectedResults);
     }
-    
+
     @SuppressWarnings("unused")
     private void printExpectedTestData(String[] expected) {
 
@@ -327,7 +333,7 @@ public class ResultsFileTest extends AbstractTestCase {
 
     /**
      * Compare results file info to expected info.
-     * 
+     *
      * @param results
      * @param expectedResults
      */

--- a/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoaderTest.java
@@ -88,6 +88,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
 
     @Override
     protected void setUp() throws Exception {
+        ensureStaticLog();
         super.setUp();
 
         // setDebugMode(true); // debug mode
@@ -1597,7 +1598,7 @@ public class ContestSnakeYAMLLoaderTest extends AbstractTestCase {
             loader.loadCCSProblemFiles(contest, secretDataDir, problem, problemDataFiles);
 
             assertTrue("Expecting more than one data set in " + secretDataDir, problemDataFiles.getJudgesDataFiles().length > 1);
-            assertTrue("Expecting more than on data set in " + secretDataDir, problemDataFiles.getJudgesAnswerFiles().length > 1);
+            assertTrue("Expecting more than one data set in " + secretDataDir, problemDataFiles.getJudgesAnswerFiles().length > 1);
         }
     }
 

--- a/test/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoaderTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoaderTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.imports.ccs;
 
 import java.io.File;
@@ -17,11 +17,17 @@ import edu.csus.ecs.pc2.core.util.AbstractTestCase;
 
 /**
  * Unit Test ICPCTSVLoader.
- * 
+ *
  */
 public class ICPCTSVLoaderTest extends AbstractTestCase {
 
     private boolean debugMode = false;
+
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
 
     private String findTestDataFile(String filename) throws IOException {
 
@@ -46,7 +52,7 @@ public class ICPCTSVLoaderTest extends AbstractTestCase {
 
     /**
      * Test load of groups and teams tsv files.
-     * 
+     *
      * @throws Exception
      */
     public void testLoad() throws Exception {
@@ -65,26 +71,26 @@ public class ICPCTSVLoaderTest extends AbstractTestCase {
 
         assertNotEquals("Missing InstituionCode", "", accounts[0].getInstitutionCode());
     }
-    
-    
+
+
     /**
      * Test 7th and 8th column for teams.tsv.
-     * 
-     * Bug 1229 
+     *
+     * Bug 1229
      * @throws Exception
      */
     public void testLoad78fields() throws Exception {
-        
+
         String configDir = getTestSampleContestDirectory("sumitMTC") + File.separator + IContestLoader.CONFIG_DIRNAME;
         assertDirectoryExists(configDir);
-        
+
 //        startExplorer(configDir);
 
         String groupFile = configDir + File.separator + "groups.tsv";
         String teamFileName = configDir + File.separator + "teams.tsv";
-        
+
 //        editFile(teamFileName);
-        
+
         ICPCTSVLoader.loadGroups(groupFile);
         Account[] accounts = ICPCTSVLoader.loadAccounts(teamFileName);
 
@@ -132,9 +138,9 @@ public class ICPCTSVLoaderTest extends AbstractTestCase {
 
     /**
      * Test load accounts.tsv with teamN login names.
-     * 
+     *
      * Bug 1241.
-     * 
+     *
      * @throws Exception
      */
     public void testTeamNumberfromAccountsTSVFile() throws Exception {
@@ -154,12 +160,12 @@ public class ICPCTSVLoaderTest extends AbstractTestCase {
 
         Vector<Account> va = contest.getAccounts(Type.TEAM);
         Account[] accounts =
-                (Account[]) va.toArray(new Account[va.size()]);
+                va.toArray(new Account[va.size()]);
 
         assertEquals("Expecting N accounts", 128, accounts.length);
 
         Arrays.sort(accounts, new AccountComparator());
-        
+
         for (int i = 1; i < accounts.length + 1; i++) {
             assertEquals("Expeting team number " + i, "team" + i, accounts[i - 1].getTeamName());
         }
@@ -168,7 +174,7 @@ public class ICPCTSVLoaderTest extends AbstractTestCase {
 
     /**
      * Load contest from contest.yaml.
-     * 
+     *
      * @param contest
      * @param configDir
      * @return

--- a/test/edu/csus/ecs/pc2/imports/ccs/TestDataGroupsTest.java
+++ b/test/edu/csus/ecs/pc2/imports/ccs/TestDataGroupsTest.java
@@ -34,6 +34,7 @@ public class TestDataGroupsTest extends AbstractTestCase {
             System.err.println("could not find " + loadDir);
             throw new Exception("Unable to locate " + loadDir);
         }
+        ensureStaticLog();
         super.setUp();
     }
 
@@ -164,7 +165,6 @@ public class TestDataGroupsTest extends AbstractTestCase {
         String inputTestDirectory = getDataDirectory("testTestDataGroup") + File.separator + "data";
         String testDir = getOutputDataDirectory();
 
-        ensureStaticLog();
         TestDataGroup secret = new TestDataGroup("data", inputTestDirectory, null);
         assertTrue(secret.readTestCases(StaticLog.getLog()));
         assertEquals("Expecting total test case of 16 ", 16, secret.getTotalTestCases());

--- a/test/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitorTest.java
+++ b/test/edu/csus/ecs/pc2/shadow/RemoteEventFeedMonitorTest.java
@@ -1,3 +1,4 @@
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
 import java.io.File;
@@ -18,14 +19,20 @@ import edu.csus.ecs.pc2.util.ContestLoadUtilities;
 
 /**
  * Unit test.
- * 
+ *
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
 public class RemoteEventFeedMonitorTest extends AbstractTestCase {
 
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
+
     /**
      * Contact app server?
-     * 
+     *
      * true = yes, contact server at {@link #LOCALHOST_CONTEST_EVENT_FEED}
      * false = no, skip test.
      */
@@ -39,7 +46,7 @@ public class RemoteEventFeedMonitorTest extends AbstractTestCase {
 
     /**
      * Tests RemoteEventFeedMonitor using running pc2 server with feeder login.
-     * 
+     *
      * @throws Exception
      */
     public void testSubmmissonsLive() throws Exception {

--- a/test/edu/csus/ecs/pc2/ui/team/QuickSubmitterTest.java
+++ b/test/edu/csus/ecs/pc2/ui/team/QuickSubmitterTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui.team;
 
 import java.io.File;
@@ -24,6 +24,12 @@ import edu.csus.ecs.pc2.list.SubmissionSample;
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
 public class QuickSubmitterTest extends AbstractTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
 
     void addOtherLangugages(IInternalContest contest)
     {

--- a/test/edu/csus/ecs/pc2/util/ScoreboardVariableReplacerTest.java
+++ b/test/edu/csus/ecs/pc2/util/ScoreboardVariableReplacerTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.util;
 
 import java.util.Arrays;
@@ -16,6 +16,12 @@ import edu.csus.ecs.pc2.core.util.AbstractTestCase;
  *
  */
 public class ScoreboardVariableReplacerTest extends AbstractTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        ensureStaticLog();
+        super.setUp();
+    }
 
     /**
      * Test substituteDisplayNameVariables with var string, account and group.


### PR DESCRIPTION
### Description of what the PR does

1. The **JUnit** tests for the `ContestSnakeYamlLoader `made some assumptions about the locations of the secret data.  This is now handled automatically by the `TestDataGroup `class.  Fix the routine in `ContestSnakeYamlLoader `to not put the "`secret`" folder on the directory path for data.
2. Fix spelling error in **JUnit** print message.
3. Make sure the static log is created before running junits since the TestDataGroup stuff will log things.

### Issue which the PR addresses
Partially implements #1006 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
WIndows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Build this PR.
2. In the Eclipse explorer, navigate to the `test.edu.csus.ecs.pc2.imports.ccs/ContestSnakeYAMLLoaderTest.java` module
3. Right click and select **Run As->JUnit Test**
4. All the tests should pass.
