### PR TITLE
i_1144 Implement CIs to make loading contests easier

### DIFF
--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -864,6 +864,12 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
         contest.addAccounts(accounts);
 
+        // Apply YAML permissions to ALL accounts, not just those that were added
+        // in the ACCOUNTS_KEY section.
+        PermissionYamlLoader loader = new PermissionYamlLoader(yamlLines, contest.getAccounts());
+        // This will replace all accounts if they exist, which, of course, they will.
+        contest.addAccounts(loader.getAccountsArray());
+
         AutoJudgeSetting[] autoJudgeSettings = null;
         if (problems.length == 0) {
             /**
@@ -1215,11 +1221,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
         }
 
-        // Load permissions from yaml into accounts
-        Account[] fullAccountList = accountVector.toArray(new Account[accountVector.size()]);
-        PermissionYamlLoader loader = new PermissionYamlLoader(yamlLines, fullAccountList);
-        return loader.getAccountsArray();
-
+        return(accountVector.toArray(new Account[accountVector.size()]));
     }
 
     private Object fetchObjectValue(Map<String, Object> content, String key) {
@@ -1581,7 +1583,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             problem.setMaxOutputSizeKB(maxOutputPC2);
         }
 
-        Integer memoryLimit = fetchIntValue(content, MEMORY_LIMIT_IN_MEG_KEY, Problem.DEFAULT_MEMORY_LIMIT_MB);
+        Integer memoryLimit = fetchIntValue(content, MEMORY_LIMIT_IN_MEG_KEY, contest.getContestInformation().getMemoryLimitInMeg());
         problem.setMemoryLimitMB(memoryLimit);
 
         String sandboxCommandLine = fetchValue(content, SANDBOX_COMMAND_LINE_KEY, "");
@@ -1651,7 +1653,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                 problem.setMaxOutputSizeKB(clicsMaxOutput * Constants.KIBIBYTE_PER_MEBIBYTE);
             }
 
-            Integer clicsMemoryLimit = fetchIntValue(limitsContent, MEMORY_LIMIT_CLICS, Problem.DEFAULT_MEMORY_LIMIT_MB);
+            Integer clicsMemoryLimit = fetchIntValue(limitsContent, MEMORY_LIMIT_CLICS, memoryLimit.intValue());
             problem.setMemoryLimitMB(clicsMemoryLimit);
         }
 

--- a/src/edu/csus/ecs/pc2/imports/ccs/PermissionYamlLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/PermissionYamlLoader.java
@@ -23,7 +23,7 @@ import edu.csus.ecs.pc2.core.security.Permission;
 
 /**
  * Class to load "custom" Permissions from yaml file.
- * 
+ *
  * @author Douglas A. Lane <pc2@ecs.csus.edu>
  *
  */
@@ -33,7 +33,7 @@ public class PermissionYamlLoader {
 
     public PermissionYamlLoader(String[] yamlLines, Account[] accounts) {
         if (accounts == null || accounts.length == 0) {
-            
+
             // no accounts to update - done here.
             return;
         }
@@ -67,7 +67,7 @@ public class PermissionYamlLoader {
         Map<String, Object> content = loadYaml(null, yamlLines);
 
         ArrayList permissionList = fetchList(content, "permissions");
-        
+
         if (permissionList == null) {
             // No permissions section in yaml - nothing more to do.
             return;
@@ -90,7 +90,7 @@ public class PermissionYamlLoader {
             int siteNumber = accountList.get(0).getClientId().getSiteNumber();
 
             int[] clientNumbers = getClientNumbers(accountList, numberString, clientType);
-            
+
             for (int i = 0; i < clientNumbers.length; i++) {
 
                 ClientId clientId = new ClientId(siteNumber, clientType, clientNumbers[i]);
@@ -158,30 +158,6 @@ public class PermissionYamlLoader {
         return number;
     }
 
-    int[] getNumberList(String numberString) {
-
-        String[] list = numberString.split(",");
-        if (list.length == 1) {
-            int[] out = new int[1];
-            out[0] = getIntegerValue(list[0], 0);
-            // if (out[0] < 1) {
-            // // SOMEDAY 669 throw invalid number in list exception
-            // }
-            return out;
-        } else {
-            int[] out = new int[list.length];
-            int i = 0;
-            for (String n : list) {
-                out[i] = getIntegerValue(n, 0);
-                // if (out[i] < 1) {
-                // // SOMEDAY 669 throw invalid number in list exception
-                // }
-                i++;
-            }
-            return out;
-        }
-    }
-
     private int[] getClientNumbers(List<Account> list, String numberString, Type type) {
 
         int[] outList = null;
@@ -189,7 +165,7 @@ public class PermissionYamlLoader {
         if ("all".equalsIgnoreCase(numberString)) {
             outList = getAccountNumbers(list, type);
         } else {
-            outList = getNumberList(numberString.trim());
+            outList = StringUtilities.getNumberList(numberString.trim());
         }
         return outList;
     }
@@ -216,7 +192,7 @@ public class PermissionYamlLoader {
     }
 
     public Account[] getAccountsArray() {
-        return (Account[]) accountList.toArray(new Account[accountList.size()]);
+        return accountList.toArray(new Account[accountList.size()]);
     }
 
     List<Account> getAccounts() {
@@ -237,7 +213,7 @@ public class PermissionYamlLoader {
 
     /**
      * Create a simple string with parse info.
-     * 
+     *
      * @param markedYAMLException
      * @return
      */

--- a/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
+++ b/src/edu/csus/ecs/pc2/ui/ResultsComparePane.java
@@ -290,14 +290,14 @@ public class ResultsComparePane extends JPanePlugin {
 
         ClientSettings clientSet = getClientSettings(getContest());
         String exportDir = clientSet.getProperty(ClientSettings.PC2_RESULTS_DIR);
-        if(exportDir.isEmpty()) {
+        if(StringUtilities.isEmpty(exportDir)) {
             exportDir = guessResultsDirectory(CCS_SHADOW_DIR);
         }
         pc2ResultsDirectoryTextField.setText(exportDir);
         exportDirectoryLabel.setToolTipText(exportDir);
 
         String primaryResultsDir = clientSet.getProperty(ClientSettings.PRIMARY_CCS_RESULTS_DIR);
-        if(primaryResultsDir.isEmpty()) {
+        if(StringUtilities.isEmpty(primaryResultsDir)) {
             primaryResultsDir = guessResultsDirectory(CCS_PRIMARY_DIR);
         }
         primaryCCSResultsDirectoryTextField.setText(primaryResultsDir);


### PR DESCRIPTION
### Description of what the PR does
Allow ranges for permissions in` system.pc2.yaml`
Obey system wide memory limit for problems that do not specify a limit
Fix NPE in `ResultsCompareFrame` if no paths are defined yet
Apply account permissions from `system.pc2.yaml` to all accounts, not just those generated by the **accounts:** section.


### Issue which the PR addresses
Fixes #1144 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
While these issues are all very small, testing them and duplicating them requires a fair amount of set up and understanding of how the `ContestSnakeYamlLoader `works.

1. Start with the **clics_sumithello** sample contest
2. Create a `teams2.tsv` file that has, at the very least, a team1 account in it.
3. Create a `groups.tsv `file that has one group in it (this is required so the system will read teams2.tsv).
4. Edit the `system.pc2.yaml `file so it has a permissions section.
5. Add the **VIEW_EVENT_FEED** permissions to a team account such as team number 1.

```
  - account: TEAM
    number: 1
    enable: VIEW_EVENT_FEED

```

6. Change the "`accounts:`", **TEAM** section so that the **TEAM** generation starts at 2, eg. start: 2  This will generate accounts starting at **team2**, since we already created **team1** in `teams2.tsv`.

```
accounts:

  - account: TEAM
    site: 1
    start: 2
    count: 20
```

7. Add another permission entry for **TEAM**, and attempt to specify a range of 1-5 for the teams:

```
  - account: TEAM
    number: 1-5
    disable: DISPLAY_ON_SCOREBOARD

```

8. Load the contest using the modified CDP.
9. You will hopefully **not** get a load error (exception) - bad number format due to the range of 1-5 on the teams above.
12. Start an administrator client up.
13. Note that **team1** has the **VIEW_EVENT_FEED** permission set.
14. Note that teams 1 - 5 all have the **Show on Scoreboard** permission removed (disabled).
15. Note that no NPE occurs in `ResultsComparePane `when you start the administrator.  
16. It will be left as an exercise to the reader to test out the problem memory limit since it requires modifying the `problem.yaml` and the` system.pc2.yaml` and is easier done than said.