### PR TITLE
i_1166 Better heuristics for guessing problem name

### DIFF
--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -25,6 +25,13 @@ server=localhost:50002
 wtiport=8080
 wtiwsName=/websocket
 
+[admin]
+sampleSubmitPane=true
+
+[judge]
+sampleSubmitPane=true
+
+
 [clics]
 apiVersionsSupported=2023-06,2020-03
 # Comma separated list of notification types (EventFeedTypes) to not use collections on.

--- a/src/edu/csus/ecs/pc2/ui/team/QuickSubmitter.java
+++ b/src/edu/csus/ecs/pc2/ui/team/QuickSubmitter.java
@@ -186,8 +186,47 @@ public class QuickSubmitter implements UIPlugin {
      * @return
      */
     private Problem guessProblem(IInternalContest contest2, String absolutePath) {
+
         Problem[] problems = contest.getProblems();
+        // The problem short name will come before the submissions/ folder
+        String submissionsBase = File.separator + IContestLoader.SUBMISSIONS_DIRNAME + File.separator;
+
+        // First heuristic is to isolate the problem shortname in the path.  A path looks like this:
+        // .../probshortname/submissions/accepted/xxx.cpp and we want to get probshortname
+        int iSub = absolutePath.indexOf(submissionsBase);
+        if(iSub != -1) {
+            String beforeSubmissionBase = absolutePath.substring(0, iSub);
+            // find previous File.separator
+            int iPrev = beforeSubmissionBase.lastIndexOf(File.separator);
+            // as long as it found one, we're good.
+            if(iPrev != -1) {
+                // starting index of problem short name
+                iPrev += File.separator.length();
+                // Get problem short name
+                String problemShortName = beforeSubmissionBase.substring(iPrev);
+                if(problemShortName.isEmpty() == false) {
+                    // scan problem list looking for it
+                    for (Problem problem : problems) {
+                        if (problemShortName.equals(problem.getShortName())) {
+                            return problem;
+                        }
+                    }
+                }
+                // If we can't find it, revert to the old method.
+            }
+        }
+
+        // 2nd heuristic Look for "/probshortname/"
         for (Problem problem : problems) {
+
+            if (absolutePath.indexOf(File.separator + problem.getShortName() + File.separator) != -1) {
+                return problem;
+            }
+        }
+
+        // Finally, just look for the problem short name anywhere in the path
+        for (Problem problem : problems) {
+
             if (absolutePath.indexOf(problem.getShortName()) != -1) {
                 return problem;
             }


### PR DESCRIPTION
### Description of what the PR does
Fixed `QuickSubmitter.guessProblem()`, which is ONLY used pre-contest when submitting judge's samples, so it better chooses the correct problem.  The fix involved adding 2 additional ways to guess the correct problem.  First, it will try looking at the expected pathname of the judge's submission, and it will isolate the problem short-name (id).  If that fails, it will try to look for `'/' + problem-short-name + '/'` in the pathname.  If that fails, it will just do what it did before, namely, just see if the problem short-name is anywhere in the pathname.

Also include an updated `pc2v9.ini `that will show the **Submit Samples** pane on the admin and judges.  (This is a good default anyway.)


### Issue which the PR addresses
Fixes #1166 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)
and
Ubuntu 24.04
Java 21.0.4

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Follow the same steps in the issue #1166, but note that the correct problem is chosen.