### PR TITLE
i_1164 Be sure to send to team id in announcement

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/ClarificationService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ClarificationService.java
@@ -300,7 +300,22 @@ public class ClarificationService implements Feature {
                     // not fit in the model of CLICS
                     // tell listener what to wait for
                     // TODO: allow submitAnnouncement to take 'null' for the 2 arrays.
-                    clarListener.setWaitId(controller.submitAnnouncement(clientId, problem, clar.getText(), new ElementId[0], new ClientId[0]));
+
+                    // Need to get client id of clar.getTo_team_id() and fill in first element
+                    // of array that gets passed to submitAnnouncement()
+                    String teamId = clar.getTo_team_id();
+                    ClientId [] destTeams = null;
+                    if(teamId == null || teamId.isEmpty()) {
+                        destTeams = new ClientId[0];
+                    } else {
+                        destTeams = new ClientId[1];
+                        destTeams[0] = getClientIdFromUser("team" + teamId);
+                        if(destTeams[0] == null) {
+                            // bad to team specified
+                            return Response.status(Status.BAD_REQUEST).entity("Bad to_team_id " + teamId).build();
+                        }
+                    }
+                    clarListener.setWaitId(controller.submitAnnouncement(clientId, problem, clar.getText(), new ElementId[0], destTeams));
                 } else {
                     // tell listener what to wait for
                     clarListener.setWaitId(controller.submitClarification(clientId, problem, clar.getText()));


### PR DESCRIPTION
### Description of what the PR does
If a `to_team_id `was specified for an announcement, it was ignored and the announcement was sent to everyone.
This fixes that by sending the team id to the `submitAnnouncement() `method if one was specified, otherwise an empty list is sent, like before, which means it would go to everyone.


### Issue which the PR addresses
Fixes #1164 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
TBD - It's easy to test if the environment is set up to send clars to the clics API.  I do not want to waste time at this point writing a long procedure to set that up, so, suffice to say, if you submit an announcement to the CLICS 2023-06 API, and specify a to_team_id property in the JSON, it will now send it to that team only.