### PR TITLE
i_1111 Format clarification answers so spacing is preserved

### DIFF
--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.html
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.html
@@ -47,9 +47,9 @@
             <tr *ngFor='let clarification of filteredClarifications' [class.pending]='!clarification.isAnswered'>
                 <td>{{ clarification.recipient }}</td>            
                 <td>{{ clarification.problem }}</td>
-                <td>{{ clarification.question }}</td>
-                <td>
-                    <ng-container *ngIf='clarification.isAnswered'>
+                <td [ngStyle]="{ 'white-space': 'pre-wrap' }">{{ clarification.question }}</td>
+                <td [ngStyle]="{ 'white-space': 'pre-wrap' }">
+                    <ng-container *ngIf='clarification.isAnswered' >
                         {{ clarification.answer }}
                     </ng-container>
                     <ng-container *ngIf='!clarification.isAnswered'>

--- a/projects/WTI-UI/src/app/modules/clarifications/components/new-announcement-clarification-alert/new-announcement-alert.component.html
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/new-announcement-clarification-alert/new-announcement-alert.component.html
@@ -1,7 +1,7 @@
 <h1 mat-dialog-title>Announcement Received</h1>
 <div mat-dialog-content>
     <p>Problem: {{ problem }}</p>
-    <p>Announcement: {{ answer }}</p>
+    <p [ngStyle]="{ 'white-space': 'pre-wrap' }">Announcement: {{ answer }}</p>
 </div>
 <div mat-dialog-actions>
     <button (click)='goToClarifications()' type='button' class='warning'>Go to Clarifications</button>&nbsp;

--- a/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification-alert/new-clarification-alert.component.html
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification-alert/new-clarification-alert.component.html
@@ -1,8 +1,8 @@
 <h1 mat-dialog-title>Clarification Reply Received</h1>
 <div mat-dialog-content>
     <p>Problem: {{ problem }}</p>
-    <p>Question: {{ question }}</p>
-    <p>Answer: {{ answer }}</p>
+    <p [ngStyle]="{ 'white-space': 'pre-wrap' }">Question: {{ question }}</p>
+    <p [ngStyle]="{ 'white-space': 'pre-wrap' }">Answer: {{ answer }}</p>
 </div>
 <div mat-dialog-actions>
     <button (click)='goToClarifications()' type='button' class='warning'>Go to Clarifications</button>&nbsp;

--- a/src/edu/csus/ecs/pc2/core/Utilities.java
+++ b/src/edu/csus/ecs/pc2/core/Utilities.java
@@ -524,6 +524,10 @@ public final class Utilities {
                 result.append("&#045;");
             } else if (character == '\n') {
                 result.append("<br>");
+            } else if (character == ' ') {
+                result.append("&nbsp;");
+            } else if (character == '\t') {
+                result.append("&nbsp;&nbsp;&nbsp;&nbsp;");
             } else {
                 // the char is not a special one
                 // add it to the result as is

--- a/src/edu/csus/ecs/pc2/ui/GenerateAnnouncementPane.java
+++ b/src/edu/csus/ecs/pc2/ui/GenerateAnnouncementPane.java
@@ -642,7 +642,7 @@ public class GenerateAnnouncementPane extends JPanePlugin {
                 + "            font-size: 1.1em;" + "        }" + "    </style>" + "    </head>" + "    <body>"
                 + "    <div style = \"padding-bottom: 8px\">Do you wish to submit an announcement clarification for </div>" + "    <table style=\"width:100%; max-width: 700px\">" + "        <tr>"
                 + "            <td style=\"width:20%\">Problem:</td>" + "            <td style = \"width:50%\"><font color=\"blue\">" + Utilities.forHTML(problem.toString()) + "</font></td>"
-                + "        </tr>" + "        <tr>" + "            <td>Announcement:</td>" + "            <td><font color=\"blue\">" + Utilities.forHTML(announcement) + "</font></td>"
+                + "        </tr>" + "        <tr>" + "            <td>Announcement:</td>" + "            <td><font color=\"blue\">" +Utilities.forHTML(announcement) + "</font></td>"
                 + "        </tr>" + "        <tr>");
         if (destinationCategories.equals(ALL_TEAMS)) {
             stringBuilder.append("            <td  class=\"no-padding\">Destination:</td>" + "            <td class=\"no-padding\"><font color=\"blue\">" + Utilities.forHTML(ALL_TEAMS)


### PR DESCRIPTION

### Description of what the PR does
Displays enter, tabs, multiple spaces correctly in WTI and some parts of PC2 namely clarification/announcement creation confirmation page. 

### Issue which the PR addresses
Fixes #1111 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse, Java 1.8
### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

Try stuffs shown in the screenshot. Create announcements. clarifications, clarification answers that contain enter. tab, multiple spaces. It should look good. This includes announcement creation scene. 
<img width="461" height="502" alt="Screenshot 2025-07-28 202928" src="https://github.com/user-attachments/assets/eb202708-3076-4425-b192-59e10dedc2ef" />
<img width="1396" height="657" alt="Screenshot 2025-07-28 203059" src="https://github.com/user-attachments/assets/29b55ae9-c85f-48bc-b620-259d6b1938e6" />
