### PR TITLE
I1170 handle zero-length WTI submission files

### DIFF
--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -286,6 +286,10 @@ public class TeamsController extends MainController {
 			    case SOURCE_TOO_BIG:
 			        stat = Response.Status.REQUEST_ENTITY_TOO_LARGE;
 			        break;
+			    case ZERO_LENGTH_FILE:
+			        //not strictly necessary since BAD_REQUEST is the default (assigned above), but added here for clarity/completeness
+                    stat = Response.Status.BAD_REQUEST;
+                    break;
 			}
 			return Response.status(stat)
 					.entity(Entity.json(new ServerErrorResponseModel(stat, msg)))

--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -277,7 +277,7 @@ public class TeamsController extends MainController {
 		}
 		catch (SubmissionRejectedException e) {
 			String msg = e.getMessage();
-			Response.Status stat = Response.Status.BAD_REQUEST;
+			Response.Status stat ;
 			// set appropriate HTML status code depending on why the submission was rejected
 			switch(e.getRejectionReason()) {
 			    case THROTTLE_EXCEEDED:
@@ -287,9 +287,11 @@ public class TeamsController extends MainController {
 			        stat = Response.Status.REQUEST_ENTITY_TOO_LARGE;
 			        break;
 			    case ZERO_LENGTH_FILE:
-			        //not strictly necessary since BAD_REQUEST is the default (assigned above), but added here for clarity/completeness
                     stat = Response.Status.BAD_REQUEST;
                     break;
+			    default:
+			    	stat = Response.Status.BAD_REQUEST;
+			    	break;
 			}
 			return Response.status(stat)
 					.entity(Entity.json(new ServerErrorResponseModel(stat, msg)))

--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -237,7 +237,7 @@ public class TeamsController extends MainController {
 
 			IFile main = new PC2APIFile(run.getMainFile().getFileName(), run.getMainFile().getByteData());
 
-			if(run.getExtraFiles() != null) {			
+			if(run.getExtraFiles() != null  &&  run.getExtraFiles().length > 0) {			
 				IFile[] extraFiles = FileService.createFileArray(run.getExtraFiles());
 				teamsConn.submitJudgeRun(prob, lang, main, extraFiles);
 			}

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run/new-run.component.ts
@@ -141,12 +141,14 @@ export class NewRunComponent implements OnInit, OnDestroy {
 	        this._teamService.runsUpdated.next();
 	    },
 	    error: (error: any) => {
-          let msg = 'Not accepting submissions at this time';
-          // 429 = too many requests, 413 = request entity too large, in these cases
-          // we'll use whatever msg was supplied by the PC2 API
-          if (error.status == 429 || error.status == 413){
-              msg = error.error.entity.message;
+	      //get the error message supplied by the PC2 API (if any)
+          let msg = error.error.entity.message;
+	      
+	      // if the error msg wasn't a valid string (or was empty) we'll use a generic default message.
+          if (!(typeof msg === 'string' && msg.trim().length > 0)){
+              msg = 'Error in submission';
           }
+	      
 	      this._uiHelper.alertError(msg);
 	      console.error(msg);
 	    },

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -27,6 +27,7 @@ import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType;
+import edu.csus.ecs.pc2.core.model.ContestInformation;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -431,37 +432,26 @@ public class ServerConnection {
         checkWhetherLoggedIn();
 
         checkIsAllowed (Permission.Type.SUBMIT_RUN, "User not allowed to submit run");
-
-        File mainFile = new File(mainFileName);
-        if (! mainFile.isFile()){
-            throw new Exception("File '" + mainFileName + "': no such file (not found)");
-        }
         
-        long sourceSize = mainFile.length();
-        
-        // make sure we don't accept a zero-length main file if that's not allowed
-        if (sourceSize <= 0) {
-            throw new SubmissionRejectedException("Zero-length file not allowed", SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);            
-        }
+        //throw an exception if the main file is not legal
+        checkLegalFile(mainFileName);
 
         // we are keeping track of the total submission size in sourceSize
+        File mainFile = new File(mainFileName);
+        long sourceSize = mainFile.length();
+        
+        //check each "additional file" (if any) for validity and if valid, add file size to running total size
         SerializedFile[] list = new SerializedFile[additionalFileNames.length];
         for (int i = 0; i < additionalFileNames.length; i++) {
-            File addFile = new File(additionalFileNames[i]);
-            //make sure the named item really is a file...
-            if (addFile.isFile()) {
-                // make sure we don't accept a zero-length additional file if that's not allowed
-                if (addFile.length() <= 0) {
-                    throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
-                            SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-                } else {
-                    //file is ok; add to list and update total source size
-                    list[i] = new SerializedFile(additionalFileNames[i]);
-                    sourceSize += addFile.length();
-                } 
-            } else {
-                throw new Exception("File '" + additionalFileNames[i] + "': no such file (not found)");
-            }
+            
+            //throw an exception if the current additional file is not legal
+            checkLegalFile(additionalFileNames[i]);
+            
+            //file is ok; add to list and update total source size
+            list[i] = new SerializedFile(additionalFileNames[i]);
+            File addlFile = new File(additionalFileNames[i]);
+            sourceSize += addlFile.length();
+
         }
 
         long sourceSizeByteLimit = internalContest.getContestInformation().getMaxSourceSizeInBytes();
@@ -472,6 +462,7 @@ public class ServerConnection {
 //            StaticLog.getLog().log(Level.WARNING, sizeMsg);
             throw new SubmissionRejectedException(sizeMsg, SubmissionRejectedException.SubmissionRejectionReason.SOURCE_TOO_BIG);
         }
+        
         ProblemImplementation problemImplementation = (ProblemImplementation) problem;
         Problem submittedProblem = internalContest.getProblem(problemImplementation.getElementId());
 
@@ -578,18 +569,9 @@ public class ServerConnection {
 
         checkIsAllowed (Permission.Type.SUBMIT_RUN, "User not allowed to submit run");
 
-        //reject zero-length file if such is not allowed
-        if (mainFile!=null && mainFile.getByteData().length<=0 && 
-                !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
-            throw new SubmissionRejectedException("Zero-length file not allowed", 
-                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-        }
+        //throw an exception if the main file isn't legal
+        checkValidIFile(mainFile);
         
-        //validate mainFile param
-        if (!validIFile(mainFile)) {
-            throw new Exception("Invalid mainFile parameter");
-        }
-
         // we keep track of the total submission size of all the source files
         long sourceSize = mainFile.getByteData().length;
         
@@ -597,24 +579,10 @@ public class ServerConnection {
         if (additionalFiles != null && additionalFiles.length > 0) {
             for (IFile nextFile : additionalFiles) {
                 
-                //reject zero-length additional file if such is not allowed
-                if (nextFile!=null && nextFile.getByteData().length<=0 && 
-                        !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
-                    throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
-                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-                }
-                
-                //check IFile validity
-                if (!validIFile(nextFile)) {
-                    // check whether the "invalid IFile" reason is a zero-length file if that's not allowed
-                    if (nextFile.getByteData().length <= 0) {
-                        throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
-                                                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-                    } else {
-                        throw new Exception("Invalid IFile in additionalFiles array");
-                    }
-                }
-                
+                //throw an exception if the current "additional file" isn't legal
+                checkValidIFile(nextFile);
+                        
+                //nextFile is valid; add its size to the running total size
                 sourceSize += nextFile.getByteData().length;
             }
         }
@@ -742,62 +710,25 @@ public class ServerConnection {
 
         checkIsAllowed (Permission.Type.SUBMIT_RUN, "User not allowed to submit test run");
 
-        //reject zero-length file if such is not allowed
-        if (mainFile!=null && mainFile.getByteData().length<=0 && 
-                !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
-            throw new SubmissionRejectedException("Zero-length file not allowed", 
-                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-        }
+        //TODO:  when (if) "test submissions" are eventually supported, need to add checks for exceeding submission file size limit
         
-        //validate mainFile param
-        if (!validIFile(mainFile)) {
-            throw new Exception("Invalid mainFile parameter");
-        }
+        //throw an exception if either the main file or the test data file isn't legal
+        checkValidIFile(mainFile);
+        checkValidIFile(testDataFile);
         
         // validate additionalSourceFiles param
         if (additionalSourceFiles != null && additionalSourceFiles.length > 0) {
             for (IFile nextFile : additionalSourceFiles) {
-
-                //reject zero-length additional file if such is not allowed
-                if (nextFile!=null && nextFile.getByteData().length<=0 && 
-                        !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
-                    throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
-                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-                }
-                
-                if (!validIFile(nextFile)) {
-                    throw new Exception("Invalid IFile in additionalSourceFiles array");
-                }
+                //throw an exception if the next file isn't legal
+                checkValidIFile(nextFile);
             }
-        }
-
-        //reject zero-length testDataFile if such is not allowed
-        if (testDataFile!=null && testDataFile.getByteData().length<=0 && 
-                !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
-            throw new SubmissionRejectedException("Zero-length file not allowed", 
-                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-        }
-        
-        // validate testDataFile param
-        if (!validIFile(testDataFile)) {
-            throw new Exception("Invalid testDataFile parameter");
         }
 
         // validate additionalTestDataFiles param
         if (additionalTestDataFiles != null && additionalTestDataFiles.length > 0) {
             for (IFile nextFile : additionalTestDataFiles) {
-
-                //reject zero-length additionalTestDataFile if such is not allowed
-                if (nextFile!=null && nextFile.getByteData().length<=0 && 
-                        !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
-                    throw new SubmissionRejectedException("Zero-length file not allowed", 
-                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-                }
-                
-                
-                if (!validIFile(nextFile)) {
-                    throw new Exception("Invalid IFile in additionalTestDataFiles array");
-                }
+                //throw an exception if the next file isn't legal
+                checkValidIFile(nextFile);
             }
         }
 
@@ -892,12 +823,26 @@ public class ServerConnection {
 
         checkIsAllowed (Permission.Type.SUBMIT_RUN, "User not allowed to submit test run");
 
-        if (! new File(mainFileName).isFile()){
-            throw new Exception("File '"+mainFileName+"' no such file (not found)");
+        //TODO:  when (if) "test submissions" are eventually supported, need to add checks for exceeding submission file size limit
+        
+        //check for legal main file and test data file
+        checkLegalFile(mainFileName);
+        checkLegalFile(testDataFileName);
+        
+        // validate otherSourceFiles param
+        if (otherSourceFileNames != null && otherSourceFileNames.length > 0) {
+            for (String nextFileName : otherSourceFileNames) {
+                //throw an exception if the next file isn't legal
+                checkLegalFile(nextFileName);
+            }
         }
 
-        if (testDataFileName != null && ! new File(testDataFileName).isFile()){
-            throw new Exception("File '"+testDataFileName+"' no such file (not found)");
+        // validate additionalTestDataFiles param
+        if (otherDataFileNames != null && otherDataFileNames.length > 0) {
+            for (String nextFileName : otherDataFileNames) {
+                //throw an exception if the next file isn't legal
+                checkLegalFile(nextFileName);
+            }
         }
 
         ProblemImplementation problemImplementation = (ProblemImplementation) problem;
@@ -1677,29 +1622,67 @@ public class ServerConnection {
     }
 
     /**
-     * Returns an indication of whether the specified {@link IFile} is valid or not.
-     * An IFile is considered "valid" if it is not null and has a non-null, non-zero-length name.
-     * 
-     * Note that a PREVIOUS version of this method also required the file to have more than 
-     * zero bytes of data to be valid. However, that check was incompatible with newly-added features which
-     * allow the Admin to allow (or disallow) zero-length files.  Checks for zero-length files
-     * now need to be done external to this method, in order to allow separate detection of the
-     * zero-file-length condition so that the appropriate {@link SubmissionRejectedException} can
-     * be thrown.
+     * Throws an Exception if the specified {@link IFile} is invalid.
+     * An IFile is considered "invalid" if it is null, has a name which is null or empty,
+     * or is  zero length when zero-length files have been prohibited in the current {@link ContestInformation} configuration.
      *
      * @param file the IFile to be checked for validity.
      *
-     * @return true if the IFile is not null and has a file name that is not null and not empty;
-     *         false otherwise.
-     *         
-     * @see SubmissionRejectedException
+     * @throws Exception if the file is null or has a name which is null or empty.
+     * @throws SubmissionRejectedException if the file has zero length but such files are not allowed in submissions.
+     * 
      */
-    private boolean validIFile(IFile file) {
+    private void checkValidIFile(IFile file) throws Exception {
         if (file==null || file.getFileName()==null || file.getFileName().equals("")) {
-            return false;
+            throw new Exception("Invalid file");
         }
-        return true;
+        
+        //reject zero-length file if such is not allowed
+        if (file.getByteData().length<=0 && !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", 
+                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+        }
     }
+    
+    /**
+     * Checks whether the specified File is zero length; throws {@link SubmissionRejectedException} if so AND if
+     * zero-length files have been configured as being disallowed.
+     * 
+     * @param aFile the File whose length is to be checked.
+     * @throws SubmissionRejectedException if the file is zero length AND zero-length files are not allowed in submissions.
+     */
+    private void checkFilePassesZeroLengthRestrictions(File aFile) throws SubmissionRejectedException {
+        
+        long fileSize = aFile.length();
+
+        if (fileSize <= 0 && !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);            
+        }   
+    }
+
+
+    /**
+     * Throws an exception if the specified fileName string is not the name of a legitimate file,
+     * or if the file exists but is zero length when zero-length files are prohibited.
+     * 
+     * @param fileName the String name of the file to be checked.
+     * 
+     * @throws Exception if the specified file name String isn't actually a file.
+     * @throws SubmissionRejectedException if the file exists but has zero length when that is prohibited.
+     *          Note that this exception is thrown by being forwarded from method {@link #checkFilePassesZeroLengthRestrictions(File)}.
+     *          
+     */
+    private void checkLegalFile(String fileName) throws Exception {
+        
+        File theFile = new File(fileName);
+        if (fileName == null  || !theFile.isFile()){
+            throw new Exception("File '" + fileName + "': no such file (not found)");
+        } else {
+            // throw an exception if mainFile is zero-length but that's not allowed
+            checkFilePassesZeroLengthRestrictions(theFile);
+        }
+    }
+
 
     private static void fatalError(String string) {
         System.err.println(string);

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -434,19 +434,33 @@ public class ServerConnection {
 
         File mainFile = new File(mainFileName);
         if (! mainFile.isFile()){
-            throw new Exception("File '"+mainFileName+"' no such file (not found)");
+            throw new Exception("File '" + mainFileName + "': no such file (not found)");
+        }
+        
+        long sourceSize = mainFile.length();
+        
+        // make sure we don't accept a zero-length main file if that's not allowed
+        if (sourceSize <= 0) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);            
         }
 
         // we are keeping track of the total submission size in sourceSize
-        long sourceSize = mainFile.length();
         SerializedFile[] list = new SerializedFile[additionalFileNames.length];
         for (int i = 0; i < additionalFileNames.length; i++) {
             File addFile = new File(additionalFileNames[i]);
+            //make sure the named item really is a file...
             if (addFile.isFile()) {
-                list[i] = new SerializedFile(additionalFileNames[i]);
-                sourceSize += addFile.length();
+                // make sure we don't accept a zero-length additional file if that's not allowed
+                if (addFile.length() <= 0) {
+                    throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
+                            SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+                } else {
+                    //file is ok; add to list and update total source size
+                    list[i] = new SerializedFile(additionalFileNames[i]);
+                    sourceSize += addFile.length();
+                } 
             } else {
-                throw new Exception("File '" + additionalFileNames[i] + "' no such file (not found)");
+                throw new Exception("File '" + additionalFileNames[i] + "': no such file (not found)");
             }
         }
 
@@ -572,6 +586,7 @@ public class ServerConnection {
         // we keep track of the total submission size of all the source files
         long sourceSize = mainFile.getByteData().length;
         
+        // make sure we don't accept a zero-length main file if that's not allowed
         if (sourceSize <= 0) {
             throw new SubmissionRejectedException("Zero-length file not allowed", SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);            
         }
@@ -579,7 +594,9 @@ public class ServerConnection {
         // validate additionalSourceFiles param
         if (additionalFiles != null && additionalFiles.length > 0) {
             for (IFile nextFile : additionalFiles) {
+                //check IFile validity (includes checking for length > 0)
                 if (!validIFile(nextFile)) {
+                    // check whether the "invalid IFile" reason is a zero-length file if that's not allowed
                     if (nextFile.getByteData().length <= 0) {
                         throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
                                                                 SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -571,12 +571,21 @@ public class ServerConnection {
 
         // we keep track of the total submission size of all the source files
         long sourceSize = mainFile.getByteData().length;
+        
+        if (sourceSize <= 0) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);            
+        }
 
         // validate additionalSourceFiles param
         if (additionalFiles != null && additionalFiles.length > 0) {
             for (IFile nextFile : additionalFiles) {
                 if (!validIFile(nextFile)) {
-                    throw new Exception("Invalid IFile in additionalFiles array");
+                    if (nextFile.getByteData().length <= 0) {
+                        throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
+                                                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+                    } else {
+                        throw new Exception("Invalid IFile in additionalFiles array");
+                    }
                 }
                 sourceSize += nextFile.getByteData().length;
             }
@@ -636,8 +645,7 @@ public class ServerConnection {
                                         overrideSubmissionTimeMS, overrideRunId);
         }
         catch (SubmissionRejectedException e) {
-            //the submission was rejected, presumably because of the submitJudgeRun() method's ThrottleStrategy;
-            //forward the exception to the caller
+            //the submission was rejected; forward the exception to the caller
             throw e ;
         }
         catch (Exception e) {

--- a/src/edu/csus/ecs/pc2/api/ServerConnection.java
+++ b/src/edu/csus/ecs/pc2/api/ServerConnection.java
@@ -578,6 +578,13 @@ public class ServerConnection {
 
         checkIsAllowed (Permission.Type.SUBMIT_RUN, "User not allowed to submit run");
 
+        //reject zero-length file if such is not allowed
+        if (mainFile!=null && mainFile.getByteData().length<=0 && 
+                !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", 
+                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+        }
+        
         //validate mainFile param
         if (!validIFile(mainFile)) {
             throw new Exception("Invalid mainFile parameter");
@@ -586,24 +593,22 @@ public class ServerConnection {
         // we keep track of the total submission size of all the source files
         long sourceSize = mainFile.getByteData().length;
         
-        // make sure we don't accept a zero-length main file if that's not allowed
-        if (sourceSize <= 0) {
-            throw new SubmissionRejectedException("Zero-length file not allowed", SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);            
-        }
-
         // validate additionalSourceFiles param
         if (additionalFiles != null && additionalFiles.length > 0) {
             for (IFile nextFile : additionalFiles) {
-                //check IFile validity (includes checking for length > 0)
-                if (!validIFile(nextFile)) {
-                    // check whether the "invalid IFile" reason is a zero-length file if that's not allowed
-                    if (nextFile.getByteData().length <= 0) {
-                        throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
-                                                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
-                    } else {
-                        throw new Exception("Invalid IFile in additionalFiles array");
-                    }
+                
+                //reject zero-length additional file if such is not allowed
+                if (nextFile!=null && nextFile.getByteData().length<=0 && 
+                        !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+                    throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
+                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
                 }
+                
+                //check IFile validity
+                if (!validIFile(nextFile)) {
+                    throw new Exception("Invalid IFile in additionalFiles array");
+                }
+                
                 sourceSize += nextFile.getByteData().length;
             }
         }
@@ -731,19 +736,42 @@ public class ServerConnection {
 
         checkIsAllowed (Permission.Type.SUBMIT_RUN, "User not allowed to submit test run");
 
+        //reject zero-length file if such is not allowed
+        if (mainFile!=null && mainFile.getByteData().length<=0 && 
+                !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", 
+                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+        }
+        
         //validate mainFile param
         if (!validIFile(mainFile)) {
             throw new Exception("Invalid mainFile parameter");
         }
+        
         // validate additionalSourceFiles param
         if (additionalSourceFiles != null && additionalSourceFiles.length > 0) {
             for (IFile nextFile : additionalSourceFiles) {
+
+                //reject zero-length additional file if such is not allowed
+                if (nextFile!=null && nextFile.getByteData().length<=0 && 
+                        !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+                    throw new SubmissionRejectedException("Zero-length file (in 'additional files') not allowed", 
+                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+                }
+                
                 if (!validIFile(nextFile)) {
                     throw new Exception("Invalid IFile in additionalSourceFiles array");
                 }
             }
         }
 
+        //reject zero-length testDataFile if such is not allowed
+        if (testDataFile!=null && testDataFile.getByteData().length<=0 && 
+                !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+            throw new SubmissionRejectedException("Zero-length file not allowed", 
+                        SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+        }
+        
         // validate testDataFile param
         if (!validIFile(testDataFile)) {
             throw new Exception("Invalid testDataFile parameter");
@@ -752,6 +780,15 @@ public class ServerConnection {
         // validate additionalTestDataFiles param
         if (additionalTestDataFiles != null && additionalTestDataFiles.length > 0) {
             for (IFile nextFile : additionalTestDataFiles) {
+
+                //reject zero-length additionalTestDataFile if such is not allowed
+                if (nextFile!=null && nextFile.getByteData().length<=0 && 
+                        !internalContest.getContestInformation().isAllowZeroLengthSubmissionFiles()) {
+                    throw new SubmissionRejectedException("Zero-length file not allowed", 
+                                SubmissionRejectedException.SubmissionRejectionReason.ZERO_LENGTH_FILE);
+                }
+                
+                
                 if (!validIFile(nextFile)) {
                     throw new Exception("Invalid IFile in additionalTestDataFiles array");
                 }
@@ -1635,19 +1672,24 @@ public class ServerConnection {
 
     /**
      * Returns an indication of whether the specified {@link IFile} is valid or not.
-     * An IFile is considered "valid" if it is not null, has a non-null, non-zero-length name,
-     * and has more than zero bytes of data.
+     * An IFile is considered "valid" if it is not null and has a non-null, non-zero-length name.
+     * 
+     * Note that a PREVIOUS version of this method also required the file to have more than 
+     * zero bytes of data to be valid. However, that check was incompatible with newly-added features which
+     * allow the Admin to allow (or disallow) zero-length files.  Checks for zero-length files
+     * now need to be done external to this method, in order to allow separate detection of the
+     * zero-file-length condition so that the appropriate {@link SubmissionRejectedException} can
+     * be thrown.
      *
-     * @param file the IFile to be checked for validity
+     * @param file the IFile to be checked for validity.
      *
-     * @return true if the IFile is not null, has a file name that is not null and not empty,
-     *          and has greater than zero data bytes; false otherwise
+     * @return true if the IFile is not null and has a file name that is not null and not empty;
+     *         false otherwise.
+     *         
+     * @see SubmissionRejectedException
      */
     private boolean validIFile(IFile file) {
         if (file==null || file.getFileName()==null || file.getFileName().equals("")) {
-            return false;
-        }
-        if (file.getByteData().length<=0) {
             return false;
         }
         return true;

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
+import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException.SubmissionRejectionReason;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
@@ -679,9 +680,21 @@ public class SubmissionService implements Feature {
                 // No run entered, this is really really bad
                 log.log(Level.WARNING, "No Run added after submitting CLICS API run for team " + team_id + " by " + user);
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Unable to add submission").build();
-            } catch (SubmissionRejectedException sje) {
-                log.log(Level.WARNING, "SubmissionRejectedException submitting CLICS API run for team " + team_id + " by " + user);
-                return Response.status(Response.Status.TOO_MANY_REQUESTS).entity("Unable to submit run: " + sje.getLocalizedMessage()).build();
+            } catch (SubmissionRejectedException sre) {
+            	switch (sre.getRejectionReason()) {
+            	    case THROTTLE_EXCEEDED :
+            	        log.log(Level.WARNING, "SubmissionRejectedException (Throttling) submitting CLICS API run for team " + team_id + " by " + user);
+            	        return Response.status(Response.Status.TOO_MANY_REQUESTS).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
+                    case SOURCE_TOO_BIG :
+                        log.log(Level.WARNING, "SubmissionRejectedException (Source too large) submitting CLICS API run for team " + team_id + " by " + user);
+                        return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
+                    case ZERO_LENGTH_FILE :
+                        log.log(Level.WARNING, "SubmissionRejectedException (Zero-length file) submitting CLICS API run for team " + team_id + " by " + user);
+                        return Response.status(Response.Status.BAD_REQUEST).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
+            	    default:
+                        log.log(Level.WARNING, "SubmissionRejectedException (Reason: Unknown) submitting CLICS API run for team " + team_id + " by " + user);
+                        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
+            	}
             } catch (Exception e) {
                 log.log(Level.WARNING, "Exception submitting CLICS API run for team " + team_id + " by " + user, e);
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Unable to submit run: " + e.getLocalizedMessage()).build();

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -685,12 +685,17 @@ public class SubmissionService implements Feature {
             	    case THROTTLE_EXCEEDED :
             	        log.log(Level.WARNING, "SubmissionRejectedException (Throttling) submitting CLICS API run for team " + team_id + " by " + user);
             	        return Response.status(Response.Status.TOO_MANY_REQUESTS).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
-                    case SOURCE_TOO_BIG :
+
+            	    //the following case should never happen since the webserver has a filter which rejects submissions which are too large before
+            	    //they ever get to this method (see SubmitPostSizeLimitFilter and ResourceConfig202306.getResourceConfig()).  But... Tammy...
+            	    case SOURCE_TOO_BIG :
                         log.log(Level.WARNING, "SubmissionRejectedException (Source too large) submitting CLICS API run for team " + team_id + " by " + user);
                         return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
-                    case ZERO_LENGTH_FILE :
+
+            	    case ZERO_LENGTH_FILE :
                         log.log(Level.WARNING, "SubmissionRejectedException (Zero-length file) submitting CLICS API run for team " + team_id + " by " + user);
                         return Response.status(Response.Status.BAD_REQUEST).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
+
             	    default:
                         log.log(Level.WARNING, "SubmissionRejectedException (Reason: Unknown) submitting CLICS API run for team " + team_id + " by " + user);
                         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Unable to submit run: " + sre.getLocalizedMessage()).build();

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -636,7 +636,8 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
             sendToLocalServer(packet);
         } else {
-            throw new SubmissionRejectedException("Submission threshhold exceeded");
+            throw new SubmissionRejectedException("Submission threshhold exceeded", 
+                                                    SubmissionRejectedException.SubmissionRejectionReason.THROTTLE_EXCEEDED);
         }
     }
 
@@ -5037,7 +5038,8 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideSubmissionId);
             sendToLocalServer(packet);
         } else {
-            throw new SubmissionRejectedException("Submission threshhold exceeded");
+            throw new SubmissionRejectedException("Submission threshhold exceeded",
+                                                    SubmissionRejectedException.SubmissionRejectionReason.THROTTLE_EXCEEDED);
         }
     }
 

--- a/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
+++ b/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
@@ -25,12 +25,6 @@ public class SubmissionRejectedException extends Exception {
     private SubmissionRejectionReason rejectReason = SubmissionRejectionReason.UNKNOWN;
 
     /**
-     * Constructs an empty SubmissionRejectedException which contains no textual information about the reason for the Exception.
-     */
-    public SubmissionRejectedException() {
-    }
-
-    /**
      * Constructs a SubmissionRejectedException containing text message and reason.
      *
      * @param message A text message associated with the Exception

--- a/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
+++ b/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
@@ -18,7 +18,8 @@ public class SubmissionRejectedException extends Exception {
     public enum SubmissionRejectionReason {
         UNKNOWN,
         THROTTLE_EXCEEDED,
-        SOURCE_TOO_BIG
+        SOURCE_TOO_BIG,
+        ZERO_LENGTH_FILE
     }
 
     private SubmissionRejectionReason rejectReason = SubmissionRejectionReason.UNKNOWN;
@@ -27,17 +28,6 @@ public class SubmissionRejectedException extends Exception {
      * Constructs an empty SubmissionRejectedException which contains no textual information about the reason for the Exception.
      */
     public SubmissionRejectedException() {
-    }
-
-    /**
-     * Constructs a THROTTLE_EXCEEDED SubmissionRejectedException containing the supplied text message.
-     * This is for backward compatibility.
-     * TODO: eventually change any code that calls this to specify the reason Enum explicitly.
-     *
-     * @param message A text message associated with the Exception using the reason THROTTLE_EXCEEDED.
-     */
-    public SubmissionRejectedException(String message) {
-        this(message, SubmissionRejectionReason.THROTTLE_EXCEEDED);
     }
 
     /**
@@ -71,7 +61,7 @@ public class SubmissionRejectedException extends Exception {
     }
 
     /**
-     * Return the enum of why the submission was rejected
+     * Return the enum of why the submission was rejected.
      *
      * @return SubmissionRejectionReason
      */

--- a/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
+++ b/src/edu/csus/ecs/pc2/core/model/ContestInformation.java
@@ -224,6 +224,11 @@ public class ContestInformation implements Serializable{
      * Submission Throttling
      */
     private boolean submissionThrottling = true;
+    
+    /**
+     * Whether or not zero-length files are allowed in submissions.
+     */
+    private boolean allowZeroLengthSubmissionFiles = false;
 
     /**
      * Returns the date/time when the contest is scheduled (intended) to start.
@@ -463,7 +468,11 @@ public class ContestInformation implements Serializable{
                 return false;
             }
 
-            return true;
+            if (allowZeroLengthSubmissionFiles != contestInformation.isAllowZeroLengthSubmissionFiles()) {
+                return false;
+            }
+
+           return true;
         } catch (Exception e) {
             e.printStackTrace(System.err); // TODO log this exception
             return false;
@@ -970,6 +979,14 @@ public class ContestInformation implements Serializable{
 
     public void setSubmissionThrottling(boolean submissionThrottling) {
         this.submissionThrottling = submissionThrottling;
+    }
+
+    public boolean isAllowZeroLengthSubmissionFiles() {
+        return allowZeroLengthSubmissionFiles;
+    }
+
+    public void setAllowZeroLengthSubmissionFiles(boolean allowZeroLengthSubmissionFiles) {
+        this.allowZeroLengthSubmissionFiles = allowZeroLengthSubmissionFiles;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -477,7 +477,11 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         //set allow-multiple-team-logins mode
         boolean allowMultipleTeamLogins = fetchBooleanValue(content, ALLOW_MULTIPLE_TEAM_LOGINS_KEY, contestInformation.isAllowMultipleLoginsPerTeam());
         contestInformation.setAllowMultipleLoginsPerTeam(allowMultipleTeamLogins);
-
+        
+        //set allow-zero-length-submission-files mode
+        boolean allowZeroLengthSubmissionFiles = fetchBooleanValue(content, ALLOW_ZERO_LENGTH_SUBMISSION_FILES_KEY, contestInformation.isAllowZeroLengthSubmissionFiles());
+        contestInformation.setAllowZeroLengthSubmissionFiles(allowZeroLengthSubmissionFiles);
+        
         // Load team scoreboard string (the one with variables)
         String teamScoreboadDisplayString = fetchValue(content, TEAM_SCOREBOARD_DISPLAY_FORMAT_STRING, contestInformation.getTeamScoreboardDisplayFormat());
         contestInformation.setTeamScoreboardDisplayFormat(teamScoreboadDisplayString);

--- a/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
@@ -236,6 +236,8 @@ public interface IContestLoader {
 
     String ALLOW_MULTIPLE_TEAM_LOGINS_KEY = "allow-multiple-team-logins";
 
+    String ALLOW_ZERO_LENGTH_SUBMISSION_FILES_KEY = "allow-zero-length-submission-files";
+
     String LOAD_ACCOUNTS_FILE_KEY = "load-accounts-file";
 
     String SANDBOX_GRACE_TIME = "sandbox-grace-time-secs";

--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -236,11 +236,15 @@ public class ContestInformationPane extends JPanePlugin {
 
     private JCheckBox allowMultipleTeamLoginsCheckbox;
 
+    private JCheckBox allowZeroLengthSubmissionFilesCheckbox;
+
     private Component rigidArea1;
 
     private Component rigidArea2;
 
     private Component rigidArea3;
+
+    private Component rigidArea4;
 
     private JPanel teamScoreboardDisplayFormatPane;
 
@@ -676,8 +680,25 @@ public class ContestInformationPane extends JPanePlugin {
             teamSettingsPane.add(getAllowMultipleTeamLoginsCheckbox(), null);
             teamSettingsPane.add(getRigidArea2());
             teamSettingsPane.add(getTeamScoreboardDisplayFormatPane(), null);
+            teamSettingsPane.add(getRigidArea4());
+            teamSettingsPane.add(getAllowZeroLengthSubmissionFilesCheckbox(), null);
         }
         return teamSettingsPane;
+    }
+
+    private JCheckBox getAllowZeroLengthSubmissionFilesCheckbox() {
+        if (allowZeroLengthSubmissionFilesCheckbox==null) {
+            allowZeroLengthSubmissionFilesCheckbox = new JCheckBox("Allow zero-length submission files", false);
+            allowZeroLengthSubmissionFilesCheckbox.addActionListener (new ActionListener() {
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    enableUpdateButton();
+                }
+            });
+
+        }
+        return allowZeroLengthSubmissionFilesCheckbox ;
     }
 
     private JPanel getTeamScoreboardDisplayFormatPane() {
@@ -1145,6 +1166,7 @@ public class ContestInformationPane extends JPanePlugin {
         maximumFileSize = Long.parseLong(maxFileSizeString);
         newContestInformation.setMaxSourceSizeInBytes(maximumFileSize * 1024);
         newContestInformation.setAllowMultipleLoginsPerTeam(getAllowMultipleTeamLoginsCheckbox().isSelected());
+        newContestInformation.setAllowZeroLengthSubmissionFiles(getAllowZeroLengthSubmissionFilesCheckbox().isSelected());
         newContestInformation.setTeamScoreboardDisplayFormat(getTeamScoreboardDisplayFormatTextfield().getText());
 
         //fill in values already saved, if any
@@ -1971,4 +1993,11 @@ public class ContestInformationPane extends JPanePlugin {
         }
         return rigidArea3;
     }
+    
+    private Component getRigidArea4() {
+        if (rigidArea4==null) {
+            rigidArea4 = Box.createRigidArea(new Dimension(20,20));
+        }
+        return rigidArea4;    }
+
 }

--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -1252,6 +1252,7 @@ public class ContestInformationPane extends JPanePlugin {
                 getMaxOutputSizeInKTextField().setText((contestInformation.getMaxOutputSizeInBytes() / 1024) + "");
                 getMaxSourceSizeInKTextField().setText((contestInformation.getMaxSourceSizeInBytes() / 1024) + "");
                 getAllowMultipleTeamLoginsCheckbox().setSelected(contestInformation.isAllowMultipleLoginsPerTeam());
+                getAllowZeroLengthSubmissionFilesCheckbox().setSelected(contestInformation.isAllowZeroLengthSubmissionFiles());
                 getTeamScoreboardDisplayFormatTextfield().setText(contestInformation.getTeamScoreboardDisplayFormat());
                 getContestFreezeLengthtextField().setText(contestInformation.getFreezeTime());
 


### PR DESCRIPTION
### Description of what the PR does
  Provides support for enabling or disabling acceptance of zero-length files in WTI submissions.  Specifically:
- Adds a new configuration variable `allowZeroLengthSubmissionFiles` to the `ContestInformation` class (the default value for this is `false`), along with accessors and corresponding appropriate updates to method `isSameAs(ContestInformation)`.
- Adds a new "Allow zero-length submission files" checkbox to the `ContestInformationPane`.  Checking or unchecking this box respectively allows or disallows WTI submissions to contain zero-length files.  Pressing `Update` saves the new value in the current `ContestInformation`.
- Updates `IContestLoader` and `ContestSnakeYAMLLoader` by adding support for a new YAML variable `allow-zero-length-submission-files`.  The default value for this variable (if it is undefined in a YAML file being loaded) is `false`; specifying `allow-zero-length-submission-files: true` in YAML will override the default and update the current `ContestInformation` to allow zero-length files in WTI submissions.
- Updates `SubmissionRejectedException` to contain a new `SubmissionRejectedReason` of `ZERO_LENGTH_FILE`.
- Updates PC2 API `ServerConnection` to throw `SubmissionRejectedException`, with a reason of `ZERO_LENGTH_FILE`, when the WTI client submits a zero-length file.
- Updates `WTI-UI.new-run.component` to handle the various `SubmissionRejectionReason`s better. 
- Updates the `catch` clause in `clics.API202306.SubmissionService` to handle all `SubmissionRejectedReason`s.

Also contains the following "Continuous Improvement (CI)" updates:
- Updates `SubmissionRejectedException` by eliminating constructors which are inappropriate (e.g. constructors with no arguments; every `SubmissionRejectedException` is now required to specify a _reason_).
- Updates `InternalController` to invoke a constructor which specifies a `SubmissionRejectionReason` (instead of a constructor which allowed no reason, which was eliminated).
- Updates `TeamsController` to properly recognize when the list of "additional files" is empty, and to handle `SubmissionRejectedExceptions` properly.
- Replaces the default error message `Not accepting submissions at this time` in `WTI-UI.new-run.component` (see the Issue description) with the content of the actual error message supplied by the PC2 API, or none then with a more generic message "Error in submission".

### Issue which the PR addresses
Fixes #1170

### Environment in which the PR was developed:
Windows 11, Eclipse Version: 2020-12 (4.18.0), Java 1.8.0_271, Chrome Version 140.0.7339.81

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly):

### Basic Testing

#### Main file test:

- Download and unzip the PR distribution.
- Start a PC2 Server and load a contest (e.g. with --load sumithello).
- Start a PC2 Admin.
- On the `Configure Contest > Settings` tab, verify that the "Allow zero-length submission files" checkbox (in the `Team Settings` section) is UNCHECKED.
- Start the contest clock running (e.g. using the Admin "Times" tab).
- Go into the "Projects" folder and unzip the WebTeamInterface-1.2 zip file.
- Go into the unzipped WTI folder and start the WTI Server (e.g. using `./bin/pc2wti`).
- Open a browser and login to the WTI as a team.
- On the "Runs" page, select "Submit Problem".
- Choose any  problem and any language.
- Create a file of zero length and select that as the "Main File".
- Click "Submit"
- Verify that a red error message like "Zero-length file not allowed" is displayed.

#### Additional Files test:

- Select "Submit Problem" on the WTI Runs page.
- Choose any problem and language.
- Select any NON-ZERO-LENGTH file as the "Main File".
- Click "Additional Files" and select a ZERO-LENGTH file.
- Click "Submit"
- Verify that an error message like "Zero-length file not allowed" is displayed in red.

### Regression Testing

#### Test that Throttling still works as expected:

- Submit 7 (or more) runs within a single minute.  (It's possible to do this via the WTI GUI if you're quick.)
- Verify that on the 7th submission you get a red error message like "Submission threshold exceeded".


#### Test that rejection of files which are too large still works as expected:

- Select "Submit Problem" on the WTI Runs page.
- Choose a problem and a language.
- Select a text file which is larger than the source file size limit as the "Main File".
	(The default is 256KiB, plus some overhead to allow for encoding; any text file larger than 264K should suffice.)
- Click "Submit"
- Verify that a red error message like "Source file(s) are too large" is displayed.


### Contest Settings Tests

#### Test Allow-Zero-Length-Files from GUI

- On the PC2 Admin "Settings" tab, CHECK (enable) the "Allow zero-length submission files" checkbox, then click "Update".
- Re-execute the "Main File test" and "Additional Files tests" above; verify that both tests now DO allow submission of a
zero-length file (i.e. that a green "Run successfully submitted" message is received in response to each of those tests).


#### Test Allow-Zero-Length-Files from YAML

- Completely shut down the WTI Browser, the WTI Server, and the PC2 Server.
- Delete the "profiles" and "logs" folders, and the "profiles.properties" file, under the PR's PC2 distribution (i.e. the files which were created by the above tests).
- Add an entry "allow-zero-length-submission-files: true" to the "contest.yaml" or "system.pc2.yaml" file for whatever contest you are using for testing. (For example, if you've been using `--load sumithello`, go into `samps/contests/sumithello/config` and edit the `contest.yaml` file, adding that entry.)
- Restart the PC2 Server (be sure it starts from scratch; i.e. it doesn't give a Warning about "using an existing profile" -- check the console for such a message).
- Restart the PC2 Admin.
- Verify that the "Allow zero-length submission files" checkbox on the Admin Settings pane is CHECKED (enabled).
- Start the contest running.
- Restart the PC2 WTI Server.
- Start a new browser session (or clear the browser's cache).
- Connect the browser to the PC2 WTI Server and login as a team.
- Re-execute the "Main File" and "Additional Files" tests (above); verify that zero-length files ARE accepted.

#### Test disabling of Allow-Zero-Length-Files after being enabled from YAML

- On the PC2 Admin, UNCHECK the "Allow zero-length submission files" checkbox, then click `Update`.
- In the WTI browser, re-execute the "Main File" and "Additional Files" tests (above); verify that zero-length files now REJECTED.

