### PR TITLE
i_1171 Do not generate Honors rules for groups

### DIFF
--- a/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
@@ -172,7 +172,8 @@ public class ResultsFile {
         if (finalizeData == null) {
             finalizeData = GenDefaultFinalizeData();
         }
-        // Do not use Bill honors WF ranking rules for groups
+        // Only use Bill honors WF ranking rules if not for a specific group and we're doing WF ranks
+        // Calculating the Bill honors rules doesn't make sense for sub-groups
         boolean useHonorsRules = (group == null && finalizeData.isUseWFGroupRanking());
 
         if (useHonorsRules && finalizeData.isCustomizeHonorsSolvedCount()) {

--- a/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
@@ -172,8 +172,10 @@ public class ResultsFile {
         if (finalizeData == null) {
             finalizeData = GenDefaultFinalizeData();
         }
+        // Do not use Bill honors WF ranking rules for groups
+        boolean useHonorsRules = (group == null && finalizeData.isUseWFGroupRanking());
 
-        if (finalizeData.isUseWFGroupRanking() && finalizeData.isCustomizeHonorsSolvedCount()) {
+        if (useHonorsRules && finalizeData.isCustomizeHonorsSolvedCount()) {
             if (finalizeData.getHighestHonorSolvedCount() != 0) {
                 highestHonorSolvedCount = finalizeData.getHighestHonorSolvedCount();
             }
@@ -205,11 +207,13 @@ public class ResultsFile {
         Arrays.sort(standingsRecords, comparator);
 
         int realRank = 0;
-        if (highestHonorSolvedCount == 0) {
-            highestHonorSolvedCount = standingsRecords[lastMedalRank - 1].getNumberSolved();
-        }
-        if (highHonorSolvedCount == 0) {
-            highHonorSolvedCount = standingsRecords[lastMedalRank - 1].getNumberSolved() - 1;
+        if(useHonorsRules) {
+            if (highestHonorSolvedCount == 0) {
+                highestHonorSolvedCount = standingsRecords[lastMedalRank - 1].getNumberSolved();
+            }
+            if (highHonorSolvedCount == 0) {
+                highHonorSolvedCount = standingsRecords[lastMedalRank - 1].getNumberSolved() - 1;
+            }
         }
 
         for (StandingsRecord record : standingsRecords) {
@@ -231,7 +235,7 @@ public class ResultsFile {
             boolean isHighHonor = false;
             boolean isHonor = false;
 
-            if (finalizeData.isUseWFGroupRanking()) {
+            if (useHonorsRules) {
                 if (record.getNumberSolved() >= highestHonorSolvedCount) {
                     isHighestHonor = true;
                 } else if (record.getNumberSolved() >= highHonorSolvedCount) {


### PR DESCRIPTION
### Description of what the PR does
It makes no sense to apply WF honors rules for individual groups.  This PR avoids generating the honors rules results for groups.

### Issue which the PR addresses
Fixes #1171 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

Ubuntu 24.04

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Load a completed contest that has groups that contain less than the number of medals (usually 12).
2. Finalize the contest if it is not already finalized.
3. Start a scoreboard thick client.
4. Observe that all "`index.html`", "`results.tsv`" and "`results.csv`" are generated for all non-hidden groups, even if the groups are empty.
