### PR TITLE
I_1149 Playback Throttling control

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -613,9 +613,15 @@ public class SubmissionService implements Feature {
                 if("".equals(fileName)) {
                     return Response.status(Response.Status.BAD_REQUEST).entity("no file name specified").build();
                 }
+                // allow contestant submission of a zero length file.  This will generate a CE (hopefully).
+                // if the following code is uncommented, the submission is not made and a 400 is returned to the submitter.
+                // it appears that other CCS's allow zero length submissions.  *sigh* -- JB
                 String fileData = file.getData();
                 if(fileData == null || fileData.length() == 0) {
-                    return Response.status(Response.Status.BAD_REQUEST).entity("no file data specified for " + fileName).build();
+                    // nice to put it in the log in case any questions come up.
+                    log.info(user + " POSTing empty source submission on behalf of team " + team_id);
+
+//                    return Response.status(Response.Status.BAD_REQUEST).entity("no file data specified for " + fileName).build();
                 }
                 IFile iFile = new IFileImpl(file.getFilename(), fileData);
                 srcFiles.add(iFile);

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -610,20 +610,23 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         //determine whether to apply the "current throttling strategy" to this submission
         // (i.e., whether to accept the run for submission to the PC2 Server)
         boolean accept = true;
-        Account submitterAccount = contest.getAccount(contest.getClientId());
 
-        if (submitterAccount.isTeam()) {
-            //Determine the throttling strategy to be applied to team submissions.
-            //The following shows several alternative strategy selections, with only one being enabled.
-            //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
-            // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
-            // GUI (such as the PC2 Admin)
-//            IThrottleStrategy strategy = new AcceptAllStrategy();
-//            IThrottleStrategy strategy = new RejectAllStrategy();
-            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,6);
-//            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
-//            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest); //uses DEFAULT_MAX_SUBMISSIONS_PER_MINUTE; same as prev line
-            accept = strategy.accept(run);
+        if(contest.getContestInformation().isSubmissionThrottling()) {
+            Account submitterAccount = contest.getAccount(contest.getClientId());
+
+            if (submitterAccount.isTeam()) {
+                //Determine the throttling strategy to be applied to team submissions.
+                //The following shows several alternative strategy selections, with only one being enabled.
+                //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
+                // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
+                // GUI (such as the PC2 Admin)
+    //            IThrottleStrategy strategy = new AcceptAllStrategy();
+    //            IThrottleStrategy strategy = new RejectAllStrategy();
+                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,6);
+    //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+    //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest); //uses DEFAULT_MAX_SUBMISSIONS_PER_MINUTE; same as prev line
+                accept = strategy.accept(run);
+            }
         }
 
         Packet packet ;
@@ -5008,21 +5011,24 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         //       There should probably be a "bypass" flag that can be set via config file, or
         //       a separate user created for receiving CLICS API requests.
         boolean accept = true;
-        // use the submitter account, not this client.  This client is doing a proxy submit for a team.
-        Account submitterAccount = contest.getAccount(submitter);
 
-        if (submitterAccount.isTeam()) {
-            //Determine the throttling strategy to be applied to team submissions.
-            //The following shows several alternative strategy selections, with only one being enabled.
-            //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
-            // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
-            // GUI (such as the PC2 Admin)
-//            IThrottleStrategy strategy = new AcceptAllStrategy();
-//            IThrottleStrategy strategy = new RejectAllStrategy();
-            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 6);
-//            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+        if(contest.getContestInformation().isSubmissionThrottling()) {
+            // use the submitter account, not this client.  This client is doing a proxy submit for a team.
+            Account submitterAccount = contest.getAccount(submitter);
 
-            accept = strategy.accept(run);
+            if (submitterAccount.isTeam()) {
+                //Determine the throttling strategy to be applied to team submissions.
+                //The following shows several alternative strategy selections, with only one being enabled.
+                //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
+                // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
+                // GUI (such as the PC2 Admin)
+    //            IThrottleStrategy strategy = new AcceptAllStrategy();
+    //            IThrottleStrategy strategy = new RejectAllStrategy();
+                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 6);
+    //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+
+                accept = strategy.accept(run);
+            }
         }
 
         if (accept) {

--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -215,6 +215,11 @@ public class ContestInformation implements Serializable{
     private String overrideLoadAccountsFilename = null;
 
     /**
+     * Submission Throttling
+     */
+    private boolean submissionThrottling = true;
+
+    /**
      * Returns the date/time when the contest is scheduled (intended) to start.
      * This value is null if no scheduled start time has been set,
      * or if the contest has already started.
@@ -929,6 +934,14 @@ public class ContestInformation implements Serializable{
 
     public void setSandboxInteractiveGraceMultiplier(int nSecs) {
         sandboxInteractiveGraceMultiplier = nSecs;
+    }
+
+    public boolean isSubmissionThrottling() {
+        return submissionThrottling;
+    }
+
+    public void setSubmissionThrottling(boolean submissionThrottling) {
+        this.submissionThrottling = submissionThrottling;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -482,6 +482,10 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         String teamScoreboadDisplayString = fetchValue(content, TEAM_SCOREBOARD_DISPLAY_FORMAT_STRING, contestInformation.getTeamScoreboardDisplayFormat());
         contestInformation.setTeamScoreboardDisplayFormat(teamScoreboadDisplayString);
 
+        // control submission throttling
+        boolean submissionThrottling = fetchBooleanValue(content, SUBMISSION_THROTTLING_KEY, contestInformation.isSubmissionThrottling());
+        contestInformation.setSubmissionThrottling(submissionThrottling);
+
         // enable shadow mode
         boolean shadowMode = fetchBooleanValue(content, SHADOW_MODE_KEY, contestInformation.isShadowMode());
         contestInformation.setShadowMode(shadowMode);

--- a/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.imports.ccs;
 
 import java.io.File;
@@ -245,6 +245,8 @@ public interface IContestLoader {
      * @see ScoreboardVariableReplacer#substituteDisplayNameVariables(String, IInternalContest, edu.csus.ecs.pc2.core.model.Account)
      */
     String TEAM_SCOREBOARD_DISPLAY_FORMAT_STRING  = "team-scoreboard-display-format-string";
+
+    String SUBMISSION_THROTTLING_KEY = "submission-throttling";
 
     Problem addDefaultPC2Validator(Problem problem, int optionNumber);
 


### PR DESCRIPTION
### Description of what the PR does
Add a configuration parameter, "`submission-throttling`", whose default value is "**true**", to the `system.pc2.yaml` file.  This will provide a means of allowing a contest administrator to disable the throttling mechanism.  This is useful during contest playback at high speeds.

### Issue which the PR addresses
Fixes #1149 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. In the system.pc2.yaml file, add a configuration parameter:
`

submission-throttling: false
`
2. Follow the same steps in the Issue #1149. 
3. You will notice that submissions are no longer rejected due to exceeding the submission limit imposed by the system.
