### PR TITLE
I1162 wti filter out clarifications

### DIFF
--- a/projects/WTI-UI/src/app/app.component.ts
+++ b/projects/WTI-UI/src/app/app.component.ts
@@ -323,6 +323,17 @@ export class AppComponent implements OnInit {
       return value ? JSON.parse(value) : null;
   }
   
+  //save the current clarification page filter values in sessionStorage so a subsequent F5 (refresh) can restore them
+  export function saveClarPageFilterValues(clarFilterValues: Object) {
+      return (sessionStorage.setItem(Constants.CLARS_PAGE_FILTER_KEY, JSON.stringify(clarFilterValues)));
+  }
+  
+  //return the most recently saved clarification page filter values from sessionStorage
+  export function getClarPageFilterValues() {
+      const value = sessionStorage.getItem(Constants.CLARS_PAGE_FILTER_KEY);
+      return value ? JSON.parse(value) : null;
+  }
+  
   //clear all data in sessionStorage
   export function clearSessionStorage() {
       sessionStorage.clear();

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.html
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.html
@@ -28,7 +28,7 @@
                 </label>
             </div>
             <div>
-    			<app-problem-selector [allowGeneral]='true' formControlName='problem'></app-problem-selector>
+				<app-problem-selector formControlName='problem' [allowMultiSelect]="true" [allowGeneral]='true'></app-problem-selector>
             </div>
             <div>
                 <button class='outline' type='button' (click)='reset()'>Clear Filters</button>

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -78,12 +78,32 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
   }
 
   private buildForm(): void {
+	
+	//Try to restore clar page filter form settings from sessionStorage
+  	let savedForm: { recipient?: string; problem?: string | string[] } = {};
+  	try {
+    	const stored = sessionStorage.getItem(Constants.CLARS_PAGE_FILTER_KEY);
+    	if (stored) {
+      		savedForm = JSON.parse(stored);
+    	}
+  	} catch (e) {
+    	console.warn('Failed to parse clar filter form settings from sessionStorage', e);
+  	}
+
+	//build the form using the saved filter values (or defaults)
     this.filterForm = this._formBuilder.group({
-      recipient: [''],
-      problem: [],
+      recipient: [savedForm.recipient || ''],
+      problem: [savedForm.problem || []],     // default to empty array if nothing saved
     });
 
-    this.filterForm.valueChanges.subscribe(_ => this.filterClarifications());
+	//filter and save clar page filter settings on any change
+    this.filterForm.valueChanges.subscribe(formValue => {
+	
+		this.filterClarifications();
+		
+		//save the updated filter settings to sessionStorage
+		sessionStorage.setItem(Constants.CLARS_PAGE_FILTER_KEY, JSON.stringify(formValue));
+	});
   }
 
   private loadClars(): void {
@@ -106,6 +126,7 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
   }
 
   public reset(): void {
+	sessionStorage.removeItem(Constants.CLARS_PAGE_FILTER_KEY);
     this.filteredClarifications = this.clarifications;
     this.buildForm();
   }

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -70,7 +70,8 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
 	//filter out clars for any not-selected problem
 	const selectedProblems = filterParams.problem;
 	if (Array.isArray(selectedProblems) && selectedProblems.length > 0) {
-  		filtered = filtered.filter(x => selectedProblems.includes(x.problem));
+		//ignore case (necessary so "General" matches "general")
+		filtered = filtered.filter(x => selectedProblems.some(p => p.toLowerCase() === x.problem.toLowerCase()));
 	}
 
     this.filteredClarifications = filtered;

--- a/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/clarifications/components/clarifications-page/clarifications-page.component.ts
@@ -66,7 +66,12 @@ export class ClarificationsPageComponent implements OnInit, OnDestroy {
     if (filterParams.recipient === 'all') { filtered = filtered.filter(x => (x.recipient === 'All' || x.recipient === "No Answer Yet")); }
     if (filterParams.recipient === 'some') { filtered = filtered.filter(x => (x.recipient === 'Some' || x.recipient === "No Answer Yet")); }
     if (filterParams.recipient === 'team') { filtered = filtered.filter(x => (x.recipient === 'My Team' || x.recipient === "No Answer Yet")); }
-    if (filterParams.problem) { filtered = filtered.filter(x => x.problem?.toLowerCase() === filterParams.problem.toLowerCase()); }
+
+	//filter out clars for any not-selected problem
+	const selectedProblems = filterParams.problem;
+	if (Array.isArray(selectedProblems) && selectedProblems.length > 0) {
+  		filtered = filtered.filter(x => selectedProblems.includes(x.problem));
+	}
 
     this.filteredClarifications = filtered;
   }

--- a/projects/WTI-UI/src/app/modules/shared/components/problem-selector/problem-selector.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/problem-selector/problem-selector.component.html
@@ -6,10 +6,9 @@
     	[(ngModel)]='value' 
     	(ngModelChange)='onChange($event)'
     	[multiple]='allowMultiSelect'>
-		<mat-option *ngIf="!allowMultiSelect" [value]="undefined">Select Problem</mat-option>
-        <mat-option *ngIf='allowGeneral' value='general'>
-            General
-        </mat-option>
+    	<!-- Add "General" to drop-down problem list if allowed (i.e. if specified by parent component) -->
+        <mat-option *ngIf='allowGeneral' value='general'>General</mat-option>
+        <!-- Add each problem name to  drop-down problem list -->
         <mat-option *ngFor='let problem of problems' [value]='problem.name'>{{ problem.name }}</mat-option>
     </mat-select>
 </mat-form-field>

--- a/projects/WTI-UI/src/app/modules/shared/components/problem-selector/problem-selector.component.html
+++ b/projects/WTI-UI/src/app/modules/shared/components/problem-selector/problem-selector.component.html
@@ -1,9 +1,12 @@
-<mat-form-field>
+<mat-form-field [matTooltip]="getTooltip()" matTooltipPosition="right">
     <mat-label>
         Select Problem
     </mat-label>
-    <mat-select [(ngModel)]='value' (ngModelChange)='onChange($event)'>
-            <mat-option [value]='undefined'>Select Problem</mat-option>
+    <mat-select 
+    	[(ngModel)]='value' 
+    	(ngModelChange)='onChange($event)'
+    	[multiple]='allowMultiSelect'>
+		<mat-option *ngIf="!allowMultiSelect" [value]="undefined">Select Problem</mat-option>
         <mat-option *ngIf='allowGeneral' value='general'>
             General
         </mat-option>

--- a/projects/WTI-UI/src/app/modules/shared/components/problem-selector/problem-selector.component.ts
+++ b/projects/WTI-UI/src/app/modules/shared/components/problem-selector/problem-selector.component.ts
@@ -29,11 +29,13 @@ providers: [
 })
 export class ProblemSelectorComponent implements OnInit, OnDestroy, ControlValueAccessor {
 	private _unsubscribe = new Subject<void>();
-	@Input() allowGeneral = false;
+	@Input() allowGeneral = false;	//default is don't include "general" as a problem choice
+	@Input() allowMultiSelect = false;  // default to single-select unless the parent component overrides
+	
 	problems: ContestProblem[] = [];
 	
 	//fields required to implement "ControlValueAccessor"
-	value: string;
+	value: string | string[];  // depending on single-select or multiSelect mode
 	onChange = (event: any) => { };
 	onTouched = (event: any) => { };
 
@@ -75,8 +77,12 @@ export class ProblemSelectorComponent implements OnInit, OnDestroy, ControlValue
 		this.onTouched = fn;
 	}
 
-	writeValue(value: string) {
-		this.value = (value === null) ? undefined : value;
+	writeValue(value: string | string[] | null) {
+  		if (this.allowMultiSelect) {
+    		this.value = Array.isArray(value) ? value : (value ? [value] : []);
+  		} else {
+    		this.value = typeof value === 'string' ? value : (Array.isArray(value) && value.length > 0 ? value[0] : '');
+  		}
 	}
 
 	/**
@@ -136,4 +142,21 @@ export class ProblemSelectorComponent implements OnInit, OnDestroy, ControlValue
 			return false;
 		}
 	}
+	
+	/**
+	 * If we are in multi-select mode, returns a tooltip string which is a comma-separated list
+	 * of all the currently selected problems.
+	 * In single-select mode, returns a string containing the (single) currently selected problem.
+     * In either mode, if no problem has been selected, returns the string "No problem selected".
+	 */
+	public getTooltip(): string {
+  		if (this.allowMultiSelect && Array.isArray(this.value)) {
+    		return this.value.length > 0 ? this.value.join(', ') : 'No problems selected';
+  		} else if (typeof this.value === 'string' && this.value) {
+    		return this.value;
+  		} else {
+    		return 'No problem selected';
+  		}
+	}
+
 }

--- a/projects/WTI-UI/src/app/modules/shared/shared.module.ts
+++ b/projects/WTI-UI/src/app/modules/shared/shared.module.ts
@@ -12,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { AboutWtiComponent } from './components/about-wti/about-wti.component';
 import { BrowserModule } from '@angular/platform-browser';
 import { DisplayTimePipe } from 'src/app/modules/core/services/displayTimePipe.service';
@@ -42,6 +43,7 @@ import { HttpClient } from '@angular/common/http';
     MatInputModule,
     MatSelectModule,
     MatSnackBarModule,
+	MatTooltipModule,
     BrowserModule,
     DisplayTimePipe
   ],

--- a/projects/WTI-UI/src/constants.ts
+++ b/projects/WTI-UI/src/constants.ts
@@ -48,6 +48,11 @@ export const RUNS_ENABLED_OPTIONS_KEY = 'runsNotificationsEnabled';
 export const CLARIFICATIONS_PAGE = 'clarifications';
 
 /**
+ * The storageSession key indicating what filter settings (recipient and problems) have been selected on the CLARIFICATIONS page filter.
+ */
+export const CLARS_PAGE_FILTER_KEY = 'clarificationsFilterForm';
+
+/**
   * The storageSession value indicating the SCOREBOARD page is "current".
  */
 export const SCOREBOARD_PAGE = 'scoreboard';


### PR DESCRIPTION
### Description of what the PR does
Provides support for multi-selection of problems in the Clarifications Page problem filter dropdown list.  This allows teams to choose to filter out certain problems they may not be interested in seeing clarifications for.

Also provides support for SAVING clar page filter settings in sessionStorage -- including both problem  and "recipient" settings -- and subsequently restoring them on a page reload.

### Issue which the PR addresses
Fixes #1162 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, Eclipse Version: 2020-12 (4.18.0), Java version "1.8.0_271"

### Precise steps for _testing_ the PR

- Download and unzip the PR distribution
- Start a PC2 Server using `--load tenprobs`
- Start a PC2 Admin
- In the "projects" folder, unzip the WTI distribution
- 'cd' to the WebTeamInterface-1.2 folder
- Execute the command `./bin/pc2wti` to start the WTI server
- Open a browser and connect to the WTI server (e.g. using "http://localhost:8080")
- Login as a team
- Select the "Clarifications" tab
- Select "New Clarification"
- Select a problem (e.g. "Sumit a"), enter some clarification text, and submit a clarification request
- Select "New Clarification" again
- Select a DIFFERENT problem (e.g. "Sumit b") and submit a clarification request for that problem.
- On the main "Clarifications" screen, click "Select Problem", then check the boxes for both "Sumit a" AND "Sumit b".
- Verify that both clars (one for problem "a", one for problem "b") are shown on the screen
- Click the "Select Problem" dropdown again, and *deselect* one of the problems ("a" or "b").
- Verify that only the clar for the still-selected problem is displayed.
- Click the "Clear Filters" button; verify that all clars are once again displayed.

- Click the "Select Problem" dropdown again; select some problem (or multiple problems) for which no clars have been submitted.
- Verify that no clars are displayed on the main display

- Select several problems, including at least one for which a clar has been submitted. Also change the "Recipient" filter radio button from the default ("All the above") to some other setting.  Remember what filter settings you've chosen.
- Click the "Runs" tab.
- Click the "Clars" tab; verify that the filter setting you chose are still the current settings (i.e., verify that filter settings are preserved when navigating to another page and back).
- Hit F5 (Refresh the page), then verify that the filter settings are still retained.

