### PR TITLE
I1155 judgment text inconsistent

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1535,8 +1535,6 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                     // get the judgment out of the feedback file
                     String judgement = readFileAsString(judgementFileName);
 
-                    // Make sure the judgment is in our list of judgments and adjust if necessary
-                    judgement = mapCLICSValidatorJudgmentToDefinedJudgments(judgement, exitCode);
                     //put the judgement from the validator into the executionData object
                     executionData.setValidationResults(judgement);
                     log.info("Saving CLICS Validator judgement '" + judgement + "'");
@@ -1569,70 +1567,6 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             log.warning("No CLICS validator feedback directory named '" + feedbackDirPath + "' found");
             saveDefaultClicsValidatorResult(exitCode);
         }
-    }
-
-    /**
-     * Maps a clics judgment string returned by a clics validator into a configured judgment display name.
-     * We first look for an exact match in the configure list of judgments.  If we find it, we return the original string.
-     * Otherwise, we'll see if we found a case insensitive match (eg, Wrong Answer == wrong answer).  If so, use that.
-     * If no match is found using either of the above techniques, then use the configured display names for AC
-     * or WA as to whether the validator exit code was success (42) or failure (43).  If it's an unknown exitCode,
-     * we return the original judgment string.
-     *
-     * @param judgment string return by the CLICS validator
-     * @param exitCode system exit code from the CLICS validator (42 or 43, hopefully)
-     * @return closest match to configured judgments
-     */
-    private String mapCLICSValidatorJudgmentToDefinedJudgments(String judgment, int exitCode) {
-        Judgement[] judgements = getContest().getJudgements();
-        String judgmentDisplay;
-        String caseInsensitiveMatch = null;
-        String acJudgment = null;
-        String waJudgment = null;
-
-        // Go through all configured judgments and see if the supplied judgment matches any of them.
-        // If so, we found it and it's good as is (just return it).
-        // While we go through the loop, remember if a case insensitive compare of the judgment string
-        // matches, if so, remember that, because if nothing else matches, we'll use that.
-        // Also, remember the judgment strings for "AC" and "WA", as we may need though if no match
-        // at all is found.
-        for(Judgement j : judgements) {
-            judgmentDisplay = j.getDisplayName();
-            // Exact match found?
-            if(judgmentDisplay.equals(judgment)) {
-                return(judgment);
-            }
-            // Remember if a case insensitive compare worked
-            if(judgmentDisplay.equalsIgnoreCase(judgment)) {
-                caseInsensitiveMatch = judgmentDisplay;
-            }
-            if(j.getAcronym().equals(Judgement.ACRONYM_ACCEPTED)) {
-                acJudgment = j.getDisplayName();
-            } else if(j.getAcronym().equals(Judgement.ACRONYM_WRONG_ANSWER)) {
-                waJudgment = j.getDisplayName();
-            }
-        }
-        // If not match at all, use exit code
-        if(caseInsensitiveMatch == null) {
-            if(exitCode == ClicsValidator.CLICS_VALIDATOR_JUDGED_RUN_SUCCESS_EXIT_CODE) {
-                if(acJudgment != null) {
-                    judgment = acJudgment;
-                } else {
-                    // This is very bad, Tammy.  Best guess.
-                    judgment = "accepted";
-                }
-            } else if(exitCode == ClicsValidator.CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE) {
-                if(waJudgment != null) {
-                    judgment = waJudgment;
-                } else {
-                    // This is very bad, Tammy.  Best guess.
-                    judgment = "wrong answer";
-                }
-            }
-        } else {
-            judgment = caseInsensitiveMatch;
-        }
-        return(judgment);
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1532,21 +1532,23 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 File judgementFile = new File(judgementFileName);
                 if (judgementFile.exists()) {
 
-                    // get the judgement out of the feedback file
+                    // get the judgment out of the feedback file
                     String judgement = readFileAsString(judgementFileName);
 
-                //put the judgement from the validator into the executionData object
+                    // Make sure the judgment is in our list of judgments and adjust if necessary
+                    judgement = mapCLICSValidatorJudgmentToDefinedJudgments(judgement, exitCode);
+                    //put the judgement from the validator into the executionData object
                     executionData.setValidationResults(judgement);
                     log.info("Saving CLICS Validator judgement '" + judgement + "'");
 
                 } else {
-                //we found no judgement file in the feedback dir -- that's a problem (the Validator implementation should ALWAYS create one)!
-                log.warning ("No Clics Validator judgement file '" + judgementFileName + "' found in feedback directory '" + feedbackDirPath + "'");
-                saveDefaultClicsValidatorResult(exitCode);
+                    //we found no judgement file in the feedback dir -- that's a problem (the Validator implementation should ALWAYS create one)!
+                    log.warning ("No Clics Validator judgement file '" + judgementFileName + "' found in feedback directory '" + feedbackDirPath + "'");
+                    saveDefaultClicsValidatorResult(exitCode);
                 }
 
-            // check for a judgement details file
-            String detailsFileName = feedbackDirPath + ClicsValidator.CLICS_JUDGEMENT_DETAILS_FEEDBACK_FILE_NAME ;
+                // check for a judgement details file
+                String detailsFileName = feedbackDirPath + ClicsValidator.CLICS_JUDGEMENT_DETAILS_FEEDBACK_FILE_NAME ;
                 File detailsFile = new File(detailsFileName);
                 if (detailsFile.exists()) {
 
@@ -1567,7 +1569,71 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             log.warning("No CLICS validator feedback directory named '" + feedbackDirPath + "' found");
             saveDefaultClicsValidatorResult(exitCode);
         }
+    }
+
+    /**
+     * Maps a clics judgment string returned by a clics validator into a configured judgment display name.
+     * We first look for an exact match in the configure list of judgments.  If we find it, we return the original string.
+     * Otherwise, we'll see if we found a case insensitive match (eg, Wrong Answer == wrong answer).  If so, use that.
+     * If no match is found using either of the above techniques, then use the configured display names for AC
+     * or WA as to whether the validator exit code was success (42) or failure (43).  If it's an unknown exitCode,
+     * we return the original judgment string.
+     *
+     * @param judgment string return by the CLICS validator
+     * @param exitCode system exit code from the CLICS validator (42 or 43, hopefully)
+     * @return closest match to configured judgments
+     */
+    private String mapCLICSValidatorJudgmentToDefinedJudgments(String judgment, int exitCode) {
+        Judgement[] judgements = getContest().getJudgements();
+        String judgmentDisplay;
+        String caseInsensitiveMatch = null;
+        String acJudgment = null;
+        String waJudgment = null;
+
+        // Go through all configured judgments and see if the supplied judgment matches any of them.
+        // If so, we found it and it's good as is (just return it).
+        // While we go through the loop, remember if a case insensitive compare of the judgment string
+        // matches, if so, remember that, because if nothing else matches, we'll use that.
+        // Also, remember the judgment strings for "AC" and "WA", as we may need though if no match
+        // at all is found.
+        for(Judgement j : judgements) {
+            judgmentDisplay = j.getDisplayName();
+            // Exact match found?
+            if(judgmentDisplay.equals(judgment)) {
+                return(judgment);
             }
+            // Remember if a case insensitive compare worked
+            if(judgmentDisplay.equalsIgnoreCase(judgment)) {
+                caseInsensitiveMatch = judgmentDisplay;
+            }
+            if(j.getAcronym().equals(Judgement.ACRONYM_ACCEPTED)) {
+                acJudgment = j.getDisplayName();
+            } else if(j.getAcronym().equals(Judgement.ACRONYM_WRONG_ANSWER)) {
+                waJudgment = j.getDisplayName();
+            }
+        }
+        // If not match at all, use exit code
+        if(caseInsensitiveMatch == null) {
+            if(exitCode == ClicsValidator.CLICS_VALIDATOR_JUDGED_RUN_SUCCESS_EXIT_CODE) {
+                if(acJudgment != null) {
+                    judgment = acJudgment;
+                } else {
+                    // This is very bad, Tammy.  Best guess.
+                    judgment = "accepted";
+                }
+            } else if(exitCode == ClicsValidator.CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE) {
+                if(waJudgment != null) {
+                    judgment = waJudgment;
+                } else {
+                    // This is very bad, Tammy.  Best guess.
+                    judgment = "wrong answer";
+                }
+            }
+        } else {
+            judgment = caseInsensitiveMatch;
+        }
+        return(judgment);
+    }
 
     /**
      * Saves into the current executionData object a Clics Validator result string based on the specified exitCode.
@@ -2391,6 +2457,10 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             proceedToValidation = false;
         } else if(executionData.isMemoryLimitExceeded()) {
             Judgement judgement = JudgementUtilities.findJudgementByAcronym(contest, Judgement.ACRONYM_MEMORY_LIMIT_EXCEEDED);
+            // If MLE is not a configured judgment type, use RTE
+            if(judgement == null) {
+                judgement = JudgementUtilities.findJudgementByAcronym(contest, Judgement.ACRONYM_RUN_TIME_ERROR);
+            }
             String judgementString = "No - Memory Limit Exceeded"; // default
             if (judgement != null) {
                 judgementString = judgement.getDisplayName();

--- a/src/edu/csus/ecs/pc2/core/execute/JudgementUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/execute/JudgementUtilities.java
@@ -21,6 +21,7 @@ import edu.csus.ecs.pc2.core.model.Pluralize;
 import edu.csus.ecs.pc2.core.model.Problem;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.model.RunTestCase;
+import edu.csus.ecs.pc2.validator.clicsValidator.ClicsValidator;
 
 /**
  * Judgement utilities.
@@ -168,6 +169,73 @@ public final class JudgementUtilities {
         }
 
         return null;
+    }
+
+    /**
+     * Maps a clics judgment string returned by a clics validator into a configured judgment display name.
+     * We first look for an exact match in the configure list of judgments.  If we find it, we return the original string.
+     * Otherwise, we'll see if we found a case insensitive match (eg, Wrong Answer == wrong answer).  If so, use that.
+     * If no match is found using either of the above techniques, then use the configured display names for AC
+     * or WA as to whether the validator exit code was success (42) or failure (43).  If it's an unknown exitCode,
+     * we return the original judgment string.
+     *
+     * @param contest the contest
+     * @param judgment string return by the CLICS validator
+     * @param exitCode system exit code from the CLICS validator (42 or 43, hopefully)
+     * @return closest match to configured judgments
+     */
+    public static String mapCLICSValidatorJudgmentToDefinedJudgments(IInternalContest contest, String judgment, long exitCode) {
+        Judgement[] judgements = contest.getJudgements();
+        String judgmentDisplay;
+        String caseInsensitiveMatch = null;
+        String acJudgment = null;
+        String waJudgment = null;
+
+        // We do not map "accepted" - all modules know that "accepted" means yes.  This may later be
+        // mapped  -- JB TODO CHECK THIS.
+        // Go through all configured judgments and see if the supplied judgment matches any of them.
+        // If so, we found it and it's good as is (just return it).
+        // While we go through the loop, remember if a case insensitive compare of the judgment string
+        // matches, if so, remember that, because if nothing else matches, we'll use that.
+        // Also, remember the judgment strings for "AC" and "WA", as we may need them if no match
+        // at all is found.
+        for(Judgement j : judgements) {
+            judgmentDisplay = j.getDisplayName();
+            // Exact match found?
+            if(judgmentDisplay.equals(judgment)) {
+                return(judgment);
+            }
+            // Remember if a case insensitive compare worked
+            if(judgmentDisplay.equalsIgnoreCase(judgment)) {
+                caseInsensitiveMatch = judgmentDisplay;
+            }
+            if(j.getAcronym().equals(Judgement.ACRONYM_ACCEPTED)) {
+                acJudgment = j.getDisplayName();
+            } else if(j.getAcronym().equals(Judgement.ACRONYM_WRONG_ANSWER)) {
+                waJudgment = j.getDisplayName();
+            }
+        }
+        // If no match at all, use exit code
+        if(caseInsensitiveMatch == null) {
+            if(exitCode == ClicsValidator.CLICS_VALIDATOR_JUDGED_RUN_SUCCESS_EXIT_CODE) {
+                if(acJudgment != null) {
+                    judgment = acJudgment;
+                } else {
+                    // This is very bad, Tammy.  Best guess.
+                    judgment = "accepted";
+                }
+            } else if(exitCode == ClicsValidator.CLICS_VALIDATOR_JUDGED_RUN_FAILURE_EXIT_CODE) {
+                if(waJudgment != null) {
+                    judgment = waJudgment;
+                } else {
+                    // This is very bad, Tammy.  Best guess.
+                    judgment = "wrong answer";
+                }
+            }
+        } else {
+            judgment = caseInsensitiveMatch;
+        }
+        return(judgment);
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -565,19 +565,27 @@ public class AutoJudgingMonitor implements UIPlugin {
                 }
 
                 boolean solved = false;
+                String savedJudgmentDisplayName = null;
 
                 // Try to find result text in judgement list
-                //  (start with a default of a non-variable-scoring "no" judgment)
+                //  (start with a default of a non-variable-scoring "no" judgment, eg. RTE)
+                // JB TODO: This is horrible.  There should be a "default" defined in the configuration.
+                // We should not blindy choose element[2] of judgments.
                 ElementId elementId = contest.getJudgements()[2].getElementId();
 
                 for (Judgement judgement : contest.getJudgements()) {
                     if (judgement.getDisplayName().trim().equalsIgnoreCase(results)) {
                         elementId = judgement.getElementId();
+                        // Remember this for later when we map to allowed judgment results
+                        savedJudgmentDisplayName = judgement.getDisplayName();
+                        break;
                     }
                 }
 
                 // Or perhaps it is a yes? yes?
+                // JB TODO: This is horrible.  Should look up AC judgment, not assumes it's index 0
                 Judgement yesJudgement = contest.getJudgements()[0];
+
                 // bug 280 ICPC Validator Interface Standard calls for "accepted" in any case.
                 if (results.equalsIgnoreCase("accepted")) {
                     results = yesJudgement.getDisplayName();
@@ -585,6 +593,18 @@ public class AutoJudgingMonitor implements UIPlugin {
                 if (yesJudgement.getDisplayName().equalsIgnoreCase(results)) {
                     elementId = yesJudgement.getElementId();
                     solved = true;
+                }
+                // If it's not solved, we will try to map the judgment result string to one that
+                // is configured.
+                if(!solved) {
+                    // Map to defined judgments
+                    if(problem.isUsingCLICSValidator()) {
+                        results = JudgementUtilities.mapCLICSValidatorJudgmentToDefinedJudgments(contest, results, executable.getExecutionData().getValidationReturnCode());
+                    } else if(savedJudgmentDisplayName != null) {
+                        // Use judgment display from configured judgment types.  Basically, this will make the
+                        // judgment display string uniform case
+                        results = savedJudgmentDisplayName;
+                    }
                 }
 
                 judgementRecord = new JudgementRecord(elementId, contest.getClientId(), solved, true, true);

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -884,8 +884,10 @@ public class SelectJudgementPaneNew extends JPanePlugin {
 
         executable = new Executable(getContest(), getController(), run, runFiles, executeFrame);
 
+        Problem problem = getContest().getProblem(run.getProblemId());
+
         // only if do not show output is not checked, clear the results pane
-        if (!getContest().getProblem(run.getProblemId()).isHideOutputWindow()) {
+        if (!problem.isHideOutputWindow()) {
             getTestResultsFrame().clearData();
         }
 
@@ -900,10 +902,9 @@ public class SelectJudgementPaneNew extends JPanePlugin {
 
         // Dump execution results files to log
         String executeDirctoryName = JudgementUtilities.getExecuteDirectoryName(getContest().getClientId());
-        Problem juProblem = getContest().getProblem(run.getProblemId());
         ClientId clientId = getContest().getClientId();
         List<Judgement> judgements = JudgementUtilities.getLastTestCaseJudgementList(getContest(), run);
-        JudgementUtilities.dumpJudgementResultsToLog(log, clientId, run, executeDirctoryName, juProblem, judgements, executable.getExecutionData(), "", new Properties());
+        JudgementUtilities.dumpJudgementResultsToLog(log, clientId, run, executeDirctoryName, problem, judgements, executable.getExecutionData(), "", new Properties());
 
         ExecutionData executionData = executable.getExecutionData();
         if (executionData != null && executionData.getExecutionException() != null) {
@@ -940,9 +941,8 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         sendValidatorOutputFileNames();
         sendValidatorStderrFileNames();
         // only if do not show output is not checked
-        if (!getContest().getProblem(run.getProblemId()).isHideOutputWindow()) {
+        if (!problem.isHideOutputWindow()) {
             // the run gets modified in Executable to have testCases, so resend the data
-            Problem problem = getContest().getProblem(run.getProblemId());
             getTestResultsFrame().setData(run, runFiles, problem, getProblemDataFiles());
             getTestResultsFrame().setVisible(true);
         }
@@ -960,7 +960,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
                 if (results.equalsIgnoreCase("accepted") || results.equalsIgnoreCase("yes")) {
                     results = getContest().getJudgements()[0].getDisplayName();
                 }
-                validatorAnswer.setText(results);
+
 
                 boolean solved = false;
 
@@ -969,6 +969,26 @@ public class SelectJudgementPaneNew extends JPanePlugin {
                 if (yesJudgement.getElementId().equals(elementId)) {
                     solved = true;
                 }
+
+                if(!solved) {
+                    // Map results string to configured judgment display string
+                    if(problem.isUsingCLICSValidator()) {
+                        results = JudgementUtilities.mapCLICSValidatorJudgmentToDefinedJudgments(getContest(), results, executable.getExecutionData().getValidationReturnCode());
+                    } else if(elementId != null) {
+                        // Note: elementId has to be non-null here since getValidatorResultElementID() guarantees that
+                        // Use judgment display from configured judgment types.  Basically, this will make the
+                        // judgment display string consistent for all judgments (that is, whatever the display string is)
+                        Judgement judgment = getContest().getJudgement(elementId);
+                        // This had better be non-null by this point since we know elementId is valid.
+                        if(judgment != null) {
+                            results = judgment.getDisplayName();
+                        }
+                    }
+                }
+
+                // Update gui result
+                validatorAnswer.setText(results);
+
                 judgementRecord = new JudgementRecord(elementId, run.getSubmitter(), solved, true);
                 judgementRecord.setValidatorResultString(results);
 
@@ -1421,21 +1441,27 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     }
 
     /*
-     * Get the ElementId corresponding to the Validator Judgement. @returns 1st No if not found
+     * Get the ElementId corresponding to the Validator Judgement.
+     * @returns 1st No if not found (TODO: this is bad and has to be addressed.  JB)
      */
     private ElementId getValidatorResultElementID(String results) {
         // Try to find result text in judgement list
         // (start with a default of a non-variable-scoring "no" judgment)
+        // JB TODO: This is horrible.  There should be a "default" defined in the configuration.
+        // We should not blindy choose element[2] of judgments.
         ElementId elementId = getContest().getJudgements()[2].getElementId();
 
         for (Judgement judgement : getContest().getJudgements()) {
-            if (judgement.getDisplayName().equals(results)) {
+            if (judgement.getDisplayName().trim().equalsIgnoreCase(results)) {
                 elementId = judgement.getElementId();
+                break;
             }
         }
 
         // Or perhaps it is a yes? yes?
+        // JB TODO: This is horrible.  Should look up AC judgment, not assumes it's index 0
         Judgement yesJudgement = getContest().getJudgements()[0];
+
         if (yesJudgement.getDisplayName().equalsIgnoreCase(results)) {
             elementId = yesJudgement.getElementId();
         }


### PR DESCRIPTION
### Description of what the PR does
Judgment result strings (judgment text) should only include those strings defined in `reject.ini`, or, the defaults if there is no `reject.ini`.  Some CLICS validators return "_Wrong Answer_" as a judgment string when the `reject.ini` specifically sets WA to be "_wrong answer_".  This causes confusion for contestants who are told they will only see a very specific set of judgment types (for example, the World Finals rules explicitly say "_wrong answer_".
Fixed bug where an MLE (memory limit exceeded) would be returned, even it it was not configured in `reject.ini`.  This is now mapped to RTE (run-time error) if MLE is not configured.
Make judge thick client operate the same as the AJ Monitor when deciding on the result string.  That is, it does a case insensitive compare now, as opposed to a an exact compare when testing result strings against those configured.

### Issue which the PR addresses
Fixes #1155 
Partially fixes #1154 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
**Windows 11**
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)
**Ubuntu 24.04**
openjdk version "21.0.4" 2024-07-16
OpenJDK Runtime Environment (build 21.0.4+7-Ubuntu-1ubuntu224.04)
OpenJDK 64-Bit Server VM (build 21.0.4+7-Ubuntu-1ubuntu224.04, mixed mode, sharing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Load sample contest **sumithello**.  Be sure to include a `reject.ini` file, such as the one attached here (rename it to `reject.ini`)
2. [reject.txt](https://github.com/user-attachments/files/21760773/reject.txt).  The `reject.ini `file must exist in the `config` folder before loading the initial contest.
3. Open an administrator client and verify the judgment types are what is specified in the `reject.ini` file.  If not, go back to step 1 and figure out why.
4. Edit problem "**hello**" and change the time limit to 5 seconds to save some time during testing.  You'll thank me.
5. Start the contest.
6. Start `pc2team `using **team1**
7. Start `pc2judge `using **judge4** to _autojudge_ the problems in the contest.
8. Make submissions to the **hello** problem that should cause the following:
  - Correct (accepted) (src/hello.java)
  - Time limit exceeded (src/TLE.java)
  - Run-time error (src/RuntimeError.java)
  - Memory limit exceeded (only on Linux is this possible)
  - Wrong answer (you'll have to edit something like hello.java and change it to output the wrong answer)
  - Compile error (submit a c/c++ program as a java program to generate a compile error)
9. You should see only those judgments that appear in the `reject.ini `file, eg.
<img width="461" height="226" alt="image" src="https://github.com/user-attachments/assets/a9d32282-17ba-4bae-90ff-189a2d259cb7" />

If you rerun the procedure above, but do not put a reject.ini file in the config folder before starting the contest for the first time, you will see different (default) judgments:  Yes instead of accepted, No - Compilation Error, No - Run-time Error, No - Time Limit Exceeded, No - Wrong Answer, etc.  Basically, you will not see the judgments that are in the reject.ini file.
<img width="499" height="241" alt="image" src="https://github.com/user-attachments/assets/1172e411-9034-4598-b9f5-629acbb4f621" />


As a note, this PR is being used for the 2025 ICPC World Finals Online Practice Contest, so, assuming this is being reviewed during that practice, you can use one of the test team accounts (team153-team160) to make test submissions if you wish.


