### PR TITLE
I448 wti general clar category

### DIFF
--- a/projects/WTI-API/src/main/controllers/MainController.java
+++ b/projects/WTI-API/src/main/controllers/MainController.java
@@ -14,7 +14,6 @@ import edu.csus.ecs.pc2.api.ILanguage;
 import edu.csus.ecs.pc2.api.IProblem;
 import edu.csus.ecs.pc2.api.ServerConnection;
 import edu.csus.ecs.pc2.api.implementation.Contest;
-import edu.csus.ecs.pc2.api.implementation.ProblemImplementation;
 import edu.csus.ecs.pc2.core.log.Log;
 import emptyObjs.EmptyLanguage;
 import emptyObjs.EmptyProblem;

--- a/projects/WTI-API/src/main/controllers/MainController.java
+++ b/projects/WTI-API/src/main/controllers/MainController.java
@@ -14,6 +14,7 @@ import edu.csus.ecs.pc2.api.ILanguage;
 import edu.csus.ecs.pc2.api.IProblem;
 import edu.csus.ecs.pc2.api.ServerConnection;
 import edu.csus.ecs.pc2.api.implementation.Contest;
+import edu.csus.ecs.pc2.api.implementation.ProblemImplementation;
 import edu.csus.ecs.pc2.core.log.Log;
 import emptyObjs.EmptyLanguage;
 import emptyObjs.EmptyProblem;
@@ -59,10 +60,35 @@ public abstract class MainController {
 		client = new WTIWebsocket(new URI(String.format("%s/%s", this.websocketUrl, "server")));
 	}
 
+	/**
+	 * Searches the given array of IProblems and returns the first problem whose name matches the specified 
+	 * nameOfProblem, or returns an {@link EmptyProblem} object if there was no match.
+	 * <P>
+	 * Note that this method is only invoked by the {@link TeamsController} class, and only from TeamsController 
+	 * methods submitClarification(), submitRun(), and submitTestRun().  This means that the received array
+	 * contains only actual contest problems (in the case of being invoked by submitting a Run), or may
+	 * also contain "Categories" (which are, somewhat illogically, defined as "class Category extends Problem") in
+	 * the case of being invoked by submitting a Clarification request.
+	 * <P>
+	 * Note also that all three invocations of this method construct the IProblems[] array which they send
+	 * to this method by invoking api.ServerConnection.getContest().getProblems() and/or
+	 * api.ServerConnection.getContest().getClarificationCategories, both of which return an array of
+	 * ProblemImplementation (NOT an array of Problems).  This works because both ProblemImplementation and
+	 * Problem implement IProblem.  Thus, while the declared ("Apparent") type of the elements in the received
+	 * array is "IProblem", the ACTUAL TYPE of the elements will in all cases be "ProblemImplementation".
+	 * 
+	 * @param problems an array of IProblems, which are actually ProblemImplementations.
+	 * @param nameOfProblem a String giving the name of the desired problem.
+	 * 
+	 * @return the named problem if it is found in the input array; otherwise, an {@link EmptyProblem} object.
+	 */
 	protected IProblem findProblem(IProblem[] problems, String nameOfProblem) {
-		for(IProblem prob : problems)
+		//check if the named problem is one of the problems in the received array.
+		for(IProblem prob : problems) {
 			if(prob.getName().equalsIgnoreCase(nameOfProblem))
 				return prob;
+		}
+		//we didn't find a problem (or category) whose name matches; return a dummy problem.
 		return new EmptyProblem();
 	}
 

--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -17,6 +17,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 
 import edu.csus.ecs.pc2.api.exceptions.NotLoggedInException;
+import edu.csus.ecs.pc2.api.implementation.ProblemImplementation;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.api.IClient;
@@ -516,11 +517,39 @@ public class TeamsController extends MainController {
 	private Response submitClarification(ServerConnection teamsConn, SubmitClarificationRequestModel clar) {
 
 		try {
-			IProblem prob = this.findProblem(teamsConn.getContest().getProblems(), clar.getProbName());
+			//start with an empty list of all known problems
+			ArrayList<ProblemImplementation> problemList = new ArrayList<ProblemImplementation>();
+			
+			//get the real problems (except inactive ones) and add them to the list.
+			//Note that method Contest.getProblems() returns an array of objects whose "apparent type"
+			// is "IProblem" but whose ACTUAL type is "ProblemImplementation".
+			IProblem [] actualProblems = teamsConn.getContest().getProblems();
+			for (IProblem prob : actualProblems) {
+				problemList.add((ProblemImplementation) prob);
+			}
+			
+			//get the "Problem Categories".
+			//Note that, in a poorly-designed mixup, "class Category extends Problem" --
+			// meaning (quite illogically) that a Category IS-A Problem.  
+			// But it means we can treat categories interchangeably with problems.
+			//Note also that, as with the real problems (above), the ACTUAL type of the
+			// objects in the array returned by getClarificationCategories() is "ProblemImplementation".
+			IProblem [] categories = teamsConn.getContest().getClarificationCategories();
+			for (IProblem prob : categories) {
+				problemList.add((ProblemImplementation) prob);
+			}
+			
+			//construct the IProblem array expected by findProblem()
+	        IProblem [] iProbs = (ProblemImplementation[]) problemList.toArray(new ProblemImplementation[problemList.size()]);
+
+	        //find the IProblem whose name matches the problem name specified in the clar
+			IProblem prob = this.findProblem(iProbs, clar.getProbName());
+
+			//get the text of the clarification request
 			String message = clar.getMessage();
 
-			teamsConn.submitClarification(prob, message);;
-
+			//submit the clar request (problem and message) to the PC2 Server via the PC2 API
+			teamsConn.submitClarification(prob, message);
 		} 
 		catch(NullPointerException e) {
 			return Response.status(Response.Status.BAD_REQUEST)

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.html
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.html
@@ -28,7 +28,7 @@
                 </label>
             </div>
             <div>
-                <app-problem-selector formControlName='problem'></app-problem-selector>
+    			<app-problem-selector [allowGeneral]='true' formControlName='problem'></app-problem-selector>
             </div>
             <div>
                 <button class='outline' type='button' (click)='reset()'>Clear Filters</button>

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -66,7 +66,7 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
     if (filterParams.recipient === 'all') { filtered = filtered.filter(x => (x.recipient === 'All' || x.recipient === "No Answer Yet")); }
     if (filterParams.recipient === 'some') { filtered = filtered.filter(x => (x.recipient === 'Some' || x.recipient === "No Answer Yet")); }
     if (filterParams.recipient === 'team') { filtered = filtered.filter(x => (x.recipient === 'My Team' || x.recipient === "No Answer Yet")); }
-    if (filterParams.problem) { filtered = filtered.filter(x => x.problem === filterParams.problem); }
+    if (filterParams.problem) { filtered = filtered.filter(x => x.problem?.toLowerCase() === filterParams.problem.toLowerCase()); }
 
     this.filteredClarifications = filtered;
   }

--- a/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.html
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.html
@@ -1,6 +1,6 @@
 <form class='newClarificationForm' [formGroup]='newClarificationForm' (ngSubmit)='submitNewClarification()'>
     <h1 mat-dialog-title>Submit a Clarification</h1>
-    <app-problem-selector [allowGeneral]='false' formControlName='problem'></app-problem-selector>
+    <app-problem-selector [allowGeneral]='true' formControlName='problem'></app-problem-selector>
     <br />
     <br />
     <textarea placeholder='Enter Clarification...' formControlName='content'></textarea>

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -270,8 +270,13 @@ public class ServerConnection {
     /**
      * Submit a clarification request to the PC2 Server.
      * 
-     * @param problem  the Problem for which the clarification request is being submitted
+     * @param problem  the Problem for which the clarification request is being submitted.
+     *                  Note that while the "apparent type" of parameter "problem" is "IProblem", the 
+     *                  *actual type* is expected to be "ProblemImplementation"; that is,
+     *                  the method casts "problem" to "ProblemImplementation" and throws
+     *                  ClassCastException if this casting fails.
      * @param question text of question
+     * 
      * @throws NotLoggedInException if the client is not currently logged in to the server
      * @throws SecurityException if the user allowed to perform this action.
      * @throws Exception if the specified Problem is null or the clarification request could not be submitted to the server


### PR DESCRIPTION
### Description of what the PR does
Adds support for "General" clarifications to the WTI.  Specifically, the following four files were changed:
- `WTI-UI/src/app/modules/clarifications/components/new-clarification/new-clarification.component.html`
  - `allowGeneral` was set to `true`, allowing this component to tell its child `ProblemSelectorComponent` to include "General" in the dropdown list of problems on the New Clarification page's `Select Problem` list.
- `/pc2v9/src/edu/csus/ecs/pc2/api/ServerConnection.java`
  - Added documentation to method `submitClarification(IProblem problem, String question)` explaining some subleties associated with the inclusion of `Category`s as a type of "problem".
  - No logic changes were made to this file.
- `WTI-API/src/main/controllers/MainController.java`
  - Added substantial documentation explaining the addition of `Category`s to the input parameters to method `findProblem(IProblem[] problems, String nameOfProblem)`.  
  - Some very minor reformatting of code; no logic changes.
- Updated `WTI-API/src/main/controllers/TeamsController.java` method `SubmitClarification(ServerConnection teamConn, SubmitClarificationRequestModel clar)` to fetch problem `Category`s from the PC2 Server (via the PC2 API) and include the returned `Category` values in the list of "problems" to be searched for a match with the "problem" (which could be a `Category`) specified in the submitted clar request. 

### Issue which the PR addresses
Fixes #448 

### Environment in which the PR was developed
Windows 11, Eclipse Version: 2020-12 (4.18.0) with Java version "1.8.0_271"

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Start a PC2 Server, loading a contest with multiple problems (e.g. --load sumithello). 
  - Do NOT start the contest yet (sumithello by default does not automatically start).
  - Be sure the contest you start has a Scoreboard2 account (sumithello does).
- Start the WTI Server.
- Open a browser and connect to the WTI Server (e.g. at http://localhost:8080 which is the default.)
- Login as a team.
- Verify:
  - Clicking `Runs>Submit Problem>Select Problem` does NOT show any problems (because the contest hasn't been started).
  - Clicking `Clarifications>New Clarification>Select Problem` shows "General" but does not show any actual problems (again, because the contest hasn't started).
- Start a PC2 Admin.
- Start the contest.
- On the WTI, verify:
  - Selecting `Runs>Submit Problem>Select Problem` now shows the contest problems (but does NOT show "General").
  - Selecting `Clarifications>New Clarification>Select Problem` shows all the contest problems AND shows "General".
- Select a problem (not "General") and submit a clarification request for that problem.
- On the Admin, verify that the clarification is received.
- On the Admin, answer the clarification but do NOT check "Send to all teams".
- On the WTI team, verify that the reply was received.
- On the WTI team, submit another clarification, selecting "General".
- On the Admin, verify that the clarification was received and is marked "General" under the "Problem" column.
- On the Admin, answer the "General" clar, and DO check the box "Send to all teams".
- On the WTI team, verify that the answer was received.
- Open a separate browser and login as a *different* team.
- Verify that the new team can see the answer to the "General" clarification that was sent to all teams.

