### PR TITLE
I1189 Add multi-pass problem support as per Problem Package Spec 2023-07draft

### DIFF
--- a/bin/pc2submit
+++ b/bin/pc2submit
@@ -522,12 +522,15 @@ def do_api_submit():
         
     if team_id :
         jsonSub['team_id'] = team_id
+        
+    zip = io.BytesIO()
+    
+    with zipfile.ZipFile(zip, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for filename in filenames:
+            arcname = os.path.basename(filename)
+            zipf.write(filename, arcname)
 
-    jsonSub['files'] = []
-    for filename in filenames :
-        with open(filename, 'rb') as file:
-            data = base64.b64encode(file.read()).decode("utf-8")
-        jsonSub['files'].append({ 'data' : data, 'filename' : filename })
+    jsonSub['files'] = [{ 'data' : base64.b64encode(zip.getvalue()).decode("utf-8"), 'mime' : 'application/zip' }]
 
     logging.debug(f"API Post info: jsonSub: {jsonSub}")
 

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -13,12 +13,14 @@
                 		'color': item.textColor,
                 		'cursor': 'pointer' 
                 	}">
+				<!-- 
                 	<a [href]="isContestStarted() ? item.url : null" 
                 			(click)="onLinkClick($event, item.url)" 
                 			target="_blank" 
                 			class="problem-writeup-link" >
-    					{{ item.label }}
   					</a>
+  				-->
+    					{{ item.label }}
 
                 </th>
                 <th style="text-align: center">Solved</th>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
@@ -26,10 +26,6 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	numProblems: number = 0;
 	problemDetailHeaders: ProblemHeader[] = [];
 	
-	//TODO: provide support for more than 26 problems
-	//TODO: provide support for the possibility that problems are not listed in alphabetical order
-	problemLetters = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z'];
-
 	constructor(
 		private _contestService: IContestService,
 		private _appTitleService: AppTitleService,
@@ -43,8 +39,8 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 		
 		this._appTitleService.setTitleWithTeamId("Scoreboard");
 		
-        	//indicate that this Scoreboard page is the most recently accessed page
-        	saveCurrentPage(Constants.SCOREBOARD_PAGE);
+        //indicate that this Scoreboard page is the most recently accessed page
+        saveCurrentPage(Constants.SCOREBOARD_PAGE);
 
 		this.loadStandings();
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestInfo.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSContestInfo.java
@@ -107,6 +107,9 @@ public class CLICSContestInfo {
             }
         }
         penalty_time = Integer.valueOf(ci.getScoringProperties().getProperty(DefaultScoringAlgorithm.POINTS_PER_NO, "20"));
+        if(ci.getThawed() != null) {
+            scoreboard_thaw_time = Utilities.getIso8601formatterWithMS().format(ci.getThawed());
+        }
         scoreboard_type = "pass-fail";
     }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/ContestService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ContestService.java
@@ -3,6 +3,7 @@ package edu.csus.ecs.pc2.clics.API202306;
 
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Map;
 
@@ -420,11 +421,22 @@ public class ContestService implements Feature {
         // thaw time present, validate now
         GregorianCalendar thawTime = getDate(contestId, thawTimeValue);
         if (thawTime != null) {
-            // Set thaw time to this time.
-            // TODO: tell PC2 to thaw the contest at the given time.
-            controller.getLog().log(Log.WARNING, LOG_PREFIX + contestId + ": setting of contest thaw time is not implemented");
-            return Response.status(Status.NOT_MODIFIED).entity("Unable to set contest thaw time to " + thawTime.toString()).build();
+            Date thawDate = thawTime.getTime();
+            String thawStr = Utilities.getIso8601formatterWithMS().format(thawDate);
+            // get the local model's ContestInformation sincd we are modifying the thaw time
+            ContestInformation ci = model.getContestInformation();
+            if (ci != null) {
+                // set the new start date/time into the ContestInformation
+                ci.setThawed(thawDate);
+                // tell the Controller to update the ContestInformation, eg the thaw time in this case
+                controller.updateContestInformation(ci);
+                controller.getLog().log(Log.INFO, LOG_PREFIX + contestId + ": setting contest thaw time to " + thawStr);
+                return Response.ok().entity("Contest thaw time set to " + thawStr).build();
+            }
+            controller.getLog().log(Log.WARNING, LOG_PREFIX + contestId + ": can not get contest information to set thaw time");
+            return Response.status(Status.NOT_MODIFIED).entity("Unable to set contest thaw time to " + thawStr).build();
         }
+        controller.getLog().log(Log.WARNING, LOG_PREFIX + contestId + ": bad value for contest thaw time: " + thawTimeValue);
         return Response.status(Status.BAD_REQUEST).entity("Bad value for contest thaw time request").build();
 
     }

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import edu.csus.ecs.pc2.convert.EventFeedUtilities;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
@@ -607,24 +608,44 @@ public class SubmissionService implements Feature {
                 return Response.status(Response.Status.BAD_REQUEST).entity("no file specified").build();
             }
 
-            List<IFile> srcFiles = new ArrayList<IFile>();
-            for(CLICSFileReference file : files) {
-                String fileName = file.getFilename();
-                if("".equals(fileName)) {
-                    return Response.status(Response.Status.BAD_REQUEST).entity("no file name specified").build();
-                }
-                // allow contestant submission of a zero length file.  This will generate a CE (hopefully).
-                // if the following code is uncommented, the submission is not made and a 400 is returned to the submitter.
-                // it appears that other CCS's allow zero length submissions.  *sigh* -- JB
-                String fileData = file.getData();
-                if(fileData == null || fileData.length() == 0) {
-                    // nice to put it in the log in case any questions come up.
-                    log.info(user + " POSTing empty source submission on behalf of team " + team_id);
+            List<IFile> srcFiles;
 
-//                    return Response.status(Response.Status.BAD_REQUEST).entity("no file data specified for " + fileName).build();
+            // Backward compatability test: If no mime property specified on the first file, then the CLICSFileReference's are
+            // actual files and not a zip file.  This is in here because initially, due to a misinterpretation of the CLICS
+            // 2023-06 specification, the command line submit utility (a.k.a. pc2submit) did not put the files in a zip file,
+            // rather, it created an array of base64 encoded file contents.  The CLICS spec has since been clarified but for now,
+            // we will still support the incorrect implementation as well as the correct one.
+            CLICSFileReference firstFile = files[0];
+            String mimeType = firstFile.getMime();
+
+            // TODO: deprecate this "if" part and leave the "else" part.  JB
+            if(mimeType == null || "".equals(mimeType)) {
+                srcFiles = new ArrayList<IFile>();
+                for(CLICSFileReference file : files) {
+                    String fileName = file.getFilename();
+                    if("".equals(fileName)) {
+                        return Response.status(Response.Status.BAD_REQUEST).entity("no file name specified").build();
+                    }
+                    // allow contestant submission of a zero length file.  This will generate a CE (hopefully).
+                    // if the following code is uncommented, the submission is not made and a 400 is returned to the submitter.
+                    // it appears that other CCS's allow zero length submissions.  *sigh* -- JB
+                    String fileData = file.getData();
+                    if(fileData == null || fileData.length() == 0) {
+                        // nice to put it in the log in case any questions come up.
+                        log.info(user + " POSTing empty source submission on behalf of team " + team_id);
+
+    //                    return Response.status(Response.Status.BAD_REQUEST).entity("no file data specified for " + fileName).build();
+                    }
+                    IFile iFile = new IFileImpl(file.getFilename(), fileData);
+                    srcFiles.add(iFile);
                 }
-                IFile iFile = new IFileImpl(file.getFilename(), fileData);
-                srcFiles.add(iFile);
+            } else {
+                // There should be precisely one file in the files[] array, which is a zip archive of the source file(s)
+                if(files.length > 1) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity("only one zip archive is allowed").build();
+                }
+
+                srcFiles = EventFeedUtilities.getIFiles(firstFile.getData());
             }
             String entry = sub.getEntry_point();
             IFile mainFile = srcFiles.get(0);

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -1,23 +1,31 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.convert;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import edu.csus.ecs.pc2.core.model.IFile;
+import edu.csus.ecs.pc2.core.model.IFileImpl;
 
 /**
  * Event Feed Utilities
- * 
+ *
  * @author ICPC
  *
  */
 public final class EventFeedUtilities {
 
     public static final long MS_PER_SECOND = 1000;
-    
+
     private EventFeedUtilities() {
         super();
     }
@@ -29,7 +37,7 @@ public final class EventFeedUtilities {
             map.put(eventFeedRun.getLanguage(), "");
         }
         Set<String> set = map.keySet();
-        return (String[]) set.toArray(new String[set.size()]);
+        return set.toArray(new String[set.size()]);
     }
 
     public static int getMaxProblem(List<EventFeedRun> runs) {
@@ -55,7 +63,7 @@ public final class EventFeedUtilities {
 
     /**
      * Convert decimal string to ms.
-     * 
+     *
      * @param decimalSeconds
      *            - declimal second
      * @return ms
@@ -98,7 +106,7 @@ public final class EventFeedUtilities {
 
     /**
      * Fetch list of filenames, full path
-     * 
+     *
      * @param dirname
      *            location of submission files
      * @param runId
@@ -121,6 +129,90 @@ public final class EventFeedUtilities {
             }
         }
         return list;
+    }
+
+    /**
+     * Get files from a zipfile's base64 encoded string data
+     *
+     * @param base64Data String comprising a zip file encoded as base64
+     * @return list of IFiles extracted from the input bytes
+     * @throws IllegalArgumentException from the base64 decoder on a data error
+     */
+    public static List<IFile> getIFiles(String base64Data) {
+
+        // use the decoder to both check the validity of, and to store, the byte data.
+        // this will throw an IllegalArgumentException if the data is basd
+        return(getIFiles(Base64.getDecoder().decode(base64Data)));
+    }
+
+    /**
+     * Get files from a zipfile's bytes.
+     *
+     * @param bytes bytes comprising a zip file.
+     * @return list of IFiles extracted from the input bytes
+     */
+    public static List<IFile> getIFiles(byte[] bytes) {
+
+        List<IFile> files = new ArrayList<IFile>();
+
+        ZipInputStream zipStream = null;
+
+        try {
+            zipStream = new ZipInputStream(new ByteArrayInputStream(bytes));
+            ZipEntry entry = null;
+            /**
+             * Read each zip entry, add IFile.
+             */
+            while ((entry = zipStream.getNextEntry()) != null) {
+
+                String entryName = entry.getName();
+
+//                ByteOutputStream byteOutputStream = new ByteOutputStream();
+                ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+
+                byte[] buffer = new byte[8096];
+                int bytesRead = 0;
+                while ((bytesRead = zipStream.read(buffer)) != -1)
+                {
+                    byteOutputStream.write(buffer, 0, bytesRead);
+                }
+
+//                String base64Data = getBase64Data(byteOutputStream.getBytes());
+                String base64Data = getBase64Data(byteOutputStream.toByteArray());
+                IFile iFile = new IFileImpl(entryName, base64Data);
+                files.add(iFile);
+
+                byteOutputStream.close();
+
+                zipStream.closeEntry();
+            }
+            zipStream.close();
+
+        } catch (Exception e) {
+            if (zipStream != null){
+                try {
+                    zipStream.close();
+                } catch (Exception ze) {
+                    ; // problem closing stream, ignore.
+                }
+            }
+            throw new RuntimeException(e);
+        }
+
+        return files;
+
+    }
+
+    /**
+     * Encode bytes into BASE64.
+     * @param data
+     * @return
+     */
+    public static String getBase64Data( byte [] bytes) {
+        // TODO REFACTOR move to FileUtilities
+        Base64.Encoder encoder = Base64.getEncoder();
+        String base64String = encoder.encodeToString(bytes);
+        return base64String;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/Constants.java
+++ b/src/edu/csus/ecs/pc2/core/Constants.java
@@ -271,6 +271,7 @@ public final class Constants {
     public static final String VALIDATION_CUSTOM = "custom";
     public static final String VALIDATION_DEFAULT = "default";
     public static final String VALIDATION_INTERACTIVE = "interactive";
+    public static final String VALIDATION_MULTIPASS = "multi-pass";
     public static final String VALIDATION_SCORE = "score";
 
     /**
@@ -291,5 +292,10 @@ public final class Constants {
     public static final String TAB = "\t";
 
     public static final String NL = System.getProperty("line.separator");
+
+    /**
+     * For multipass problems, there are some special files
+     */
+    public static final String NEXT_PASS_FILE = "nextpass.in";
 
 }

--- a/src/edu/csus/ecs/pc2/core/FileUtilities.java
+++ b/src/edu/csus/ecs/pc2/core/FileUtilities.java
@@ -3,9 +3,16 @@ package edu.csus.ecs.pc2.core;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.CopyOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,14 +24,14 @@ import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 
 /**
  * File Utilities.
- * 
+ *
  * @author Douglas A. Lane, PC^2 Team, pc2@ecs.csus.edu
  */
 public class FileUtilities {
 
     /**
      * Write array to PrintWriter.
-     * 
+     *
      * @param writer a PrintWriter to which the specified array of Strings should be written
      * @param datalines a String array containing the lines of data to be written to the specified PrintWriter
      */
@@ -40,12 +47,12 @@ public class FileUtilities {
         writer.close();
         writer = null;
     }
-    
+
     /**
      * Search for CDP config/ path.
-     * 
+     *
      * See {@link #findCDPConfigDirectory(File)}.
-     * 
+     *
      * @param entry
      * @return null if not found
      * @throws MalformedURLException
@@ -61,14 +68,14 @@ public class FileUtilities {
 
     /**
      * Search for a CDP config/ directory.
-     * 
+     *
      * The entry can be:
      * <li> a contest.yaml filename
      * <li> a config/ directory
      * <li> a CDP directory (that contains a config/ subdirectory)
      * <li> a pc2 samps contest/CDP location, ex sumithello or sumitMTC
-     * 
-     * @param entry a location 
+     *
+     * @param entry a location
      * @return null if no config directory found, else the CDP config/ directory.
      */
     public static File findCDPConfigDirectory(File entry) {
@@ -116,7 +123,7 @@ public class FileUtilities {
     }
 
     /**
-     * 
+     *
      * @param name CDP sample directory name
      * @return null if dirname has no contest.yaml file.
      */
@@ -132,7 +139,7 @@ public class FileUtilities {
     }
 
     /**
-     * 
+     *
      * @param dirname
      * @return CDP directory under samps/contests
      */
@@ -152,7 +159,7 @@ public class FileUtilities {
     }
 
     /**
-     * 
+     *
      * @return sample contests directory.
      */
     public static String getSampleContestsDirectory() {
@@ -160,7 +167,7 @@ public class FileUtilities {
     }
 
     /**
-     * 
+     *
      * @param dirname
      * @return
      */
@@ -170,9 +177,9 @@ public class FileUtilities {
 
     /**
      * Returns all filenames for the input directory, recurses by default
-     * 
+     *
      * Read dir entries in directory, strip off relativeDirectory from any directory entry.
-     * 
+     *
      * @param directory
      * @param relativeDirectory
      * @return all files names with relative paths.
@@ -207,7 +214,7 @@ public class FileUtilities {
 
     /**
      * Get file directory entries (files only) with path.
-     * 
+     *
      * @param directory
      *            - directory to search and to prepend onto the matching filenames
      * @return a list of file entries with path
@@ -226,7 +233,7 @@ public class FileUtilities {
 
     /**
      * Get file directory entries (directories only) with path.
-     * 
+     *
      * @param directory
      *            - directory to search and to prepend onto the matching filenames
      * @return a list of directory entries with path
@@ -249,7 +256,7 @@ public class FileUtilities {
 
     /**
      * Get Current Working Directory.
-     * 
+     *
      * @return current working directory.
      */
     public static String getCurrentDirectory() {
@@ -265,7 +272,7 @@ public class FileUtilities {
 
     /**
      * get all directories and child directories (recurses).
-     * 
+     *
      * @param directory
      * @return list of directory names
      */
@@ -274,9 +281,9 @@ public class FileUtilities {
         ArrayList<String> list = new ArrayList<>();
 
         File[] files = new File(directory).listFiles();
-        
+
         if (files != null) {
-            
+
             for (File entry : files) {
                 if (entry.isDirectory()) {
                     list.add(directory + File.separator + entry.getName());
@@ -289,11 +296,11 @@ public class FileUtilities {
 
         return list;
     }
-    
-    
+
+
     /**
      * get all file names under directory (recurses).
-     * 
+     *
      * @param directory
      * @param matchString if not null returns filenames with matchString in file name.
      * @return
@@ -333,11 +340,11 @@ public class FileUtilities {
         return getAllFileEntries(directory, null);
     }
 
-    
-    
+
+
     /**
      * Select file and update text file, jlabel with selected file name.
-     * 
+     *
      * @return null if no file selected, else retrn File and update textfield and jlabel
      * @throws Exception
      */
@@ -362,10 +369,10 @@ public class FileUtilities {
         chooser = null;
         return file;
     }
-    
+
     /**
      * Select directory, update text field and jlabel.
-     * 
+     *
      * @param initDirectory
      * @param textField
      * @param label
@@ -395,7 +402,7 @@ public class FileUtilities {
         chooser = null;
         return file;
     }
-    
+
     /**
      * Is dirname an existing directory?
      * @param dirname
@@ -405,9 +412,35 @@ public class FileUtilities {
         if (StringUtilities.isEmpty(dirname)){
             return false;
         }
-        
+
         return new File(dirname).isDirectory();
     }
 
-    
+    /**
+     * Recursively copy one folder to another
+     * @param source
+     * @param target
+     * @param options
+     * @throws IOException
+     */
+    public static void copyFolder(Path source, Path target, CopyOption... options)
+            throws IOException {
+        Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                    throws IOException {
+                Files.createDirectories(target.resolve(source.relativize(dir).toString()));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                Files.copy(file, target.resolve(source.relativize(file).toString()), options);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
 }

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Hashtable;
@@ -778,18 +779,33 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 // We know the first succeeded.  Now we have to keep looping checking the feedbackdir/nextpass.in (Constants.NEXT_PASS_FILE).
                 CustomValidatorSettings cvSettings = problem.getCustomOutputValidatorSettings();
                 String feedbackDirPath = getExecuteDirectoryName() + File.separator + clicsInterfaceFeedbackDirName;
-                // This is the path to the next pass file relative to PC2
+                // This is the path to the next pass file relative to PC2, eg. executeSite1/123XRSAM.1/nextpass.in
                 String nextPassName = feedbackDirPath + Constants.NEXT_PASS_FILE;
-                // This is the path to the next pass file relative to the execute folder
+                // This is the path to the next pass file relative to the execute folder, eg.  123XRSAM.1/nextpass.in
                 String nextPassRunName = clicsInterfaceFeedbackDirName + Constants.NEXT_PASS_FILE;
-                String nextPassCopyName = feedbackDirPath + testNumber + "_pass";
+                String nextSuffix = "";
 
-                for(int nPass = 1; nPass <= cvSettings.getMaxMultipassValidationPasses(); ) {
+                log.info("This is a multi-pass problem with a maximum of " + cvSettings.getMaxMultipassValidationPasses() + " passes.");
+                for(int nPass = 1; nPass <= cvSettings.getMaxMultipassValidationPasses(); nPass++) {
                     log.info(" "); //space for readability in the log
-                    log.info("  Test case " + testNumber + " validate, run " + run.getNumber() + ", pass " + nPass);
+                    log.info("  Test case " + testNumber + " validate, run " + run.getNumber() + ", pass " + nPass +
+                            ", executeInputFile " + nextPassName + nextSuffix +
+                            ", validateInputFile " + nextPassRunName + nextSuffix);
 
+                    // Recall we did the first pass above, so don't re-execute the first time through, just
+                    // validate the result from above.
+                    if(nPass > 1) {
+                        proceedToValidation = executeProgram(dataSetNumber, nPass, nextPassName + nextSuffix);
+                        if(!proceedToValidation) {
+                            log.info("Not proceeding to validation since executeProgram(dataSetNumber=" + dataSetNumber
+                                    + ", nPass=" + nPass + ", nextInputName=" + nextPassName + nextSuffix + ") returned false");
+                            submissionIsCorrect = false;
+                            break;
+                        }
+
+                    }
                     // Test if validator finished normally.
-                    submissionIsCorrect = validateProgram(dataSetNumber, nPass, nextPassRunName);
+                    submissionIsCorrect = validateProgram(dataSetNumber, nPass, nextPassRunName + nextSuffix);
 
                     // Still need to check if they got it right.
                     if (!ExecuteUtilities.didTeamSolveProblem(executionData)) {
@@ -803,16 +819,25 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                     if(!nextPassFile.exists()) {
                         break;
                     }
-                    nPass++;
-                    // Copy the next pass input file so we have a copy for later review
-                    // File name we create is like:  clicsInterfaceFeedbackDirName/5_pass2.in
-                    String nextInputName = nextPassCopyName + nPass + ".in";
+//                    // We may want to copy feedback directory for the pass we just finished
+//                    String feedbackCopyDirectoryName = feedbackDirPath + "_" + nPass;
+//                    try {
+//                        FileUtilities.copyFolder(new File(feedbackDirPath).toPath(),
+//                                new File(feedbackCopyDirectoryName).toPath(), StandardCopyOption.REPLACE_EXISTING);
+//                    } catch(Exception e) {
+//
+//                    }
+                    // rename the next pass input file so we have a copy for later review and we have to delete
+                    // it anyway as per the spec.
+                    // File name we create is like:  clicsInterfaceFeedbackDirName/nextpass.in.pass3
+                    nextSuffix = ".pass" + nPass;
+                    String nextPassFileName = nextPassName + nextSuffix;
                     try {
-                        Files.copy(nextPassFile.toPath(), new File(nextInputName).toPath());
+                        log.info("Renaming " + nextPassName + " to " + nextPassFileName);
+                        Files.move(nextPassFile.toPath(), new File(nextPassFileName).toPath(), StandardCopyOption.REPLACE_EXISTING);
                     } catch(Exception e) {
-                        log.log(log.WARNING, "Could not copy " + nextPassName + " to " + nextInputName + " " + e);
+                        log.log(log.WARNING, "Could not move " + nextPassName + " to " + nextPassFileName + " " + e);
                     }
-                    proceedToValidation = executeProgram(dataSetNumber, nPass, nextPassName);
                 }
             } else {
                 log.info(" "); //space for readability in the log
@@ -1202,7 +1227,11 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                     }
 
                     in.close();
-                    out.close();
+                    try {
+                        out.close();
+                    } catch (java.io.IOException e) {
+                        log.info("Caught a " + e.getMessage() + " while closing team output to validator; do not be alarmed - the validator just sucks.");
+                    }
                 }
             }
 

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -57,6 +57,7 @@ import edu.csus.ecs.pc2.ui.NullViewer;
 import edu.csus.ecs.pc2.util.OSCompatibilityUtilities;
 import edu.csus.ecs.pc2.validator.clicsValidator.ClicsValidator;
 import edu.csus.ecs.pc2.validator.clicsValidator.ClicsValidatorSettings;
+import edu.csus.ecs.pc2.validator.customValidator.CustomValidatorSettings;
 import edu.csus.ecs.pc2.validator.pc2Validator.PC2ValidatorSettings;
 
 /**
@@ -221,6 +222,10 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
     private String executeDirectoryName = null;
 
     private String executeDirectoryNameSuffix = "";
+
+    private String interfaceDirectoryPrefix;
+    private String pc2InterfaceResultsFileName;
+    private String clicsInterfaceFeedbackDirName;
 
     /**
      * Overwrite judge's data and answer files.
@@ -396,6 +401,10 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
             executeDirectoryName = getExecuteDirectoryName();
 
+            // get a "random" number to be used as part of the results file name and feedback directory name, for security
+            String secs = Long.toString((new Date().getTime()) % 100);
+            interfaceDirectoryPrefix = run.getNumber() + secs + "XRSAM.";
+
             boolean dirThere = insureDir(executeDirectoryName);
 
             if (!dirThere) {
@@ -450,7 +459,8 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 // Team, just compile and execute it.
 
                 if (compileProgram()) {
-                    executeProgram(0); // execute with first data set.
+                    setResultsInterfaceNames(1);
+                    executeProgram(0, 1, null); // execute with first data set.
                 } else {
                     /**
                      * compileProgram returns false if 1) runProgram failed (errorString set) 2) compiler fails to create expected output file (errorString empty) If there is compiler stderr or stdout
@@ -717,6 +727,12 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
         return fileViewer;
     }
 
+    private void setResultsInterfaceNames(int testSetNumber) {
+        pc2InterfaceResultsFileName = interfaceDirectoryPrefix + testSetNumber + ".txt";
+        //construct a "feedback directory" name, used by CLICS Interface validators
+        clicsInterfaceFeedbackDirName = interfaceDirectoryPrefix + testSetNumber + File.separator;
+    }
+
     public String getFailureReason() {
 
         if (executionData.getExecutionException() != null) {
@@ -752,17 +768,61 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
         log.info(" "); //put space in the log for readability -- separate each test case
         log.info("  Test case " + testNumber + " execute, run " + run.getNumber());
 
-        boolean proceedToValidation = executeProgram(dataSetNumber);
+        setResultsInterfaceNames(testNumber);
+        boolean proceedToValidation = executeProgram(dataSetNumber, 1, null);
 
         if (proceedToValidation && isValidated()) {
-            log.info(" "); //space for readability in the log
-            log.info("  Test case " + testNumber + " validate, run " + run.getNumber());
-            submissionIsCorrect = validateProgram(dataSetNumber);
+            if(problem.isMultipass()) {
 
-            if (!ExecuteUtilities.didTeamSolveProblem(executionData)) {
-                submissionIsCorrect = false;
+                // For multipass, the first pass is the only special one since it uses the original judge's input file
+                // We know the first succeeded.  Now we have to keep looping checking the feedbackdir/nextpass.in (Constants.NEXT_PASS_FILE).
+                CustomValidatorSettings cvSettings = problem.getCustomOutputValidatorSettings();
+                String feedbackDirPath = getExecuteDirectoryName() + File.separator + clicsInterfaceFeedbackDirName;
+                // This is the path to the next pass file relative to PC2
+                String nextPassName = feedbackDirPath + Constants.NEXT_PASS_FILE;
+                // This is the path to the next pass file relative to the execute folder
+                String nextPassRunName = clicsInterfaceFeedbackDirName + Constants.NEXT_PASS_FILE;
+                String nextPassCopyName = feedbackDirPath + testNumber + "_pass";
+
+                for(int nPass = 1; nPass <= cvSettings.getMaxMultipassValidationPasses(); ) {
+                    log.info(" "); //space for readability in the log
+                    log.info("  Test case " + testNumber + " validate, run " + run.getNumber() + ", pass " + nPass);
+
+                    // Test if validator finished normally.
+                    submissionIsCorrect = validateProgram(dataSetNumber, nPass, nextPassRunName);
+
+                    // Still need to check if they got it right.
+                    if (!ExecuteUtilities.didTeamSolveProblem(executionData)) {
+                        submissionIsCorrect = false;
+                        break;
+                    }
+                    // May want to save executionData here for each pass? -- JB
+
+                    // If no next pass, we are done, and, we know it was successful
+                    File nextPassFile = new File(nextPassName);
+                    if(!nextPassFile.exists()) {
+                        break;
+                    }
+                    nPass++;
+                    // Copy the next pass input file so we have a copy for later review
+                    // File name we create is like:  clicsInterfaceFeedbackDirName/5_pass2.in
+                    String nextInputName = nextPassCopyName + nPass + ".in";
+                    try {
+                        Files.copy(nextPassFile.toPath(), new File(nextInputName).toPath());
+                    } catch(Exception e) {
+                        log.log(log.WARNING, "Could not copy " + nextPassName + " to " + nextInputName + " " + e);
+                    }
+                    proceedToValidation = executeProgram(dataSetNumber, nPass, nextPassName);
+                }
+            } else {
+                log.info(" "); //space for readability in the log
+                log.info("  Test case " + testNumber + " validate, run " + run.getNumber());
+                submissionIsCorrect = validateProgram(dataSetNumber, 1, null);
+
+                if (!ExecuteUtilities.didTeamSolveProblem(executionData)) {
+                    submissionIsCorrect = false;
+                }
             }
-
         } else {
             //if we get here we are not going to validate so there's no way we can declare the submission is correct
             submissionIsCorrect = false;
@@ -878,16 +938,18 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
      *
      * @param dataSetNumber
      *            a zero-based value indicating the data set against which the run was executed
+     * @param pass normally 1, but for multipass problems, if > 1 then input file is nextPassFileName
+     * @param nextPassFileName Name of file to use as input - only on multipass problems after first pass
      * @return true if the validator returns "success" (indicating that the problem was correctly solved)
      */
-    protected boolean validateProgram(int dataSetNumber) {
+    protected boolean validateProgram(int dataSetNumber, int pass, String nextPassFileName) {
 
         // SOMEDAY Handle the error messages better, log and put them before the user to
         // help with debugging
 
-        int testCase = dataSetNumber + 1;
+        int testSetNumber = dataSetNumber + 1;
         log.info(" ");
-        log.info("starting validation for test case " + testCase);
+        log.info("starting validation for test case " + testSetNumber);
 
         executionData.setValidationReturnCode(-1);
         executionData.setValidationSuccess(false);
@@ -956,7 +1018,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                  * If not external files, must unpack files.
                  */
 
-                // Create the correct output file, aka answer file
+                // Create the correct input file, aka judges test data file
                 createFile(problemDataFiles.getJudgesDataFiles(), dataSetNumber, prefixExecuteDirname(problem.getDataFileName()));
 
                 // Create the correct output file, aka answer file
@@ -965,16 +1027,36 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             } // else no need to create external data files.
 
         }
+        // For subsequent passes on multipass, use supplied judge's input file
+        if(pass > 1) {
+            judgeDataFilename = nextPassFileName;
+        }
+        boolean bSuccess = performValidation(commandPattern, dataSetNumber, testSetNumber,
+                judgeDataFilename, judgeAnswerFilename,
+                pc2InterfaceResultsFileName, clicsInterfaceFeedbackDirName, pass);
+        return bSuccess;
+    }
 
-        // get a "random" number to be used as part of the results file name and feedback directory name, for security
-        String secs = Long.toString((new Date().getTime()) % 100);
+    /**
+     * Actually performs the validation of a run test case given all the necessary input parameters:
+     * @param commandPattern Validator command including subtitution strings
+     * @param dataSetNumber Original data set number (0 - NumDatasets-1)
+     * @param testSetNumber Ordinal data set number (1 - NumDatasets)
+     * @param judgeDataFilename Judges' Input file (.in) to use
+     * @param judgeAnswerFilename Judges' answer file
+     * @param pc2InterfaceResultsFileName For PC2 validation, where to put PC2 xml result
+     * @param clicsInterfaceFeedbackDirName For CLICS validation, where to put CLICS files.
+     * @return true if the validator returns "success" (indicating that the validator finished normally
+     *          This does NOT necessarily mean the submission was correct!
+     */
+    private boolean performValidation(String commandPattern, int dataSetNumber, int testSetNumber,
+            String judgeDataFilename, String judgeAnswerFilename,
+            String pc2InterfaceResultsFileName, String clicsInterfaceFeedbackDirName,
+            int passNum) {
 
-        //construct a "results file name", used by PC2 Interface validators
-        int testSetNumber = dataSetNumber + 1;
-        String pc2InterfaceResultsFileName = run.getNumber() + secs + "XRSAM." + testSetNumber + ".txt";
-
-        //construct a "feedback directory" name, used by CLICS Interface validators
-        String clicsInterfaceFeedbackDirName = run.getNumber() + secs + "XRSAM." + testSetNumber + File.separator;
+        log.info("performValidation: passNum:" + passNum + " dataSetNumber:" + dataSetNumber + " testSetNumber:" + testSetNumber +
+                " judgeDataFilename:" + judgeDataFilename + " judgeAnswerFilename:" + judgeAnswerFilename +
+                " clicsInterfaceFeedbackDirName:" + clicsInterfaceFeedbackDirName);
 
         log.log(Log.DEBUG, "command pattern before substitution: " + commandPattern);
 
@@ -991,22 +1073,25 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
 
             String feedbackDirPath = getExecuteDirectoryName() + File.separator + clicsInterfaceFeedbackDirName;
 
-            // get rid of any pre-existing feedback dir
-            try {
-                ExecuteUtilities.removeDirectory(feedbackDirPath);
-            } catch (Exception e) {
-                log.warning("Exception trying to remove feedback directory '" + feedbackDirPath + "': " + e.getMessage());
-            }
+            // Only clean up feedback dir on first pass
+            if(passNum == 1) {
+                // get rid of any pre-existing feedback dir
+                try {
+                    ExecuteUtilities.removeDirectory(feedbackDirPath);
+                } catch (Exception e) {
+                    log.warning("Exception trying to remove feedback directory '" + feedbackDirPath + "': " + e.getMessage());
+                }
 
-            if (insureDir(feedbackDirPath)) {
-                // clean out feedback dir
-                ExecuteUtilities.clearDirectory(feedbackDirPath);
-            } else {
-                throw new SecurityException("Unable to create ClicsValidator feedback directory '" + feedbackDirPath + "'; check logs");
+                if (insureDir(feedbackDirPath)) {
+                    // clean out feedback dir
+                    ExecuteUtilities.clearDirectory(feedbackDirPath);
+                } else {
+                    throw new SecurityException("Unable to create ClicsValidator feedback directory '" + feedbackDirPath + "'; check logs");
+                }
             }
         }
 
-        cmdLine = substituteAllStrings(run, cmdLine, testCase);
+        cmdLine = substituteAllStrings(run, cmdLine, testSetNumber);
 
         log.log(Log.DEBUG, "command pattern after substitution: " + cmdLine);
 
@@ -1060,7 +1145,7 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
             log.info("constructed new validator ExecuteTimer " + validatorExecutionTimer.toString());
             long startTime = System.currentTimeMillis();
 
-            Process validatorProcess = runProgram(cmdLine, formatTestCasePhase(msg, testCase), false, validatorExecutionTimer);
+            Process validatorProcess = runProgram(cmdLine, formatTestCasePhase(msg, testSetNumber), false, validatorExecutionTimer);
 
             if (validatorProcess == null) {
                 log.warning("validator process is null; stopping ExecuteTimer");
@@ -1810,9 +1895,11 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
      *
      * @param dataSetNumber
      *            a zero-based data set number
+     * @param pass number for multi-pass problems (1 for normal problems, or first pass or multipass)
+     * @param nextPassInputFileName name to use for judge's input file in multipass on subsequent passes
      * @return true if execution worked successfully.
      */
-    protected boolean executeProgram(int dataSetNumber) {
+    protected boolean executeProgram(int dataSetNumber, int pass, String nextPassInputFileName) {
 
         boolean proceedToValidation = false;
         String inputDataFileName = null;
@@ -1941,26 +2028,31 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                     /*
                      * External data files (not inside of pc2). On local disk.
                      */
-
-                    SerializedFile serializedFile = problemDataFiles.getJudgesDataFiles()[dataSetNumber];
-                    String dataFileName = Utilities.locateJudgesDataFile(problem, serializedFile, getContestInformation().getJudgeCDPBasePath(), Utilities.DataFileType.JUDGE_DATA_FILE);
-
-                    if (dataFileName != null) {
-                        // Found file
-
-                        File dataFile = new File(dataFileName);
-                        inputDataFileName = dataFile.getCanonicalPath();
-                        log.info("(External) Input data file: " + inputDataFileName);
-
+                    if(pass > 1) {
+                        log.info("Using Multi-pass Input data file: " + nextPassInputFileName + " for pass " + pass
+                                + " instead of " + inputDataFileName);
+                        inputDataFileName = nextPassInputFileName;
                     } else {
+                        SerializedFile serializedFile = problemDataFiles.getJudgesDataFiles()[dataSetNumber];
+                        String dataFileName = Utilities.locateJudgesDataFile(problem, serializedFile, getContestInformation().getJudgeCDPBasePath(), Utilities.DataFileType.JUDGE_DATA_FILE);
 
-                        // Did not find file
+                        if (dataFileName != null) {
+                            // Found file
 
-                        String expectedFileName = serializedFile.getName();
-                        log.log(Log.DEBUG, "For problem " + problem + " test case " + testSetNumber + " expecting file " + expectedFileName + " in dir " + problem.getCCSfileDirectory());
-                        FileNotFoundException notFound = new FileNotFoundException(expectedFileName + " for test case " + testSetNumber);
-                        executionData.setExecutionException(notFound);
-                        log.info("(External) Input data file: NOT FOUND ");
+                            File dataFile = new File(dataFileName);
+                            inputDataFileName = dataFile.getCanonicalPath();
+                            log.info("(External) Input data file: " + inputDataFileName);
+
+                        } else {
+
+                            // Did not find file
+
+                            String expectedFileName = serializedFile.getName();
+                            log.log(Log.DEBUG, "For problem " + problem + " test case " + testSetNumber + " expecting file " + expectedFileName + " in dir " + problem.getCCSfileDirectory());
+                            FileNotFoundException notFound = new FileNotFoundException(expectedFileName + " for test case " + testSetNumber);
+                            executionData.setExecutionException(notFound);
+                            log.info("(External) Input data file: NOT FOUND ");
+                        }
                     }
                 }
             }
@@ -2031,6 +2123,10 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                 } else {
                     cmdline = replaceString(cmdline, Constants.CMDSUB_BASENAME_VARNAME, entryPointName);
                 }
+            }
+            // Short circuit replacement of judge's path to input file if multipass
+            if(pass > 1) {
+                cmdline = replaceString(cmdline, "{:infilename}", nextPassInputFileName);
             }
             cmdline = substituteAllStrings(run, cmdline, testSetNumber);
             log.log(Log.DEBUG, "cmdline after substitution: " + cmdline);

--- a/src/edu/csus/ecs/pc2/core/model/Problem.java
+++ b/src/edu/csus/ecs/pc2/core/model/Problem.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.File;
@@ -1317,6 +1317,10 @@ public class Problem implements IElementObject {
 
     public boolean isInteractive() {
         return isUsingCustomValidator() && customValidatorSettings.isUseInteractiveValidatorInterface();
+    }
+
+    public boolean isMultipass() {
+        return isUsingCustomValidator() && customValidatorSettings.isUseMultipassValidatorInterface();
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -1045,7 +1045,15 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
             problemMemento.putString("color", problems[i].getColorName());
             problemMemento.putString("letter", problems[i].getLetter());
             problemMemento.putString("rgb", problems[i].getColorRGB());
-            problemMemento.putString("url", "problems/" + problems[i].getLetter() + ".pdf");
+            problemMemento.putString("shortName", problems[i].getShortName());
+            
+            //construct a string pointing to the place where the Contest Admin is expected to put the problem writeup.
+            //Problem writeups are expected to be placed under the web-content folder in a problem-specific subfolder
+            // named like <letter>-capitalizeFirstLetter(shortname), in a PDF file named the same but with ".pdf" added.
+            String basename = problems[i].getLetter().toUpperCase() + "-" + capitalizeFirstLetter(problems[i].getShortName());
+            String filename = basename + ".pdf";
+            problemMemento.putString("url", "problems/" + basename + "/" + filename);
+            
             problemMemento.putLong("attempts", problemAttempts[id]);
             if (problemAttempts[id] > 0) {
                 grandTotalProblemAttempts++;
@@ -1062,6 +1070,25 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
         summaryMemento.putInteger("totalTeams", grandTotalTeams);
 
 
+    }
+
+    /**
+     * Returns a string which is identical to the input string except that the first character, if it
+     * is a letter, is guaranteed to be upper-case.
+     * @param input the string to be processed.
+     * @return an equivalent string with the first character capitalized if it is a letter.
+     */
+    private String capitalizeFirstLetter(String input) {
+        if (input == null || input.isEmpty()) {
+            return input; // Return as-is if null or empty
+        }
+        
+        char firstChar = input.charAt(0);
+        if (!Character.isLetter(firstChar)) {
+            return input; // Return unchanged if first char is not a letter
+        }
+        
+        return Character.toUpperCase(firstChar) + input.substring(1);
     }
 
     /**

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -394,8 +394,30 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
         Problem[] allProblems = theContest.getProblems();
         Hashtable <ElementId, Integer> problemsIndexHash = new Hashtable<ElementId, Integer>();
         int p2 = 0;
+        
+        //if divisionNumber!=null it means we're using Division filtering, in which case divisionNumber is 1 or 2.
+        //if wantedGroups!=null it means the caller has specified a set of groups it wants to filter on.
+        //if the caller HASN'T specified any groups, we need to add to the wantedGroups list the groups for the specified division.
+        if (wantedGroups==null && divisionNumber!=null) {
+            //the caller didn't request any group filtering via wantedGroups but we are doing division filtering so we need a collection
+            // (this is because if wantedGroups is null it causes method canView(wantedGroups) to always return "yes").
+            wantedGroups = new ArrayList<Group>();
+        }
+        
         for (int p=1; p <= allProblems.length ; p++) {
             Problem prob = allProblems[p-1];
+            
+            if (divisionNumber!=null) {
+                //we are filtering on divisions so we need to update "wantedGroups" with the "division" groups
+                // in the problem which match the desired division.
+                for (Group probGroup : prob.getGroups()) {
+                   //Note: getGroupId() returns the "CMS external id".
+                   if (probGroup.getGroupId()==divisionNumber) {
+                        wantedGroups.add(probGroup); 
+                    }
+                }
+            }
+            
             if (prob.isActive() && prob.canView(wantedGroups)) {
                 p2++;
                 problemsIndexHash.put(prob.getElementId(), new Integer(p2));

--- a/src/edu/csus/ecs/pc2/core/standings/ScoringProblem.java
+++ b/src/edu/csus/ecs/pc2/core/standings/ScoringProblem.java
@@ -16,7 +16,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @XmlRootElement(name = "problem")
 @XmlAccessorType(XmlAccessType.FIELD)
-@JsonIgnoreProperties({ "color", "rgb", "letter", "url" })
+@JsonIgnoreProperties({ "color", "rgb", "letter", "url", "shortName" })
+
 public class ScoringProblem {
 
     // <problem attempts="78" bestSolutionTime="2" id="2" lastSolutionTime="83" numberSolved="53" title="Candle Box"/>

--- a/src/edu/csus/ecs/pc2/core/util/TabSeparatedValueParser.java
+++ b/src/edu/csus/ecs/pc2/core/util/TabSeparatedValueParser.java
@@ -1,11 +1,11 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.util;
 
 import java.util.Vector;
 
 /**
  * Tab delimited parser.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -17,9 +17,11 @@ public final class TabSeparatedValueParser {
 
     private static final String TAB_STRING = String.valueOf(TAB_CHAR);
 
+    private static final char ESC_CHAR = '\\';
+
     /**
      * Return array of containing the Tab Separated Values from the input string.
-     * 
+     *
      * @return java.lang.String[]
      * @param line
      *            java.lang.String
@@ -27,11 +29,11 @@ public final class TabSeparatedValueParser {
      *             if there was a problem parsing the line
      */
     public static String[] parseLine(String line) throws Exception {
-        
+
         if (line == null) {
             throw new IllegalArgumentException("null String not allowed");
         }
-        
+
         String[] array = new String[1];
         array[0] = "";
         int fieldCount = 1;
@@ -39,6 +41,7 @@ public final class TabSeparatedValueParser {
         Vector<String> v = new Vector<String>();
         int i;
         boolean inQuote = false;
+        boolean inEscape = false;
         char current;
         char next;
         int length = line.length();
@@ -46,6 +49,15 @@ public final class TabSeparatedValueParser {
         int ignoredTerminatingQuote = 0; // SOMEDAY can this be removed??
         for (i = 0; i < line.length(); i++) {
             current = line.charAt(i);
+            if(inEscape) {
+                currentField = currentField + current;
+                inEscape = false;
+                continue;
+            }
+            if(current == ESC_CHAR) {
+                inEscape = true;
+                continue;
+            }
             if (current == '"') {
                 if (inQuote) {
                     if (i + 1 >= length) {
@@ -105,7 +117,7 @@ public final class TabSeparatedValueParser {
 
     /**
      * Return String of the Tab Separated Values made from the input array
-     * 
+     *
      * @return java.lang.String
      * @param array
      *            java.lang.String[]
@@ -141,7 +153,7 @@ public final class TabSeparatedValueParser {
     }
 
     /**
-     * 
+     *
      */
     private TabSeparatedValueParser() {
         super();

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1727,6 +1727,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             problem.setMemoryLimitMB(clicsMemoryLimit);
 
             Integer clicsValidationPasses = fetchIntValue(limitsContent, CLICS_VALIDATION_PASSES, DEFAULT_VALIDATION_PASSES);
+            problem.getCustomOutputValidatorSettings().setMaxMultipassValidationPasses(clicsValidationPasses);
         }
 
         if (!usingCustomValidator) {

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1454,16 +1454,16 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         // So, the value may be a double (IE contains a decimal pt), or an integer.
         Object oValue = map.get(key);
         Double value = null;
-        if(oValue instanceof Double) {
-            value = (Double) map.get(key);
-        } else {
-            value = new Double(((Integer)oValue).doubleValue());
-        }
-        if (value != null) {
+        if (oValue != null) {
             try {
+                if(oValue instanceof Double) {
+                    value = (Double) oValue;
+                } else {
+                    value = new Double(((Integer)oValue).doubleValue());
+                }
                 return value;
             } catch (Exception e) {
-                syntaxError("Expecting double number after " + key + ": field, found '" + value + "'");
+                syntaxError("Expecting double number after " + key + ": field, found '" + oValue + "'");
             }
         }
         return null;

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1451,7 +1451,14 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             // SOMEDAY figure out why map would every be null
             return null;
         }
-        Double value = (Double) map.get(key);
+        // So, the value may be a double (IE contains a decimal pt), or an integer.
+        Object oValue = map.get(key);
+        Double value = null;
+        if(oValue instanceof Double) {
+            value = (Double) map.get(key);
+        } else {
+            value = new Double(((Integer)oValue).doubleValue());
+        }
         if (value != null) {
             try {
                 return value;

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1446,6 +1446,22 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         return null;
     }
 
+    private Double fetchDoubleValue(Map<String, Object> map, String key) {
+        if (map == null) {
+            // SOMEDAY figure out why map would every be null
+            return null;
+        }
+        Double value = (Double) map.get(key);
+        if (value != null) {
+            try {
+                return value;
+            } catch (Exception e) {
+                syntaxError("Expecting double number after " + key + ": field, found '" + value + "'");
+            }
+        }
+        return null;
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> fetchMap(Map<String, Object> content, String key) {
         Object object = content.get(key);
@@ -1503,11 +1519,13 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         // the ONLY way to specify if the problem is interactive.
         String validationType = fetchValue(content, VALIDATION_TYPE);
         boolean isInteractive = false;
+        boolean isMultipass = false;
         if (validationType != null) {
             // validationType is a list of validation options
             String[] valOpts = validationType.split("\\s");
             // Must be one of: "default", "custom", "custom interactive"
             // PC2 does not support "custom score", which IS spec compliant; we issue a different error for that
+            // Added support for "custom multipass" (Problem Package Format: 2023-07 draft)
             if (valOpts.length >= 1) {
                 if(valOpts[0].equals(Constants.VALIDATION_CUSTOM)) {
                     usingCustomValidator = true;
@@ -1515,6 +1533,8 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                         if(valOpts[1].equals(Constants.VALIDATION_INTERACTIVE)) {
                             // Note that interactive problems require a custom validator
                             isInteractive = true;
+                        } else if(valOpts[1].equals(Constants.VALIDATION_MULTIPASS)) {
+                            isMultipass = true;
                         } else if(valOpts[1].equals(Constants.VALIDATION_SCORE)) {
                             syntaxError("Unsupported validation type: custom score");
                         } else {
@@ -1599,6 +1619,30 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             }
         }
 
+        // Make sure the validator settings are acceptable for multipass problems
+        if(isMultipass) {
+            if(!usingCustomValidator) {
+                throw new YamlLoadException("For problem short name " + problem.getShortName() +
+                        ", a custom validator is required for an multipass problem");
+
+            }
+            if(!problem.getCustomOutputValidatorSettings().isUseClicsValidatorInterface()) {
+                throw new YamlLoadException("For problem short name " + problem.getShortName() +
+                        ", the custom validator must be a CLICS compliant for an multipass problem");
+
+            } else {
+                // A note here about how multipass validation works.  The multipass validator must be CLICS
+                // compliant and return an exit code of 42 or 43, and possibly generating a feedback file for
+                // each test case.
+
+                // We set the custom output validator settings for interactive.  The CLICS spec does not have
+                // a validator section in the YAML, as such, we first verified that the custom validator is CLICS compliant.
+                // We then we set output validator type to clics interactive.
+                problem.getCustomOutputValidatorSettings().setUseMultipassValidatorInterface();
+            }
+        }
+
+
         //read any PC2-format limits specified at the top level of the problem.yaml file
         Integer timeoutSecs = fetchIntValue(content, TIMEOUT_KEY);
         if (timeoutSecs != null) {
@@ -1668,9 +1712,9 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             //check for a timeout limit within the CLICS "limits:" section.
             // Note that the presence of a "timeout:" entry within a CLICS
             // "limits:" section is non-CLICS standard -- but we want to support it in PC2.
-            Integer clicsTimeout = fetchIntValue(limitsContent, TIMEOUT_KEY);
+            Double clicsTimeout = fetchDoubleValue(limitsContent, TIMEOUT_KEY);
             if (clicsTimeout != null) {
-                problem.setTimeOutInSeconds(clicsTimeout);
+                problem.setTimeOutInSeconds(clicsTimeout.intValue());
             }
 
             //check for a CLICS maxoutput limit - the value is in MiB
@@ -1681,6 +1725,8 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
 
             Integer clicsMemoryLimit = fetchIntValue(limitsContent, MEMORY_LIMIT_CLICS, memoryLimit.intValue());
             problem.setMemoryLimitMB(clicsMemoryLimit);
+
+            Integer clicsValidationPasses = fetchIntValue(limitsContent, CLICS_VALIDATION_PASSES, DEFAULT_VALIDATION_PASSES);
         }
 
         if (!usingCustomValidator) {

--- a/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
@@ -159,6 +159,9 @@ public final class ICPCTSVLoader {
             institutionCode = fields[fieldnum++];
             String[] fieldArray = getInstitutionNames(institutionCode);
             if (fieldArray != null) {
+                if(fieldArray.length < 3) {
+                    throw new InvalidValueException("Bad institution code '" + institutionCode + "' on line " + originalLine + " (need at least 3 fields, but there are only " + fieldArray.length + ")");
+                }
                 institutionFormalName = fieldArray[1];
                 institutionName = fieldArray[2];
             }
@@ -386,7 +389,7 @@ public final class ICPCTSVLoader {
 //            String formalName = fields[1];
 //            String name = fields[2];
             institutionsMap.put(icpcId, fields);
-            
+
             // We also add the institution ID minus the INST- "Due to the non-specificity of the format of an inst code
             if(icpcId.startsWith("INST-")) {
                 institutionsMap.put(icpcId.substring(5), fields);

--- a/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
@@ -35,6 +35,8 @@ public interface IContestLoader {
 
     String DEFAULT_SYSTEM_YAML_FILENAME = "system.yaml";
 
+    public static final int DEFAULT_VALIDATION_PASSES = 2;
+
     // CDP directories
 
     String SUBMISSIONS_DIRNAME = "submissions";
@@ -88,6 +90,8 @@ public interface IContestLoader {
     String CLICS_TIME_MULTIPLIER_KEY = "time_multiplier";
 
     String CLICS_TIME_SAFETY_MARGIN_KEY = "time_safety_margin";
+
+    String CLICS_VALIDATION_PASSES = "validation_passes";
 
     final String OUTPUT_PRIVATE_SCORE_DIR_KEY = "output-private-score-dir";
 

--- a/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
+++ b/src/edu/csus/ecs/pc2/shadow/RemoteContestAPIAdapter.java
@@ -1,8 +1,7 @@
-// Copyright (C) 1989-2022 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.shadow;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,29 +9,25 @@ import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
+import edu.csus.ecs.pc2.convert.EventFeedUtilities;
 import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.model.IFile;
-import edu.csus.ecs.pc2.core.model.IFileImpl;
 import edu.csus.ecs.pc2.shadow.AbstractRemoteConfigurationObject.REMOTE_CONFIGURATION_ELEMENT;
 import edu.csus.ecs.pc2.util.HTTPSSecurity;
 
 public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
-    
+
     URL remoteURL;
     String login;
     String password;
-    
+
     /**
      * Constructs a RemoteRunMonitor with the specified values.
-     * 
+     *
      * @param remoteURL the URL to the remote CCS
      * @param login the login (account) on the remote CCS
      * @param password the password to the remote CCS account
@@ -56,13 +51,13 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
             }
         } catch (Exception e) {
             return false; // ignore exception, return false
-        } 
-        
-        //if we get here, either the createConnection() returned null or else we got an exception 
+        }
+
+        //if we get here, either the createConnection() returned null or else we got an exception
         // which fell through the catch block
         return false;
     }
-    
+
 
     protected URL getChildURL(String path) {
         if (path == null || path.isEmpty())
@@ -91,12 +86,12 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
         }
     }
 
-    
+
     protected HttpURLConnection createConnection(String path) throws IOException {
         return createConnection(getChildURL(path));
     }
-    
-    
+
+
     protected  HttpURLConnection createConnection(URL url2) throws IOException {
         try {
             HttpURLConnection conn = HTTPSSecurity.createConnection(url2, login, password);
@@ -108,7 +103,7 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
             throw new IOException("Connection error", e);
         }
     }
-    
+
     //This method can be removed
     private InputStream connect(String path) throws IOException {
         try {
@@ -133,10 +128,10 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
             throw new IOException("Connection error", e);
         }
     }
-    
+
     /**
      * Open input stream for event feed.
-     * 
+     *
      * @param remoteURL2
      * @param user
      * @param password
@@ -151,7 +146,7 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
 
     @Override
     public RemoteContestConfiguration getRemoteContestConfiguration() {
-        
+
         Map<REMOTE_CONFIGURATION_ELEMENT, List<AbstractRemoteConfigurationObject>> remoteConfigMap = new HashMap<AbstractRemoteConfigurationObject.REMOTE_CONFIGURATION_ELEMENT, List<AbstractRemoteConfigurationObject>>();
 
         // TODO TODAY implement me - add mock data into RemoteContestConfiguration
@@ -162,7 +157,7 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
 
     @Override
     public String getRemoteJSON(String endpoint) {
-        
+
         String url = remoteURL.toString() + endpoint;
         try {
             HttpURLConnection conn = createConnection(url);
@@ -170,11 +165,11 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        
+
     }
 
     private String toString(InputStream inputStream) throws IOException {
-        
+
         BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         int result = bufferedInputStream.read();
@@ -184,9 +179,9 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
         }
         return byteArrayOutputStream.toString();
     }
-    
+
     private byte[] toByteArray(InputStream inputStream) throws IOException {
-        
+
         BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         int result = bufferedInputStream.read();
@@ -205,16 +200,16 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
         // passing null here will start the feed from the beginning
         return(getRemoteEventFeedInputStream(null));
     }
-    
+
     @Override
     /**
      * {@inheritDoc}
      */
     public InputStream getRemoteEventFeedInputStream(String token) {
-        
+
         String eventFeedURLString = remoteURL.toString();
         eventFeedURLString = appendIfMissing(eventFeedURLString, "/") +"event-feed";
-        
+
         // Add on optional starting point token
         if(token != null && !token.isEmpty()) {
             eventFeedURLString += "?since_token=" + token;
@@ -244,31 +239,31 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
      * "/submissions/<submissionID>/files" and then invoking the method
      * {@link #getRemoteSubmissionFiles(URL)} with that URL, returning the result
      * of that method call.
-     * 
+     *
      * Note that if the "Primary CCS URL" ends with a "/" character then this method
      * avoids adding a duplicate "/" when concatenating the "submissions" endpoint to the URL;
      * see https://github.com/pc2ccs/pc2v9/issues/528.
-     * 
+     *
      * @param submissionID a String representation of the submission ID from the remote system
      * @return the result of calling {@link #getRemoteSubmissionFiles(URL)} with the constructed URL,
      *         or null if an exception is thrown during URL construction
      */
     @Override
     public List<IFile> getRemoteSubmissionFiles(String submissionID) {
-        
+
         //define the CLICS endpoint for fetching the files associated with a submission
         String endpoint = "/submissions/" + submissionID + "/files";
-        
+
         //get the configured Primary CCS URL
         String urlString = remoteURL.toString();
         //ensure the URL doesn't end with "/" (because we're going to add a "/" as part of the "endpoint")
         if (urlString.endsWith("/")){
             urlString = StringUtilities.removeLastChar(urlString);
         }
-        
+
         //build the full URL to the submissions/files endpoint
         urlString = urlString + endpoint;
-        
+
         URL url;
         try {
             url = new URL(urlString);
@@ -283,10 +278,10 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
     /**
      * Fetches submission files from the specified URL.
      * The URL is expected to reference an endpoint which returns a zip file
-     * containing the files comprising a contest submission.  
-     * 
+     * containing the files comprising a contest submission.
+     *
      * @param submissionFilesURL a URL where a zip file containing submitted files may be found
-     * @return a List of {@link IFile}s  containing the contents of the submission files obtained 
+     * @return a List of {@link IFile}s  containing the contents of the submission files obtained
      *          from the specified URL
      * @throws {@link RuntimeException} if an {@link IOException} occurs while connecting to the
      *          remote system at the specified URL or while reading bytes from the input stream
@@ -299,90 +294,17 @@ public class RemoteContestAPIAdapter implements IRemoteContestAPIAdapter {
 
             //make a connection to the specified URL
             HttpURLConnection conn = createConnection(submissionFilesURL);
-            
+
             //get the bytes (comprising a zipfile) from the specified URL's input stream
             byte[] bytes = toByteArray(conn.getInputStream());
 
             // Unzip the bytes/zipfile into individual IFiles
-            List<IFile> files = getIFiles(bytes);
+            List<IFile> files = EventFeedUtilities.getIFiles(bytes);
             return files;
 
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
-    
-    /**
-     * Get files from a zipfile's bytes.
-     * 
-     * @param bytes bytes comprising a zip file.
-     * @return list of IFiles extracted from the input bytes 
-     */
-    private List<IFile> getIFiles(byte[] bytes) {
-        
-        List<IFile> files = new ArrayList<IFile>();
-        
-        ZipInputStream zipStream = null;
-        
-        try {
-            zipStream = new ZipInputStream(new ByteArrayInputStream(bytes));
-            ZipEntry entry = null;
-            /**
-             * Read each zip entry, add IFile.
-             */
-            while ((entry = zipStream.getNextEntry()) != null) {
-                
-                String entryName = entry.getName();
-                
-//                ByteOutputStream byteOutputStream = new ByteOutputStream();
-                ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-                
-                byte[] buffer = new byte[8096];
-                int bytesRead = 0;
-                while ((bytesRead = zipStream.read(buffer)) != -1)
-                {
-                    byteOutputStream.write(buffer, 0, bytesRead);
-                }
 
-//                String base64Data = getBase64Data(byteOutputStream.getBytes());
-                String base64Data = getBase64Data(byteOutputStream.toByteArray());
-                IFile iFile = new IFileImpl(entryName, base64Data);
-                files.add(iFile);
-                
-                byteOutputStream.close();
-                
-                zipStream.closeEntry();
-            }
-            zipStream.close(); 
-            
-        } catch (Exception e) {
-            if (zipStream != null){
-                try {
-                    zipStream.close();
-                } catch (Exception ze) {
-                    ; // problem closing stream, ignore.
-                }
-            }
-            throw new RuntimeException(e);
-        }
-        
-        return files;
-        
-    }
-    
-    /**
-     * Encode bytes into BASE64.
-     * @param data
-     * @return
-     */
-    public String getBase64Data( byte [] bytes) {
-        // TODO REFACTOR move to FileUtilities
-        Base64.Encoder encoder = Base64.getEncoder();
-        String base64String = encoder.encodeToString(bytes);
-        return base64String;
-    }
-
-
-
-    
 }

--- a/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
+++ b/src/edu/csus/ecs/pc2/ui/EditProblemPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -74,11 +74,11 @@ import edu.csus.ecs.pc2.core.model.Problem.VALIDATOR_TYPE;
 import edu.csus.ecs.pc2.core.model.ProblemDataFiles;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 import edu.csus.ecs.pc2.core.model.inputValidation.InputValidationResult;
-import edu.csus.ecs.pc2.core.model.inputValidation.InputValidationResultsTableModel;
 import edu.csus.ecs.pc2.core.report.IReport;
 import edu.csus.ecs.pc2.core.report.ProblemsReport;
 import edu.csus.ecs.pc2.core.report.SingleProblemReport;
 import edu.csus.ecs.pc2.imports.ccs.ContestSnakeYAMLLoader;
+import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 import edu.csus.ecs.pc2.validator.clicsValidator.ClicsValidatorSettings;
 import edu.csus.ecs.pc2.validator.customValidator.CustomValidatorSettings;
 import edu.csus.ecs.pc2.validator.inputValidator.VivaAdapter;
@@ -87,7 +87,7 @@ import edu.csus.ecs.pc2.validator.pc2Validator.PC2ValidatorSettings;
 
 /**
  * Add/Edit Problem Pane.
- * 
+ *
  * @author pc2@ecs.csus.edu
  */
 
@@ -109,8 +109,8 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * The original/input problem.
      */
-    private Problem problem = null; 
-    
+    private Problem problem = null;
+
     private JTabbedPane mainTabbedPane = null;
     private JPanel generalPane = null;
     private ProblemGroupPane problemGroupPane = null;
@@ -143,8 +143,8 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * last directory where searched for files.
      */
-    private String lastDirectory; 
-    
+    private String lastDirectory;
+
     //John's local private testing directory
 //    private String lastDirectory = "C:\\clevengr\\contest\\PC2\\v9\\TestContests\\sumithello2\\config\\sumit";
 
@@ -226,7 +226,7 @@ public class EditProblemPane extends JPanePlugin {
     private JComboBox<String> pc2ValidatorOptionComboBox;
     private JCheckBox pc2ValidatorIgnoreCaseCheckBox;
     private JLabel lblWhatsThisCLICSValidator;
-    
+
     private JTextField maxOutputSizeTextfield;
     private JLabel lblMaxOutputSizeKB;
     private JLabel lblWhatsThisMaxOutputSize;
@@ -245,7 +245,7 @@ public class EditProblemPane extends JPanePlugin {
     private JLabel lblShortName;
 
     private JLabel problemLetterLabel;
-    
+
     private EditProblemSandboxPane editProblemSandboxPane;
 
     /**
@@ -255,26 +255,26 @@ public class EditProblemPane extends JPanePlugin {
         /**
          * The Problem has no associated custom validator type (eg it is bad)
          */
-        CV_NONE, 
+        CV_NONE,
         /**
          * The Custom validator uses the PC2 Validator interface, also known as the "Internal" Validator.
          */
-        CV_PC2, 
+        CV_PC2,
         /**
          * The Custom validator uses the CLICS Validator specification return values.
          */
-        CV_CLICS, 
+        CV_CLICS,
         /**
          * The Custom validator is an interactive validator using the CLICS validator specification return values.
          */
         CV_INTERACTIVE_CLICS
         }
-    
+
     private CUSTOM_VALIDATOR_INTERFACE_TYPE customValidatorInterfaceType = CUSTOM_VALIDATOR_INTERFACE_TYPE.CV_NONE;
-    
+
     /**
      * Constructs an EditProblemPane with default settings.
-     * 
+     *
      */
     public EditProblemPane() {
         super();
@@ -283,7 +283,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes this EditProblemPane.
-     * 
+     *
      */
     private void initialize() {
         this.setLayout(new BorderLayout());
@@ -294,6 +294,7 @@ public class EditProblemPane extends JPanePlugin {
         this.add(getMainTabbedPane(), java.awt.BorderLayout.CENTER);
     }
 
+    @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         super.setContestAndController(inContest, inController);
         addWindowListeners();
@@ -301,12 +302,13 @@ public class EditProblemPane extends JPanePlugin {
         getMultipleDataSetPane().setContestAndController(inContest, inController);
 
         getInputValidatorPane().setContestAndController(inContest, inController);
-        
+
         getProblemGroupPane().setContestAndController(inContest, inController);
-        
+
         getProblemSandboxPane().setContestAndController(inContest, inController);
-        
+
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 getLoadButton().setVisible(Utilities.isDebugMode());
                 getExportButton().setVisible(Utilities.isDebugMode());
@@ -319,7 +321,7 @@ public class EditProblemPane extends JPanePlugin {
                 debug22EditProblem = value.equalsIgnoreCase("true");
             }
         }
-        
+
         log = inController.getLog();
 
     }
@@ -332,9 +334,11 @@ public class EditProblemPane extends JPanePlugin {
         }
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 if (getParentFrame() != null) {
                     getParentFrame().addWindowListener(new java.awt.event.WindowAdapter() {
+                        @Override
                         public void windowClosing(java.awt.event.WindowEvent e) {
                             handleCancelButton();
                         }
@@ -344,6 +348,7 @@ public class EditProblemPane extends JPanePlugin {
                             getProblemNameTextField().requestFocus();
                         }
 
+                        @Override
                         public void windowActivated(WindowEvent e) {
                             getProblemNameTextField().requestFocus();
                         };
@@ -354,13 +359,14 @@ public class EditProblemPane extends JPanePlugin {
         });
     }
 
+    @Override
     public String getPluginTitle() {
         return "Edit Problem Pane";
     }
 
     /**
      * This method initializes messagePane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getMessagePane() {
@@ -378,7 +384,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes buttonPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getButtonPane() {
@@ -399,7 +405,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes addButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getAddButton() {
@@ -409,6 +415,7 @@ public class EditProblemPane extends JPanePlugin {
             addButton.setMnemonic(java.awt.event.KeyEvent.VK_A);
             addButton.setEnabled(false);
             addButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     addProblem();
                 }
@@ -418,12 +425,12 @@ public class EditProblemPane extends JPanePlugin {
     }
 
     /**
-     * Adds to the contest a new Problem as defined by the current GUI fields. This method is invoked by pushing the "Add" button 
+     * Adds to the contest a new Problem as defined by the current GUI fields. This method is invoked by pushing the "Add" button
      * on the EditProblemPane GUI after having defined the values for a new problem being added.
-     * 
-     * The method also gets invoked by making GUI changes to a new problem definition, then pressing "Cancel" (which displays a 
+     *
+     * The method also gets invoked by making GUI changes to a new problem definition, then pressing "Cancel" (which displays a
      * message "Problem Modified - Save Changes?") and responding "Yes" to the message.
-     * 
+     *
      * @return true if all GUI values are valid and problem is added successfully; false otherwise
      */
     protected boolean addProblem() {
@@ -445,16 +452,16 @@ public class EditProblemPane extends JPanePlugin {
         if (showMissingInputValidatorWarningOnAddProblem && getProblemRequiresDataCheckBox().isSelected()
                 && (getInputValidatorPane().getUseNoInputValidatorRadioButton().isSelected()  //the problem explicitly says "no IV"
                     || (getInputValidatorPane().getCustomInputValidatorFile() == null
-                         && (getInputValidatorPane().getVivaPatternTextArea().getText()==null 
+                         && (getInputValidatorPane().getVivaPatternTextArea().getText()==null
                              || getInputValidatorPane().getVivaPatternTextArea().getText().equals("") )
                         )
                    )
             ) {
 
             // no input validator defined; issue a warning
-            String msg = "You are attempting to add a Problem which requires Input Data files but has no Input Data Validator." 
+            String msg = "You are attempting to add a Problem which requires Input Data files but has no Input Data Validator."
                     + "\n\nThis is usually not good practice because it provides no way to insure that the"
-                    + "\nJudge's data files meet the Problem Specification." 
+                    + "\nJudge's data files meet the Problem Specification."
                     + "\n\nAre you sure you want to do this?" + "\n\n";
 
             JCheckBox checkbox = new JCheckBox("Do not show this message again.");
@@ -475,7 +482,7 @@ public class EditProblemPane extends JPanePlugin {
                 && (getInputValidatorPane().getCustomInputValidatorCommand()!=null && !getInputValidatorPane().getCustomInputValidatorCommand().equals(""))) {
 
             // no input validator program defined; issue a warning
-            String message = "You are attempting to add a problem which has an Input Data Validator command but no Input Validator Program name." 
+            String message = "You are attempting to add a problem which has an Input Data Validator command but no Input Validator Program name."
                         + "\n\nAre you sure this is what you intended to do?"
                         + "\n\n";
 
@@ -591,7 +598,7 @@ public class EditProblemPane extends JPanePlugin {
      * It does not do any data validation on the input String; it presumes the String
      * consists solely of digits which can be parsed into a Long value.
      * If any Exception occurs during parsing then the method returns zero.
-     * 
+     *
      * @param s the input String to be parsed.
      * @return a Long whose value corresponds to the input String.
      */
@@ -605,7 +612,7 @@ public class EditProblemPane extends JPanePlugin {
 
    /**
      * Enable or disable Update button based on comparison of current problem to GUI fields.
-     * 
+     *
      */
     public void enableUpdateButton() {
 
@@ -636,13 +643,13 @@ public class EditProblemPane extends JPanePlugin {
                 }
 
                 //keep track of how many files have changed
-                int numFilesChanged = 0;   
-                
+                int numFilesChanged = 0;
+
                 // see if the problem data files have changed; enable the Update button and update the tooltip if so
                 ProblemDataFiles pdf = getContest().getProblemDataFile(problem);
                 ProblemDataFiles proposedPDF = getMultipleDataSetPane().getProblemDataFiles();
                 if (pdf != null) {
-                    
+
                     //check the judge's data files
                     SerializedFile[] judgesDataFiles = pdf.getJudgesDataFiles();
                     SerializedFile[] judgesDataFilesNew = null;
@@ -753,7 +760,7 @@ public class EditProblemPane extends JPanePlugin {
                             }
                         }
                     }
-                    
+
                 } else {
                     logDebugException("No ProblemDataFiles for " + problem);
                 }
@@ -909,7 +916,7 @@ public class EditProblemPane extends JPanePlugin {
                     //the original problem and the GUI differ as to whether the Custom Validator has been run.
                     //This means either the problem originally had a Custom Validator which was run, and now a new Custom Validator
                     // has been assigned but has not been run, or else the problem did NOT have a Custom Validator which was run
-                    // but now there has been a Custom Validator which has been run.  Update the tooltip to reflect which of 
+                    // but now there has been a Custom Validator which has been run.  Update the tooltip to reflect which of
                     // these conditions is true.
                     String msg ;
                     if (!changedProblem.isCustomInputValidatorHasBeenRun()) {
@@ -925,7 +932,7 @@ public class EditProblemPane extends JPanePlugin {
                 }
 
                 //TODO: should the following Custom Input Validator settings also be checked?
-                //                    private String customInputValidatorFilesOnDiskFolderName = "";   
+                //                    private String customInputValidatorFilesOnDiskFolderName = "";
                 //                    private SerializedFile customInputValidatorSerializedFile = null;
                 //                    private Vector<InputValidationResult> customInputValidationResults ;
 
@@ -979,8 +986,8 @@ public class EditProblemPane extends JPanePlugin {
 
                     }
                 }
-                
-                
+
+
                 //see if the sandbox type has changed
                 if (!(problem.getSandboxType() == changedProblem.getSandboxType())) {
                     enableButton = true;
@@ -999,7 +1006,7 @@ public class EditProblemPane extends JPanePlugin {
                             updateToolTip = "Memory Limit";
                         } else {
                             updateToolTip += ", Memory Limit";
-                        } 
+                        }
                     }
                 }
 
@@ -1070,11 +1077,11 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Compares the specified SerializedFile with the file on disk of the specified filename and returns an indication of whether or not the two are identical.
-     * 
+     *
      * If the specified SerializedFile is null, or the specified filename is null or the empty string, returns false (since no comparison can be made and hence they cannot be "the same"). If the full
      * path file name in the SerializedFile does not match the specified filename, returns false. Otherwise, compares the checksums using method {@link #needsFreshening(SerializedFile, String)} and
      * returns an indication of whether the checksums match ({@link #needsFreshening(SerializedFile, String)} returns false if the files match).
-     * 
+     *
      * @param storedFile
      *            the SerializedFile to compare
      * @param diskFileName
@@ -1090,18 +1097,18 @@ public class EditProblemPane extends JPanePlugin {
     }
 
     /**
-     * Create a Problem from the fields in this GUI. This method assumes the data in the GUI fields has already been validated 
-     * (i.e., the GUI values define a legitimate, complete Problem); while the method does do some sanity checking 
+     * Create a Problem from the fields in this GUI. This method assumes the data in the GUI fields has already been validated
+     * (i.e., the GUI values define a legitimate, complete Problem); while the method does do some sanity checking
      * it should not be assumed to have completely verified the validity of the GUI data.
-     * 
+     *
      * This method also populates newProblemDataFiles for the data files.
-     * 
+     *
      * @param checkProblem
      *            will update this Problem if supplied, if null creates and returns a new Problem
      * @param dataFiles
-     * 
+     *
      * @return a Problem based on fields in this EditProblemPane GUI
-     * 
+     *
      * @throws InvalidFieldValue
      *             if any of the fields in the GUI are incomplete or illegally set
      */
@@ -1157,10 +1164,10 @@ public class EditProblemPane extends JPanePlugin {
         checkProblem.setLetter(getProblemLetterTextField().getText());
         checkProblem.setActive(!getDeleteProblemCheckBox().isSelected());
         checkProblem.setShortName(getShortNameTextfield().getText());
-        
+
         checkProblem.setLoadDataFilesSamplesFirst(multipleDataSetPane.isLoadSamplesFirst());
-        
-        //set checkProblem's max output to either the current problem's value (which is in KB), 
+
+        //set checkProblem's max output to either the current problem's value (which is in KB),
         // or if that's zero, set it to the global value (which is in BYTES and must be converted to KB)
         long maxOutputKB = getLongValue(getMaxOutputTextField().getText());
         if (maxOutputKB == 0) {
@@ -1276,7 +1283,7 @@ public class EditProblemPane extends JPanePlugin {
         }
 
         checkProblem.setReadInputDataFromSTDIN(getStdinRadioButton().isSelected());
-        
+
         // set the flag indicating which output validator (if any) is being used in the Problem
         VALIDATOR_TYPE validatorType;
         validatorType = getValidatorTypeFromUI();
@@ -1285,7 +1292,23 @@ public class EditProblemPane extends JPanePlugin {
         // update settings in the Problem for each type of output validator:
         checkProblem.setPC2ValidatorSettings(getPC2ValidatorSettingsFromFields());
         checkProblem.setCLICSValidatorSettings(getCLICSValidatorSettingsFromFields());
+
+        // Temporary until we fix the GUI to allow setting these - for now, just remember originals
+        boolean isMultiPass = false;
+        int maxMultiPassCount = IContestLoader.DEFAULT_VALIDATION_PASSES;
+        CustomValidatorSettings cov = checkProblem.getCustomOutputValidatorSettings();
+        if(cov != null) {
+            isMultiPass = cov.isUseMultipassValidatorInterface();
+            maxMultiPassCount = cov.getMaxMultipassValidationPasses();
+        }
         checkProblem.setCustomOutputValidatorSettings(getCustomValidatorSettingsFromFields());
+        cov = checkProblem.getCustomOutputValidatorSettings();
+        if(cov != null) {
+            if(isMultiPass) {
+                cov.setUseMultipassValidatorInterface();
+            }
+            cov.setMaxMultipassValidationPasses(maxMultiPassCount);
+        }
 
         // if Custom Output Validator is selected, make sure we have a SerializedFile for the Validator
         // (the PC2 and CLICS Validators use internal PC2 classes and don't need a separate SerializedFile)
@@ -1332,7 +1355,7 @@ public class EditProblemPane extends JPanePlugin {
                 newProblemDataFiles.setOutputValidatorFile(outputValidatorSF);
             }
         }
-        
+
         // update misc settings from GUI
         checkProblem.setShowValidationToJudges(getShowValidatorToJudgesCheckBox().isSelected());
         checkProblem.setHideOutputWindow(!getDoShowOutputWindowCheckBox().isSelected());
@@ -1342,7 +1365,7 @@ public class EditProblemPane extends JPanePlugin {
 
         //update currently-selected Input Validator Type
         checkProblem.setCurrentInputValidatorType(getInputValidatorPane().getCurrentInputValidatorType());
-        
+
         //update Custom Input Validator serialized file
         //Note: the serialized file is not displayed in the GUI, but it is a field in the InputValidatorPane
         // (or more correctly, in the DefineCustomInputValidatorPane within the InputValidatorPane)
@@ -1361,11 +1384,11 @@ public class EditProblemPane extends JPanePlugin {
             // mark the problem as not having a Custom input validator
             checkProblem.setProblemHasCustomInputValidator(false);
         }
-                        
+
         //update Custom Input Validator Command
         String inputValidatorCommand = getInputValidatorPane().getCustomInputValidatorCommand();
         checkProblem.setCustomInputValidatorCommandLine(inputValidatorCommand);
-        
+
         //update Custom Input Validator has been run status
         checkProblem.setCustomInputValidatorHasBeenRun(getInputValidatorPane().isCustomInputValidatorHasBeenRun());
 
@@ -1382,28 +1405,28 @@ public class EditProblemPane extends JPanePlugin {
 //              runResults[i].setProblem(newProblem);
                 checkProblem.addCustomInputValidationResult(currentCustomResults[i]);
             }
-        } 
+        }
 
         //Update Viva Input Validator settings in checkProblem from GUI:
-        
+
 
         //This statement is commented out because there is no longer a separate "problemHasVivaInputValidatorPattern" flag in the Problem class;
         // having a Viva pattern (or not) is determined by the value in the Pattern field in the (VivaInputValidatorSettings for the) Problem.
-        // This was done to avoid the possibility of an "invalid state" where a user sets "problemHasInputValidator" to (say) false after having 
+        // This was done to avoid the possibility of an "invalid state" where a user sets "problemHasInputValidator" to (say) false after having
         // set a non-zero-length pattern in the Problem.
 //        //update Has Viva Pattern flag
 //        checkProblem.setProblemHasVivaInputValidatorPattern(getInputValidatorPane().isProblemHasVivaInputValidatorPattern());
-        
+
         //update Viva Input Validator pattern
         String [] pattern = getInputValidatorPane().getVivaPatternText().split("\\r?\\n");
         checkProblem.setVivaInputValidatorPattern(pattern);
-        
+
         //update Viva has been run flag
         checkProblem.setVivaInputValidatorHasBeenRun(getInputValidatorPane().isVivaInputValidatorHasBeenRun());
-        
+
         //update Viva run result status
         checkProblem.setVivaInputValidationStatus(getInputValidatorPane().getVivaInputValidationStatus());
-        
+
         //update Viva Input Validation results
         checkProblem.clearVivaInputValidationResults();
         InputValidationResult [] currentVivaResults = getInputValidatorPane().getVivaInputValidatorResults();
@@ -1414,9 +1437,9 @@ public class EditProblemPane extends JPanePlugin {
 //              runResults[i].setProblem(newProblem);
                 checkProblem.addVivaInputValidationResult(currentVivaResults[i]);
             }
-        } 
+        }
 
-        
+
         // update Judging Type settings from GUI
         // TODO: should be using accessors instead of hard references for these buttons and checkboxes...
         checkProblem.setComputerJudged(computerJudgingRadioButton.isSelected());
@@ -1460,21 +1483,21 @@ public class EditProblemPane extends JPanePlugin {
         //update balloon settings from GUI
         checkProblem.setColorName(balloonColorTextField.getText());
         checkProblem.setColorRGB(rgbTextField.getText());
-        
+
         //update group settings from GUI, if any
         List<Group> groups = getProblemGroupPane().getGroups();
-        
+
         checkProblem.clearGroups();
         if (groups.size() > 0){
             for (Group group : groups) {
                 checkProblem.addGroup(group);
             }
         }
-        
+
         if (debug22EditProblem) {
             Utilities.dump(newProblemDataFiles, "debug after populateProblemTestSetFilenames");
         }
-        
+
         //update problem sandbox settings from GUI
         if (getProblemSandboxPane().getUseNoSandboxRadioButton().isSelected()) {
             checkProblem.setSandboxType(SandboxType.NONE);
@@ -1486,13 +1509,13 @@ public class EditProblemPane extends JPanePlugin {
             } catch (NumberFormatException e) {
                 log.warning("Invalid memory limit value :" + e);
                 throw new InvalidFieldValue("Invalid memory limit value");
-            } 
+            }
         } else if (getProblemSandboxPane().getUseCustomSandboxRadioButton().isSelected()) {
             log.warning("Use Custom Sandbox radio button is selected -- function not supported in this version of PC^2!");
             throw new IllegalStateException("Use Custom Sandbox radio button is selected -- function not supported in this version of PC^2!");
         }
-        
-        
+
+
         return checkProblem;
 
     }
@@ -1527,7 +1550,7 @@ public class EditProblemPane extends JPanePlugin {
 
     private CUSTOM_VALIDATOR_INTERFACE_TYPE getCustomValidatorInterfaceTypeFromUI() {
         CUSTOM_VALIDATOR_INTERFACE_TYPE cvt = CUSTOM_VALIDATOR_INTERFACE_TYPE.CV_NONE;
-        
+
         if(getUsePC2ValStdRadioButton().isSelected()) {
             cvt = CUSTOM_VALIDATOR_INTERFACE_TYPE.CV_PC2;
         } else if(getUseClicsValStdRadioButton().isSelected()) {
@@ -1537,7 +1560,7 @@ public class EditProblemPane extends JPanePlugin {
         }
         return(cvt);
     }
-    
+
     /**
      * Makes a copy of the current Custom Validator Command line so that it can be restored if the user switches back and forth between "PC2 Validator Interface" mode and "CLICS Validator Interface"
      * mode.
@@ -1564,7 +1587,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Populate the test data set file lists in Problem.
-     * 
+     *
      * @param inProblem
      * @param dataFiles
      */
@@ -1594,7 +1617,7 @@ public class EditProblemPane extends JPanePlugin {
 
         padListIfNeeded(list, filelist, dataFileList);
 
-        return (String[]) list.toArray(new String[list.size()]);
+        return list.toArray(new String[list.size()]);
     }
 
     private String[] getTestDataList(ProblemDataFiles dataFiles) {
@@ -1609,12 +1632,12 @@ public class EditProblemPane extends JPanePlugin {
 
         padListIfNeeded(list, filelist, dataFileList);
 
-        return (String[]) list.toArray(new String[list.size()]);
+        return list.toArray(new String[list.size()]);
     }
 
     /**
      * pad list with nulls if needed.
-     * 
+     *
      * @param list
      * @param filelist
      * @param dataFileList
@@ -1631,7 +1654,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes updateButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getUpdateButton() {
@@ -1641,6 +1664,7 @@ public class EditProblemPane extends JPanePlugin {
             updateButton.setEnabled(false);
             updateButton.setMnemonic(java.awt.event.KeyEvent.VK_U);
             updateButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     updateProblem();
                 }
@@ -1650,14 +1674,14 @@ public class EditProblemPane extends JPanePlugin {
     }
 
     /**
-     * Updates an existing contest Problem with the values specified by the current GUI fields. 
+     * Updates an existing contest Problem with the values specified by the current GUI fields.
      * This method is invoked by pushing the "Update" button on the EditProblemPane GUI after having entered
      * into the GUI the new (updated) values for the problem being edited.
-     * 
-     * The method also gets invoked by making GUI changes to an existing problem definition, 
+     *
+     * The method also gets invoked by making GUI changes to an existing problem definition,
      * then pressing "Cancel" (which displays a message "Problem Modified - Save Changes?") and responding "Yes"
      * to the message.
-     * 
+     *
      * @return true if all GUI values are valid and problem is updated successfully; false otherwise
      */
 
@@ -1674,16 +1698,16 @@ public class EditProblemPane extends JPanePlugin {
         if (showMissingInputValidatorWarningOnUpdateProblem  && getProblemRequiresDataCheckBox().isSelected()
                 && (getInputValidatorPane().getUseNoInputValidatorRadioButton().isSelected()  //the problem explicitly says "no IV"
                     || (getInputValidatorPane().getCustomInputValidatorFile() == null
-                         && (getInputValidatorPane().getVivaPatternTextArea().getText()==null 
+                         && (getInputValidatorPane().getVivaPatternTextArea().getText()==null
                              || getInputValidatorPane().getVivaPatternTextArea().getText().equals("") )
                         )
                    )
             ) {
 
             // no input validator defined; issue a warning
-            String msg = "You are attempting to update a Problem to a state where it requires Input Data files but has no Input Data Validator." 
+            String msg = "You are attempting to update a Problem to a state where it requires Input Data files but has no Input Data Validator."
                     + "\n\nThis is usually not good practice because it provides no way to insure that the"
-                    + "\nJudge's data files meet the Problem Specification." 
+                    + "\nJudge's data files meet the Problem Specification."
                     + "\n\nAre you sure you want to do this?" + "\n\n";
 
             JCheckBox checkbox = new JCheckBox("Do not show this message again.");
@@ -1700,12 +1724,12 @@ public class EditProblemPane extends JPanePlugin {
         }
 
         // check for the condition "missing Custom Input Validator Program name even though there is a Custom Input Validator Command defined"
-        if (showMissingInputValidatorProgramNameOnUpdateProblem 
+        if (showMissingInputValidatorProgramNameOnUpdateProblem
                 && (getInputValidatorPane().getCustomInputValidatorProgramName()==null || getInputValidatorPane().getCustomInputValidatorProgramName().equals(""))
                 && (getInputValidatorPane().getCustomInputValidatorCommand()!=null && !getInputValidatorPane().getCustomInputValidatorCommand().equals(""))) {
 
             // no input validator program defined; issue a warning
-            String message = "You are attempting to update a Problem to a state where it has an Input Data Validator command but no Input Validator Program name." 
+            String message = "You are attempting to update a Problem to a state where it has an Input Data Validator command but no Input Validator Program name."
                         + "\n\nAre you sure this is what you intended to do?"
                         + "\n\n";
 
@@ -1832,9 +1856,9 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Populate new data sets.
-     * 
+     *
      * @param problem2
-     * 
+     *
      * @param problem2
      * @return
      */
@@ -1859,7 +1883,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Validate that all problem fields in the GUI are ok.
-     * 
+     *
      * @return true if all GUI values are valid; false otherwise
      */
     private boolean validateProblemFields() {
@@ -1869,7 +1893,7 @@ public class EditProblemPane extends JPanePlugin {
             showMessage("Enter a problem name (\"General\" tab)");
             return false;
         }
-        
+
         // verify that the max output value is a non-negative number
         try {
             long maxOutput = Long.parseLong(getMaxOutputTextField().getText().trim());
@@ -1881,7 +1905,7 @@ public class EditProblemPane extends JPanePlugin {
             showMessage("Maximum output value must be a number");
             return false;
         }
-        
+
         // verify that the time limit is a positive number (code added as "continuous improvement")
         try {
             int timeLimit = Integer.parseInt(getTimeOutTextField().getText().trim());
@@ -1893,9 +1917,9 @@ public class EditProblemPane extends JPanePlugin {
             showMessage("Time limit must be a number");
             return false;
         }
-        
-        
-        // verify that the memory limit is a non-negative number 
+
+
+        // verify that the memory limit is a non-negative number
         try {
             int memLimit = Integer.parseInt(getProblemSandboxPane().getPC2SandboxOptionMemLimitTextbox().getText().trim());
             if (memLimit < 0) {
@@ -2044,11 +2068,11 @@ public class EditProblemPane extends JPanePlugin {
 
         //verify that if the Viva Input Validator has been selected then there is a valid Viva pattern provided
         if (getInputValidatorPane().getUseVivaInputValidatorRadioButton().isSelected()) {
-            
+
             String vivaPattern = getInputValidatorPane().getVivaPatternTextArea().getText();
             //check for an empty pattern
             if (vivaPattern==null || vivaPattern.trim().equals("")) {
-                showMessage ("The VIVA Input Validator has been selected; you must specify a VIVA pattern."); 
+                showMessage ("The VIVA Input Validator has been selected; you must specify a VIVA pattern.");
                 return false;
             } else {
                 //pattern is not empty; check if invalid
@@ -2056,26 +2080,26 @@ public class EditProblemPane extends JPanePlugin {
                 VivaPatternTestResult vivaPatternTestResult = vivaAdapter.checkPattern(vivaPattern);
                 if (!vivaPatternTestResult.isValidPattern()) {
                     String vivaMsg = vivaPatternTestResult.getVivaResponseMessage();
-                    String errMsg = "The VIVA Input Validator has been selected but VIVA reports that the specified pattern is invalid: " 
-                    + "\n\n" + vivaMsg ; 
+                    String errMsg = "The VIVA Input Validator has been selected but VIVA reports that the specified pattern is invalid: "
+                    + "\n\n" + vivaMsg ;
                     showMessage(errMsg);
                     return false;
                 }
             }
         }
-        
+
         //verify that if the Custom Input Validator button has been selected then there is a Custom Input Validator provided
         if (getInputValidatorPane().getUseCustomInputValidatorRadioButton().isSelected()) {
-            
+
             String customIVProgramName = getInputValidatorPane().getCustomInputValidatorProgramName();
             if (customIVProgramName==null || customIVProgramName.equals("")) {
-                showMessage ("Custom Input Validator has been selected; you must choose a Custom Input Validator program."); 
+                showMessage ("Custom Input Validator has been selected; you must choose a Custom Input Validator program.");
                 return false;
             }
         }
-        
+
        // verify that if a Custom Input Validator program has been specified, there is a command specified to invoke it.
-        // (Note that the reverse is NOT required; it would be legal to specify an Input Validator command with no 
+        // (Note that the reverse is NOT required; it would be legal to specify an Input Validator command with no
         // explicit program name -- for example, the command could contain the name of the program within the command)
         if (getInputValidatorPane().getCustomInputValidatorFile() != null) {
 
@@ -2093,7 +2117,7 @@ public class EditProblemPane extends JPanePlugin {
      * Checks to ensure the fileName exists, is a file, and is readable.
      * <P>
      * If error found will show Message to user.
-     * 
+     *
      * @param fileName
      *            the file to check
      * @return true if the is readable
@@ -2123,7 +2147,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes cancelButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getCancelButton() {
@@ -2132,6 +2156,7 @@ public class EditProblemPane extends JPanePlugin {
             cancelButton.setText("Cancel");
             cancelButton.setMnemonic(java.awt.event.KeyEvent.VK_C);
             cancelButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     handleCancelButton();
                 }
@@ -2186,13 +2211,14 @@ public class EditProblemPane extends JPanePlugin {
         problem = inProblem;
         this.newProblemDataFiles = null;
         originalProblemDataFiles = problemDataFiles;
-        
+
         if (debug22EditProblem) {
             fileNameOne = createProblemReport(inProblem, problemDataFiles, "stuf1");
             Utilities.dump(originalProblemDataFiles, "debug   ORIGINAL  setProblem");
         }
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
 
                 try {
@@ -2212,19 +2238,19 @@ public class EditProblemPane extends JPanePlugin {
                 } catch (CloneNotSupportedException e) {
                     e.printStackTrace();
                 }
-                
+
                 // this sets the tableModel files list, which is what the getProblemDataFiles uses
                 getMultipleDataSetPane().populateUI();
 
                 populateGUI(inProblem);
-                
+
                 try {
                     getProblemGroupPane().setProblem(inProblem);
                 } catch (Exception e) {
                     e.printStackTrace();
                     logWarning("Trouble populating problemGroupPane", e);
                 }
-                
+
                 // do not automatically set this to no update, the files may have changed on disk
                 if (inProblem == null) {
                     // new problem
@@ -2262,9 +2288,9 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Set/populate (or remove) General tab judge's files.
-     * 
+     *
      * If no first test set then clears fields.
-     * 
+     *
      */
     public void setJudgingTestSetOne(ProblemDataFiles datafiles) {
 
@@ -2330,7 +2356,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Set new Problem to be edited.
-     * 
+     *
      * @param problem
      */
     public void setProblem(final Problem problem) {
@@ -2338,12 +2364,13 @@ public class EditProblemPane extends JPanePlugin {
         this.problem = problem;
         this.newProblemDataFiles = null;
         this.originalProblemDataFiles = null;
-        
+
         if (debug22EditProblem) {
             fileNameOne = createProblemReport(problem, originalProblemDataFiles, "stuf1");
         }
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 getMultipleDataSetPane().clearDataFiles();
 
@@ -2356,7 +2383,7 @@ public class EditProblemPane extends JPanePlugin {
                     getMultipleDataSetPane().getInputDataStoragePanel().setEnabled(true);
                     getMultipleDataSetPane().getRdbtnCopyDataFiles().setEnabled(true);
                     getMultipleDataSetPane().getRdBtnKeepDataFilesExternal().setEnabled(true);
-                    
+
                 } else {
                     enableUpdateButton();
                 }
@@ -2397,7 +2424,7 @@ public class EditProblemPane extends JPanePlugin {
         enableOutputValidatorTabComponents();
 
         enableInputValidatorTabComponents();
-        
+
         enableSandboxTabComponents();
 
         // enableGeneralTabComponents:
@@ -2414,7 +2441,7 @@ public class EditProblemPane extends JPanePlugin {
             getMultipleDataSetPane().setProblemDataFiles(problem, originalProblemDataFiles);
         } catch (Exception e) {
             String message = "Error loading/editing problem data files: " + e.getMessage();
-            
+
 //            showMessage(message + " check logs.");
             showExceptionMessage(this, message, e);
             getLog().log(Log.WARNING, message, e);
@@ -2458,9 +2485,9 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Set Form data -- that is, populates the GUI from the specified Problem and ProblemDataFiles.
-     * 
+     *
      * Populates the form, no error checking is performed.
-     * 
+     *
      * @param inProblem
      *            - the Problem which will be used to populate the GUI form
      * @param problemDataFiles
@@ -2470,7 +2497,7 @@ public class EditProblemPane extends JPanePlugin {
 
         problem = inProblem;
         // System.out.println (inProblem.toStringDetails());
-        
+
         originalProblemDataFiles = problemDataFiles;
 
         // General tab fields:
@@ -2487,9 +2514,9 @@ public class EditProblemPane extends JPanePlugin {
 
         // Data Files tab:
         getMultipleDataSetPane().setLoadDirectory(inProblem.getExternalDataFileLocation());
-        
+
         getProblemGroupPane().setProblem(inProblem);
-        
+
         // Sandbox tab:
         initializeSandboxTabFields(inProblem);
 
@@ -2497,12 +2524,12 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the "General" tab GUI fields from the data in the specified Problem and ProblemDataFiles.
-     * 
+     *
      * @param inProblem
      *            - the Problem to be used to initialize the GUI fields
      * @param inProblemDataFiles
      *            - the ProblemDataFiles to be used to initialize the GUI fields
-     * 
+     *
      */
     private void initializeGeneralTabFields(Problem inProblem, ProblemDataFiles inProblemDataFiles) {
 
@@ -2514,7 +2541,7 @@ public class EditProblemPane extends JPanePlugin {
         //initialize problem limit fields
         getTimeOutTextField().setText(inProblem.getTimeOutInSeconds() + "");
         getMaxOutputTextField().setText(inProblem.getMaxOutputSizeKB() + "");
-        
+
         // input data fields:
         problemRequiresDataCheckBox.setSelected(inProblem.getDataFileName() != null);
         if (inProblem.isReadInputDataFromSTDIN()) {
@@ -2592,12 +2619,12 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Initializes the Validator tab (GUI pane) from the specified Problem and ProblemDataFiles.
-     * 
+     *
      * @param inProblem
      *            the {@link Problem} to be used to initialize the GUI
      * @param inProblemDataFiles
      *            the {@link ProblemDataFiles} to be used to initialize the GUI
-     * 
+     *
      * @throws {@link
      *             RuntimeException} if either the received Problem or ProblemDataFiles are null
      * @throws {@link
@@ -2716,7 +2743,7 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * This method sets the fields on the Input Validator tab (whose contents are defined by class {@link InputValidatorPane})
      * from the specified Problem information.
-     * 
+     *
      * @param prob
      *            - the problem used to set the InputValidatorPane data
      * @param probDataFile
@@ -2732,12 +2759,12 @@ public class EditProblemPane extends JPanePlugin {
 
         //initialize the current Input Validator type and radio buttons to correspond to the problem.
         INPUT_VALIDATOR_TYPE currentInputValidatorType = prob.getCurrentInputValidatorType();
-        
+
         if (currentInputValidatorType!=null) {
             setCurrentInputValidatorType(currentInputValidatorType);
 
             //enable (select) the Input Validator radio button corresponding to the current Input Validator type for the problem
-            //Note that since the radio buttons are in a ButtonGroup, setting any one of them automatically clears the others...           
+            //Note that since the radio buttons are in a ButtonGroup, setting any one of them automatically clears the others...
             switch (currentInputValidatorType) {
                 case NONE:
                     getInputValidatorPane().getUseNoInputValidatorRadioButton().setSelected(true);
@@ -2753,27 +2780,27 @@ public class EditProblemPane extends JPanePlugin {
                             + "\nPlease report this issue to the PC2 Development Team (pc2@ecs.csus.edu)." + "\nSee log for additional information.");
                     getController().getLog().severe("currentInputValidatorType in problem is not an element of INPUT_VALIDATOR_TYPE enum.");
             }
-            
-            
+
+
         } else {
             //we should NEVER have a problem that has a null InputValidatorType - if no I.V. is defined, type should be "NONE"
             String errMsg = "Internal error: currentInputValidatorType in problem is null."
-                    + "\nPlease report this issue to the PC2 Development Team (pc2@ecs.csus.edu)." 
+                    + "\nPlease report this issue to the PC2 Development Team (pc2@ecs.csus.edu)."
                     + "\nSee log for additional information." ;
             System.err.println(errMsg);
             JOptionPane.showMessageDialog(null, errMsg, "Internal Error", JOptionPane.ERROR_MESSAGE);
             getController().getLog().severe("currentInputValidatorType in problem is null.");
         }
-        
-        
+
+
         //initialize the VIVA Input Validator GUI settings from the problem:
-        
+
         //reset the Viva pattern text area
         getInputValidatorPane().getVivaPatternTextArea().setText(null);
-        
+
         //get the Viva pattern (if any) from the problem
         String [] lines = prob.getVivaInputValidatorPattern();
-        
+
         //copy the Viva pattern to the text area
         if (lines != null) {
             // add each line of new text to the text area
@@ -2781,10 +2808,10 @@ public class EditProblemPane extends JPanePlugin {
                 getInputValidatorPane().getVivaPatternTextArea().append(line + System.lineSeparator());
             }
         }
-        
+
         //initialize the Viva-has-been-run flag
         getInputValidatorPane().setVivaInputValidatorHasBeenRun(prob.isVivaInputValidatorHasBeenRun());
-        
+
         //initialize the Viva validation status flag
         setVivaInputValidationStatus(prob.getVivaInputValidationStatus()); // note: validation status variable is not displayed on the GUI
 
@@ -2793,16 +2820,16 @@ public class EditProblemPane extends JPanePlugin {
 
 
         //initialize the Custom Input Validator GUI settings from the problem:
-        
+
         //initialize the CustomInputValidator-has-been-run flag
         getInputValidatorPane().setCustomInputValidatorHasBeenRun(prob.isCustomInputValidatorHasBeenRun());
- 
+
         //initialize the Custom validation status flag
         setCustomInputValidationStatus(prob.getCustomInputValidationStatus()); // note: validation status variable is not displayed on the GUI
 
         //initialize the Custom Input Validator results
         getInputValidatorPane().setCustomInputValidatorResults(prob.getCustomInputValidatorResults());
-        
+
         //clear Custom IV accumulating results (these are updated when the Custom IV is actually run)
         getInputValidatorPane().resetCustomInputValidatorAccumulatingResults();
 
@@ -2817,7 +2844,7 @@ public class EditProblemPane extends JPanePlugin {
         //update the custom input validator serialized file and set the Program Name tooltip to its path
         SerializedFile customValidatorFile = prob.getCustomInputValidatorSerializedFile();
         getInputValidatorPane().setCustomInputValidatorFile(customValidatorFile);
-        
+
         //the following is done by the call to method setCustomInputValidatorFile() (above); it does not need to be repeated
 //        if (customValidatorFile == null) {
 //            // set the tooltip as null (otherwise we get a little sliver of a empty-string tooltip)
@@ -2861,7 +2888,7 @@ public class EditProblemPane extends JPanePlugin {
             default:
                 //we should NEVER have a problem that has an undefined inputValidatorType - if no I.V. is defined, type should be "NONE"
                 String errMsg = "Internal error: currentInputValidatorType in problem is not an element of INPUT_VALIDATOR_TYPE enum."
-                        + "\nPlease report this issue to the PC2 Development Team (pc2@ecs.csus.edu)." 
+                        + "\nPlease report this issue to the PC2 Development Team (pc2@ecs.csus.edu)."
                         + "\nSee log for additional information." ;
                 System.err.println(errMsg);
                 JOptionPane.showMessageDialog(null, errMsg, "Internal Error", JOptionPane.ERROR_MESSAGE);
@@ -2871,33 +2898,33 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Initializes the external EditProblemSandboxPane object with the values from the specified problem.
-     * 
+     *
      * @param inProblem the {@link Problem} used to initialize the sandbox pane.
      */
     private void initializeSandboxTabFields(Problem inProblem) {
-        
+
         EditProblemSandboxPane sandboxPane = getProblemSandboxPane();
-        
+
         sandboxPane.initializeFields(inProblem);
-        
+
     }
 
     /**
-     * This method updates the Input Validation Results JTable (contained in the ResultsFrame, referenced via the 
+     * This method updates the Input Validation Results JTable (contained in the ResultsFrame, referenced via the
      * {@link InputValidatorPane}) from the specified Iterable InputValidationResults.
-     * 
+     *
      * @param results an Iterable containing the InputValidationResults to be displayed in the ResultsFrame JTable.
      */
     private void updateIVResultsTable(Iterable<InputValidationResult> results) {
-        
+
         //null indicates there are no results because there is no Input Validator associated with the problem...
         if (results==null) {
             updateResultsTableModel(null);
             return;
         }
-        
+
         int numResults = 0;
-        
+
         if (results instanceof Collection) {
             numResults = ((Collection<?>) results).size();
         } else {
@@ -2906,7 +2933,7 @@ public class EditProblemPane extends JPanePlugin {
             updateResultsTableModel(null);
             return;
         }
-        
+
         // create an array with one element for each result
         InputValidationResult[] probInputValidationResults = new InputValidationResult[numResults];
 
@@ -2941,20 +2968,20 @@ public class EditProblemPane extends JPanePlugin {
             getInputValidatorPane().getShowOnlyFailedFilesCheckbox().setSelected(true);
         }
     }
-    
+
     /**
      * Updates the {@link InputValidatorPane} results table with the specified results, and fires TableDataChanged.
-     * 
+     *
      * @param results the Input Validation Results to be put into the results table.
      */
     private void updateResultsTableModel(InputValidationResult [] results) {
-        ((InputValidationResultsTableModel) getInputValidatorPane().getResultsTableModel()).setResults(results);
-        ((InputValidationResultsTableModel) getInputValidatorPane().getResultsTableModel()).fireTableDataChanged();
+        getInputValidatorPane().getResultsTableModel().setResults(results);
+        getInputValidatorPane().getResultsTableModel().fireTableDataChanged();
     }
 
     /**
      * Sets the Input Validation Status message on the ResultFrame referenced by the Input Validator pane.
-     * 
+     *
      * @param results
      *            an array containing the Input Validation Result values which determine what status message to display
      */
@@ -2964,7 +2991,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * update/enable Update button.
-     * 
+     *
      * @param fieldsChanged
      *            if false assumes changes must be undone aka Canceled.
      */
@@ -2984,7 +3011,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes mainTabbedPane
-     * 
+     *
      * @return javax.swing.JTabbedPane
      */
     private JTabbedPane getMainTabbedPane() {
@@ -3004,7 +3031,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Returns a singleton instance of the Edit Problem Sandbox pane, which is a JPanePlugin (and hence a JPanel).
-     * 
+     *
      * @return a singleton {@link EditProblemSandboxPane}.
      */
     private EditProblemSandboxPane getProblemSandboxPane() {
@@ -3031,7 +3058,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes generalPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getJudgingTypePanel() {
@@ -3047,23 +3074,23 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * This method initializes the generalPane which contains general problem description components
      * such as problem name, limits, input data and judging files, etc.
-     * 
+     *
      * @return a JPanel containing general problem description components.
      */
     private JPanel getGeneralPane() {
         if (generalPane == null) {
-            
+
             generalPane = new JPanel();
             generalPane.setLayout(null);    //TODO:  use a proper LayoutManager!
-            
+
             //add the problem identifier components -- name, shortname, letter
             generalPane.add(getProblemNameLabel(), null);
             generalPane.add(getProblemNameTextField(), null);
             generalPane.add(getShortNameLabel());
             generalPane.add(getShortNameTextField(), null);
             generalPane.add(getProblemLetterLabel(), null);
-            generalPane.add(getProblemLetterTextField(), null);      
-            
+            generalPane.add(getProblemLetterTextField(), null);
+
             //add the problem limit components
             generalPane.add(getTimeOutTextField(), null);
             generalPane.add(getProblemRequiresDataCheckBox(), null);
@@ -3074,13 +3101,13 @@ public class EditProblemPane extends JPanePlugin {
             generalPane.add(getShowCompareCheckBox(), null);
             generalPane.add(getDoShowOutputWindowCheckBox(), null);
             generalPane.add(getDeleteProblemCheckBox(), null);
-            
+
             //add "problem-specific output size limit" components
             generalPane.add(getLblMaxOutputSizeKB());
             generalPane.add(getMaxOutputTextField());
             generalPane.add(getLblWhatsThisMaxOutputSize());
-            
-           
+
+
             JLabel lblBalloonColor = new JLabel();
             lblBalloonColor.setText("Balloon Color");
             lblBalloonColor.setBounds(new Rectangle(23, 14, 179, 16));
@@ -3119,10 +3146,10 @@ public class EditProblemPane extends JPanePlugin {
         }
         return generalPane;
     }
-    
+
     /**
      * This method initializes the label for the Problem Name textfield.
-     * 
+     *
      * @return a JLabel containing the name string for the Problem Name textfield label.
      */
     private JLabel getProblemNameLabel() {
@@ -3136,7 +3163,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes problemNameTextField.
-     * 
+     *
      * @return a JTextField for holding the problem name.
      */
     protected JTextField getProblemNameTextField() {
@@ -3146,6 +3173,7 @@ public class EditProblemPane extends JPanePlugin {
             problemNameTextField.setSize(new Dimension(240, 20));
             problemNameTextField.setLocation(new Point(120, 12));
             problemNameTextField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -3156,7 +3184,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method returns the label for the Short Name textfield.
-     * 
+     *
      * @return a JLabel containing the string to be used to label the Short Name textfield.
      */
     private JLabel getShortNameLabel() {
@@ -3170,7 +3198,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the textfield used to display the problem Short name.
-     * 
+     *
      * @return a JTextField for holding the problem short name.
      */
     private JTextField getShortNameTextField() {
@@ -3179,6 +3207,7 @@ public class EditProblemPane extends JPanePlugin {
             shortNameTextfield.setPreferredSize(new Dimension(120, 20));
             shortNameTextfield.setBounds(465, 12, 97, 20);
             shortNameTextfield.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -3186,10 +3215,10 @@ public class EditProblemPane extends JPanePlugin {
         }
         return shortNameTextfield;
     }
-    
+
     /**
      * This method initializes the label for the Problem Letter textfield.
-     * 
+     *
      * @return a JLabel containing the name string for the Problem Letter textfield label.
      */
     private JLabel getProblemLetterLabel() {
@@ -3203,7 +3232,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the text field holding the problem letter.
-     * 
+     *
      * @return a JTextField used to hold the problem letter.
      */
     private JTextField getProblemLetterTextField() {
@@ -3221,7 +3250,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the label for the timeout limit textfield.
-     * 
+     *
      * @return a JLabel containing the name string for the timeout textfield.
      */
     private JLabel getTimeoutLabel() {
@@ -3235,7 +3264,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the timeOut textfield.
-     * 
+     *
      * @return javax.swing.JTextField holding the timeOut
      */
     private JTextField getTimeOutTextField() {
@@ -3245,6 +3274,7 @@ public class EditProblemPane extends JPanePlugin {
             timeOutSecondTextField.setPreferredSize(new java.awt.Dimension(120, 20));
             timeOutSecondTextField.setDocument(new IntegerDocument());
             timeOutSecondTextField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -3255,7 +3285,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the problemRequiresData checkbox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getProblemRequiresDataCheckBox() {
@@ -3264,6 +3294,7 @@ public class EditProblemPane extends JPanePlugin {
             problemRequiresDataCheckBox.setBounds(new java.awt.Rectangle(23, 76, 257, 26));
             problemRequiresDataCheckBox.setText("Problem Requires Input Data");
             problemRequiresDataCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableRequiresInputDataComponents(problemRequiresDataCheckBox.isSelected());
                     enableUpdateButton();
@@ -3288,7 +3319,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes DataProblemPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getDataProblemPane() {
@@ -3308,7 +3339,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the TeamReadsFrom Pane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getTeamReadsFromPane() {
@@ -3330,7 +3361,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes inputDataFilePane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getInputDataFilePane() {
@@ -3351,7 +3382,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes stdinRadioButton
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getStdinRadioButton() {
@@ -3359,6 +3390,7 @@ public class EditProblemPane extends JPanePlugin {
             stdinRadioButton = new JRadioButton();
             stdinRadioButton.setText("Stdin");
             stdinRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -3369,7 +3401,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes fileRadioButton
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getFileRadioButton() {
@@ -3377,6 +3409,7 @@ public class EditProblemPane extends JPanePlugin {
             fileRadioButton = new JRadioButton();
             fileRadioButton.setText("File");
             fileRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -3387,7 +3420,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes fileNamePane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getFileNamePane() {
@@ -3403,7 +3436,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes selectFileButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getSelectFileButton() {
@@ -3411,6 +3444,7 @@ public class EditProblemPane extends JPanePlugin {
             selectFileButton = new JButton();
             selectFileButton.setText("Browse");
             selectFileButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (selectFile(inputDataFileLabel, "Open Input Data File")) {
                         inputDataFileLabel.setToolTipText(inputDataFileLabel.getText());
@@ -3436,7 +3470,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the JudgesHaveAnswerFiles CheckBox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getJudgesHaveAnswerFilesCheckbox() {
@@ -3445,6 +3479,7 @@ public class EditProblemPane extends JPanePlugin {
             judgesHaveAnswerFiles.setBounds(new java.awt.Rectangle(23, 239, 302, 24));
             judgesHaveAnswerFiles.setText("Judges Have Provided Answer File");
             judgesHaveAnswerFiles.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableProvideAnswerFileComponents(judgesHaveAnswerFiles.isSelected());
                     enableUpdateButton();
@@ -3463,7 +3498,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes answerFilePane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getAnswerFilePane() {
@@ -3484,7 +3519,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes answerFilenamePane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getAnswerFilenamePane() {
@@ -3500,7 +3535,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes answerBrowseButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getAnswerBrowseButton() {
@@ -3508,6 +3543,7 @@ public class EditProblemPane extends JPanePlugin {
             answerBrowseButton = new JButton();
             answerBrowseButton.setText("Browse");
             answerBrowseButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (selectFile(answerFileNameLabel, "Open Judges Answer File")) {
                         answerFileNameLabel.setToolTipText(answerFileNameLabel.getText());
@@ -3533,6 +3569,7 @@ public class EditProblemPane extends JPanePlugin {
 
     public void showMessage(final String message) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 JOptionPane.showMessageDialog(null, message);
             }
@@ -3541,7 +3578,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * select file, if file picked updates label.
-     * 
+     *
      * @param label
      * @param dialogTitle
      *            title for file chooser
@@ -3579,7 +3616,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * select file, if file picked updates specified JTextField.
-     * 
+     *
      * @param textField
      *            -- a JTextField whose value will be updated if a file is chosen
      * @param dialogTitle
@@ -3619,7 +3656,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes teamReadsFrombuttonGroup
-     * 
+     *
      * @return javax.swing.ButtonGroup
      */
     private ButtonGroup getTeamReadsFrombuttonGroup() {
@@ -3642,7 +3679,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the Output Validator Pane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getOutputValidatorPane() {
@@ -3670,7 +3707,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the useNoValidator RadioButton.
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getUseNOValidatatorRadioButton() {
@@ -3678,6 +3715,7 @@ public class EditProblemPane extends JPanePlugin {
             useNOValidatatorRadioButton = new JRadioButton();
             useNOValidatatorRadioButton.setText("Do not use Validator");
             useNOValidatatorRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableOutputValidatorTabComponents();
                     enableUpdateButton();
@@ -3717,7 +3755,7 @@ public class EditProblemPane extends JPanePlugin {
             getShowValidatorToJudgesCheckBox().setEnabled(false);
         }
     }
-    
+
     private void enableSandboxTabComponents() {
         //get the sandbox pane (which is an external class)
         EditProblemSandboxPane sandboxPane = getProblemSandboxPane();
@@ -3733,7 +3771,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the CLICS Validator jRadioButton
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getUseCLICSValidatorRadioButton() {
@@ -3742,6 +3780,7 @@ public class EditProblemPane extends JPanePlugin {
             useCLICSValidatorRadioButton.setMargin(new Insets(2, 12, 2, 2));
             useCLICSValidatorRadioButton.setText("Use CLICS Validator");
             useCLICSValidatorRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableOutputValidatorTabComponents();
                     enableUpdateButton();
@@ -3875,7 +3914,7 @@ public class EditProblemPane extends JPanePlugin {
     private JRadioButton rdbtnUsePcStandard;
 
     private JRadioButton rdbtnUseClicsStandard;
-    
+
     private JRadioButton rdbtnUseInteractive;
 
     private final ButtonGroup validatorStandardButtonGroup = new ButtonGroup();
@@ -3883,7 +3922,7 @@ public class EditProblemPane extends JPanePlugin {
     private JLabel lblWhatsThisPC2ValStd;
 
     private JLabel lblWhatsThisCLICSValStd;
-    
+
     private JLabel lblWhatsThisInteractive;
 
     private InputValidatorPane inputValidatorPane;
@@ -3910,7 +3949,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the maximum output size textfield.
-     * 
+     *
      * @return javax.swing.JTextField holding the maximum allowed output size for this problem.
      */
     private JTextField getMaxOutputTextField() {
@@ -3920,6 +3959,7 @@ public class EditProblemPane extends JPanePlugin {
             maxOutputSizeTextfield.setPreferredSize(new java.awt.Dimension(120, 20));
             maxOutputSizeTextfield.setDocument(new IntegerDocument());
             maxOutputSizeTextfield.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -3948,7 +3988,7 @@ public class EditProblemPane extends JPanePlugin {
                 }
             });
             lblWhatsThisMaxOutputSize.setBorder(new EmptyBorder(0, 15, 0, 0));
-            
+
             //TODO: the General pane (on which this component is placed) should use a Layout Manager instead of using absolute coordinates.
             //  Until such a change is made, this component needs to have absolute coordinates for consistency with the rest of the pane.
             lblWhatsThisMaxOutputSize.setBounds(480, 42, 30, 25);
@@ -3989,7 +4029,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the Custom Validator jRadioButton
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getUseCustomValidatorRadioButton() {
@@ -3998,6 +4038,7 @@ public class EditProblemPane extends JPanePlugin {
             useCustomValidatorRadioButton.setMargin(new Insets(2, 12, 2, 2));
             useCustomValidatorRadioButton.setText("Use Custom (User-supplied) Validator");
             useCustomValidatorRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableOutputValidatorTabComponents();
                     enableUpdateButton();
@@ -4009,7 +4050,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes showValidatorToJudgesCheckBox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getShowValidatorToJudgesCheckBox() {
@@ -4019,6 +4060,7 @@ public class EditProblemPane extends JPanePlugin {
             showValidatorToJudgesCheckBox.setMargin(new Insets(2, 12, 2, 2));
             showValidatorToJudgesCheckBox.setText("Show Validator To Judges (SVTJ)");
             showValidatorToJudgesCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -4029,7 +4071,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the sub-panel containing the Default Validator options
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getClicsValidatorOptionsSubPanel() {
@@ -4093,7 +4135,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the Custom Validator panel (and its Options sub-panel)
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getCustomValidatorPanel() {
@@ -4111,7 +4153,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the isCaseSensitive checkbox for the old (deprecated) PC2 Validator.
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getCLICSValidatorCaseSensitiveCheckBox() {
@@ -4120,6 +4162,7 @@ public class EditProblemPane extends JPanePlugin {
             isCLICSCaseSensitiveCheckBox.setText("Case-sensitive");
             isCLICSCaseSensitiveCheckBox.setSelected(false);
             isCLICSCaseSensitiveCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -4130,7 +4173,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the isSpaceSensitive checkbox.
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getCLICSSpaceSensitiveCheckBox() {
@@ -4139,6 +4182,7 @@ public class EditProblemPane extends JPanePlugin {
             isCLICSSpaceSensitiveCheckBox.setText("Space-sensitive");
             isCLICSSpaceSensitiveCheckBox.setSelected(false);
             isCLICSSpaceSensitiveCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -4149,7 +4193,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the FloatRelativeTolerance checkbox.
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getFloatRelativeToleranceCheckBox() {
@@ -4158,6 +4202,7 @@ public class EditProblemPane extends JPanePlugin {
             floatRelativeToleranceCheckBox.setText("Float relative tolerance:");
             floatRelativeToleranceCheckBox.setSelected(false);
             floatRelativeToleranceCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     getFloatRelativeToleranceTextField().setEditable(floatRelativeToleranceCheckBox.isSelected());
                     enableUpdateButton();
@@ -4169,7 +4214,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the FloatRelativeTolerance Text Field.
-     * 
+     *
      * @return javax.swing.JTextField
      */
     private JTextField getFloatRelativeToleranceTextField() {
@@ -4180,6 +4225,7 @@ public class EditProblemPane extends JPanePlugin {
             floatRelativeToleranceTextField.setColumns(20);
             floatRelativeToleranceTextField.setEditable(false);
             floatRelativeToleranceTextField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -4190,7 +4236,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the FloatAbsoluteTolerance checkbox.
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getFloatAbsoluteToleranceCheckBox() {
@@ -4199,6 +4245,7 @@ public class EditProblemPane extends JPanePlugin {
             floatAbsoluteToleranceCheckBox.setText("Float absolute tolerance:");
             floatAbsoluteToleranceCheckBox.setSelected(false);
             floatAbsoluteToleranceCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     getFloatAbsoluteToleranceTextField().setEditable(floatAbsoluteToleranceCheckBox.isSelected());
                     enableUpdateButton();
@@ -4210,7 +4257,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the floatAbsoluteTolerance Text Field.
-     * 
+     *
      * @return javax.swing.JTextField
      */
     private JTextField getFloatAbsoluteToleranceTextField() {
@@ -4221,6 +4268,7 @@ public class EditProblemPane extends JPanePlugin {
             floatAbsoluteToleranceTextField.setColumns(20);
             floatAbsoluteToleranceTextField.setEditable(false);
             floatAbsoluteToleranceTextField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -4231,7 +4279,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Show diff between files using gvim.exe.
-     * 
+     *
      * @param fileOne
      * @param fileTwo
      */
@@ -4250,7 +4298,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes validatorProgramJButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getChooseCustomOutputValidatorProgramButton() {
@@ -4258,6 +4306,7 @@ public class EditProblemPane extends JPanePlugin {
             chooseValidatorProgramButton = new JButton();
             chooseValidatorProgramButton.setText("Choose...");
             chooseValidatorProgramButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (selectFile(getCustomValidatorExecutableProgramTextField(), "Select Validator Program")) {
                         getCustomValidatorExecutableProgramTextField().setToolTipText((getCustomValidatorExecutableProgramTextField().getText()));
@@ -4273,7 +4322,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes validatorCommandLineTextBox
-     * 
+     *
      * @return javax.swing.JTextField
      */
     private JTextField getCustomValidatorCommandLineTextField() {
@@ -4282,6 +4331,7 @@ public class EditProblemPane extends JPanePlugin {
             customValidatorCommandLineTextField.setEnabled(false);
             customValidatorCommandLineTextField.setMaximumSize(new Dimension(100, 20));
             customValidatorCommandLineTextField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     updateLocalCustomValidatorCommandLine();
                     enableUpdateButton();
@@ -4293,7 +4343,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes showCompareCheckBox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getShowCompareCheckBox() {
@@ -4302,6 +4352,7 @@ public class EditProblemPane extends JPanePlugin {
             showCompareCheckBox.setBounds(new Rectangle(23, 374, 207, 21));
             showCompareCheckBox.setText("Show Compare");
             showCompareCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -4312,7 +4363,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes jCheckBox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getDoShowOutputWindowCheckBox() {
@@ -4322,6 +4373,7 @@ public class EditProblemPane extends JPanePlugin {
             doShowOutputWindowCheckBox.setSelected(true);
             doShowOutputWindowCheckBox.setText("Show the output window");
             doShowOutputWindowCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                     getShowCompareCheckBox().setEnabled(getDoShowOutputWindowCheckBox().isSelected());
@@ -4333,7 +4385,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes validatorChoiceButtonGroup
-     * 
+     *
      * @return javax.swing.ButtonGroup
      */
     private ButtonGroup getValidatorChoiceButtonGroup() {
@@ -4349,12 +4401,12 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Checks whether a given {@link SerializedFile} needs to be freshened, and if so prompts the user before freshening.
-     * 
+     *
      * @param serializedFile
      *            the file to be checked to see if it is need of freshening
      * @param fileName
      *            the file name corresponding to the specified SerializedFile
-     * 
+     *
      * @return a SerializedFile which is the updated version of the specified SerializedFile if the specified file was out of date AND the user confirmed the refresh operation
      * @throws InvalidFieldValue
      *             if the specified file cannot be read or if the user cancels the operation
@@ -4397,7 +4449,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Has this file been updated on disk ?
-     * 
+     *
      * @param serializedFile
      *            existing saved file
      * @param fileName
@@ -4434,7 +4486,7 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * Checks a given {@link SerializedFile} to see if the file type matches the platform on which we are running. If the file type does not match, the user is prompted to confirm whether file should
      * be converted to the current platform format as it is read into PC2.
-     * 
+     *
      * @param newFile
      *            the SerializedFile to be checked
      * @return true if the file was converted, false if the file was null or was not converted
@@ -4521,7 +4573,7 @@ public class EditProblemPane extends JPanePlugin {
         getTimeOutTextField().setText(Integer.toString(Problem.DEFAULT_TIMEOUT_SECONDS));
         getShortNameTextfield().setText("");
         getMaxOutputTextField().setText("0");
-        
+
         //show the next letter (which would be used if the problem is eventually saved)
         int numberProblems = getContest().getProblems().length;
         String nextLetter = Utilities.getProblemLetter(numberProblems + 1);
@@ -4554,7 +4606,7 @@ public class EditProblemPane extends JPanePlugin {
 
         // Input Validator tab:
         initializeInputValidatorTabFields();
-        
+
         // Sandbox tab:
         initializeSandboxTabFields();
 
@@ -4574,13 +4626,13 @@ public class EditProblemPane extends JPanePlugin {
         getInputValidatorPane().getUseVivaInputValidatorRadioButton().setSelected(false);
         getInputValidatorPane().getUseCustomInputValidatorRadioButton().setSelected(false);
         getInputValidatorPane().setCurrentInputValidatorType(INPUT_VALIDATOR_TYPE.NONE);
-        
+
         //initialize all Viva settings to defaults
         getInputValidatorPane().setVivaInputValidatorHasBeenRun(false);
         getInputValidatorPane().setVivaInputValidatorResults(new InputValidationResult[0]);
         getInputValidatorPane().setVivaInputValidationStatus(InputValidationStatus.UNKNOWN);
         getInputValidatorPane().getVivaPatternTextArea().setText("");
-        
+
         //initialize all Custom IV settings to defaults
         getInputValidatorPane().setCustomInputValidatorHasBeenRun(false);
         getInputValidatorPane().setCustomInputValidatorResults(new InputValidationResult[0]);
@@ -4595,8 +4647,8 @@ public class EditProblemPane extends JPanePlugin {
         getInputValidatorPane().setInputValidationSummaryMessageText("<No Input Validation test run yet>");
         getInputValidatorPane().setInputValidationSummaryMessageColor(Color.BLACK);
         getInputValidatorPane().getShowOnlyFailedFilesCheckbox().setSelected(false);
-        ((InputValidationResultsTableModel) getInputValidatorPane().getResultsTableModel()).setResults(null);
-        ((InputValidationResultsTableModel) getInputValidatorPane().getResultsTableModel()).fireTableDataChanged();
+        getInputValidatorPane().getResultsTableModel().setResults(null);
+        getInputValidatorPane().getResultsTableModel().fireTableDataChanged();
     }
 
     private void initializeOutputValidatorTabFields() {
@@ -4633,13 +4685,13 @@ public class EditProblemPane extends JPanePlugin {
     }
 
     private void initializeSandboxTabFields() {
-        
+
         //get the sandbox pane (which is an external class)
         EditProblemSandboxPane sandboxPane = getProblemSandboxPane();
-        
+
         // default to "no sandbox"
         sandboxPane.getUseNoSandboxRadioButton().setSelected(true);
-        
+
         //clear and disable the PC2 sandbox options
         sandboxPane.getPC2SandboxOptionMemLimitTextbox().setText("");
         sandboxPane.setPanelEnabled(sandboxPane.getPC2SandboxOptionsSubPanel(), false);
@@ -4649,10 +4701,10 @@ public class EditProblemPane extends JPanePlugin {
         sandboxPane.getCustomSandboxExecutableProgramTextField().setText("");
         sandboxPane.setPanelEnabled(sandboxPane.getCustomSandboxOptionsSubPanel(), false);
     }
-    
+
     /**
      * This method initializes the useComputerJudging Radio Button
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getUseComputerJudgingRadioButton() {
@@ -4661,6 +4713,7 @@ public class EditProblemPane extends JPanePlugin {
             computerJudgingRadioButton.setText("Computer Judging");
             computerJudgingRadioButton.setBounds(new Rectangle(32, 14, 173, 21));
             computerJudgingRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     getManualReviewCheckBox().setEnabled(true);
                     getPrelimaryNotificationCheckBox().setEnabled(getManualReviewCheckBox().isSelected());
@@ -4675,7 +4728,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the manualJudging Radio Button
-     * 
+     *
      * @return javax.swing.JRadioButton
      */
     private JRadioButton getManualJudgingRadioButton() {
@@ -4684,6 +4737,7 @@ public class EditProblemPane extends JPanePlugin {
             manualJudgingRadioButton.setText("Manual Judging");
             manualJudgingRadioButton.setBounds(new Rectangle(32, 132, 257, 21));
             manualJudgingRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     getManualReviewCheckBox().setEnabled(false);
                     getPrelimaryNotificationCheckBox().setEnabled(false);
@@ -4697,7 +4751,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes the manualReview CheckBox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getManualReviewCheckBox() {
@@ -4707,6 +4761,7 @@ public class EditProblemPane extends JPanePlugin {
             manualReviewCheckBox.setBounds(new Rectangle(57, 47, 186, 21));
             manualReviewCheckBox.setEnabled(false);
             manualReviewCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     getPrelimaryNotificationCheckBox().setEnabled(getManualReviewCheckBox().isSelected());
                     getPrelimaryNotificationCheckBox().setEnabled(getManualReviewCheckBox().isSelected());
@@ -4720,7 +4775,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes prelimaryNotification
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getPrelimaryNotificationCheckBox() {
@@ -4730,6 +4785,7 @@ public class EditProblemPane extends JPanePlugin {
             prelimaryNotificationCheckBox.setBounds(new Rectangle(100, 80, 328, 21));
             prelimaryNotificationCheckBox.setEnabled(false);
             prelimaryNotificationCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -4741,7 +4797,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes deleteProblemCheckBox
-     * 
+     *
      * @return javax.swing.JCheckBox
      */
     private JCheckBox getDeleteProblemCheckBox() {
@@ -4750,6 +4806,7 @@ public class EditProblemPane extends JPanePlugin {
             deleteProblemCheckBox.setBounds(new Rectangle(285, 340, 182, 21));
             deleteProblemCheckBox.setText("Hide Problem");
             deleteProblemCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -4760,7 +4817,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes loadButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getLoadButton() {
@@ -4770,6 +4827,7 @@ public class EditProblemPane extends JPanePlugin {
             loadButton.setToolTipText("Load problem def from problem.yaml");
             loadButton.setMnemonic(KeyEvent.VK_L);
             loadButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     loadProblemInfoFile();
                 }
@@ -4780,9 +4838,9 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Load problem info.
-     * 
+     *
      * If selects problem.yaml then load yaml and files If selects directory will scan for .in and .ans files and load them
-     * 
+     *
      */
     protected void loadProblemInfoFile() {
         // TODO someday implement load problem info.
@@ -4838,7 +4896,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes exportButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getExportButton() {
@@ -4848,6 +4906,7 @@ public class EditProblemPane extends JPanePlugin {
             exportButton.setToolTipText("Export problem and files");
             exportButton.setMnemonic(KeyEvent.VK_X);
             exportButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     if (Utilities.isDebugMode()) {
                         saveAndCompare();
@@ -4942,8 +5001,8 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * get Letter.
-     * 
-     * 
+     *
+     *
      * @param directory
      * @return
      */
@@ -4972,7 +5031,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes reportButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getReportButton() {
@@ -4981,6 +5040,7 @@ public class EditProblemPane extends JPanePlugin {
             reportButton.setText("Report");
             reportButton.setMnemonic(KeyEvent.VK_R);
             reportButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     viewProblemReport();
                 }
@@ -5010,7 +5070,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * This method initializes judgeTypeInnerPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getJudgeTypeInnerPane() {
@@ -5028,7 +5088,7 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Compare the entries in two directories.
-     * 
+     *
      * @param directory
      *            the first directory to compare
      * @param nextDirectory
@@ -5063,9 +5123,9 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Returns all filenames (relative path) under input directory.
-     * 
+     *
      * The list does not contain the string directory. Only directories under the directory will be included.
-     * 
+     *
      * @param directory
      * @param relativeDirectory
      * @param level
@@ -5247,7 +5307,7 @@ public class EditProblemPane extends JPanePlugin {
             gbc_labelWhatsThisCLICSValStd.gridx = 2;
             gbc_labelWhatsThisCLICSValStd.gridy = 3;
             customValidatorOptionsSubPanel.add(getLabelWhatsThisCLICSValStd(), gbc_labelWhatsThisCLICSValStd);
-            
+
             // add the "This is a CLICS interactive problem" radio button to the subpanel
             GridBagConstraints gbc_rdbtnBoxInteractive = new GridBagConstraints();
             gbc_rdbtnBoxInteractive.anchor = GridBagConstraints.WEST;
@@ -5287,6 +5347,7 @@ public class EditProblemPane extends JPanePlugin {
             customValidatorProgramNameTextField.setEnabled(false);
             customValidatorProgramNameTextField.setColumns(25);
             customValidatorProgramNameTextField.addKeyListener(new java.awt.event.KeyAdapter() {
+                @Override
                 public void keyReleased(java.awt.event.KeyEvent e) {
                     enableUpdateButton();
                 }
@@ -5360,6 +5421,7 @@ public class EditProblemPane extends JPanePlugin {
             usePC2ValidatorRadioButton.setMaximumSize(new Dimension(21, 23));
             usePC2ValidatorRadioButton.setMargin(new Insets(2, 12, 2, 2));
             usePC2ValidatorRadioButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableOutputValidatorTabComponents();
                     enableUpdateButton();
@@ -5421,6 +5483,7 @@ public class EditProblemPane extends JPanePlugin {
             // pc2ValidatorOptionComboBox.setBounds(new java.awt.Rectangle(158, 24, 255, 26));
 
             pc2ValidatorOptionComboBox.addItemListener(new java.awt.event.ItemListener() {
+                @Override
                 public void itemStateChanged(java.awt.event.ItemEvent e) {
                     enableUpdateButton();
 
@@ -5444,6 +5507,7 @@ public class EditProblemPane extends JPanePlugin {
             pc2ValidatorIgnoreCaseCheckBox.setMaximumSize(new Dimension(80, 23));
             pc2ValidatorIgnoreCaseCheckBox.setPreferredSize(new Dimension(150, 23));
             pc2ValidatorIgnoreCaseCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     enableUpdateButton();
                 }
@@ -5455,16 +5519,16 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * Returns a {@link CustomValidatorSettings} object containing the Custom Validator settings currently displayed in the GUI. Displays an error message and throws {@link InvalidFieldValue} if the
      * Validator Interface buttons displayed in the GUI are inconsistent.
-     * 
+     *
      * @return a CustomValidatorSettings object populated from the GUI
-     * 
+     *
      * @throws {@link
      *             InvalidFieldValue} if it's not the case that exactly one of the GUI radio buttons identifying the Validator Interface mode is selected
      */
     private CustomValidatorSettings getCustomValidatorSettingsFromFields() {
 
         CUSTOM_VALIDATOR_INTERFACE_TYPE cvt = getCustomValidatorInterfaceTypeFromUI();
-        
+
         // make sure exactly one of the Interface mode buttons is selected
         if (cvt == CUSTOM_VALIDATOR_INTERFACE_TYPE.CV_NONE) {
             showMessage("Invalid settings for Validator Interface radio buttons");
@@ -5507,7 +5571,7 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * Returns a {@link PC2ValidatorSettings} object containing the values currently displayed in the GUI. Displays an error message and throws {@link InvalidFieldValue} if the values displayed in the
      * GUI are illegal (for example, if the PC2 Validator has been selected but no PC2 Validator Mode has been chosen.
-     * 
+     *
      * @return a PC2ValidatorSettings object populated from the GUI
      * @throws {@link
      *             InvalidFieldValue} if an invalid tolerance value is detected
@@ -5532,7 +5596,7 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * Returns a {@link ClicsValidatorSettings} object containing the values currently displayed in the GUI. Displays an error message and throws {@link InvalidFieldValue} if either the absolute or
      * relative tolerance are selected and the string in the corresponding text box is invalid.
-     * 
+     *
      * @return a ClicsValidatorSettings object populated from the GUI
      * @throws {@link
      *             InvalidFieldValue} if an invalid tolerance value is detected
@@ -5598,6 +5662,7 @@ public class EditProblemPane extends JPanePlugin {
             rdbtnUsePcStandard = new JRadioButton("Use PC^2 Standard Interface");
             rdbtnUsePcStandard.setSelected(false);
             rdbtnUsePcStandard.addActionListener(new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     // switching to Use PC2 Standard Interface for this Custom Validator;
                     // check to see if we are editing a problem which might already have a PC2 Interface Validator Command Line
@@ -5629,6 +5694,7 @@ public class EditProblemPane extends JPanePlugin {
             rdbtnUseClicsStandard = new JRadioButton("Use CLICS Standard Interface");
             rdbtnUseClicsStandard.setSelected(true);
             rdbtnUseClicsStandard.addActionListener(new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     // switching to Use Clics Standard Interface for this Custom Validator;
                     // check to see if we are editing a problem which might already have a Clics Interface Validator Command Line
@@ -5660,6 +5726,7 @@ public class EditProblemPane extends JPanePlugin {
             rdbtnUseInteractive = new JRadioButton("Use CLICS Interactive Problem Interface");
             rdbtnUseInteractive.setSelected(false);
             rdbtnUseInteractive.addActionListener(new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     // switching to Use Clics Interactive Interface for this Custom Validator;
                     // check to see if we are editing a problem which might already have a Clics Interface Validator Command Line
@@ -5782,14 +5849,14 @@ public class EditProblemPane extends JPanePlugin {
     private void setCurrentInputValidatorType(INPUT_VALIDATOR_TYPE ivType) {
         getInputValidatorPane().setCurrentInputValidatorType(ivType);
     }
-    
+
     public String getExecuteDirectoryName() {
         return "inputValidate" + getContest().getClientId().getSiteNumber() + getContest().getClientId().getName();
     }
 
     /**
      * Remove all files from specified directory, including subdirectories.
-     * 
+     *
      * @param dirName
      *            directory to be cleared.
      * @return true if directory was cleared.
@@ -5816,7 +5883,7 @@ public class EditProblemPane extends JPanePlugin {
      * Return string minus last extension. <br>
      * Finds last . (period) in input string, strips that period and all other characters after that last period. If no period is found in string, will return a copy of the original string. <br>
      * Unlike the Unix basename program, no extension is supplied.
-     * 
+     *
      * @param original
      *            the input string
      * @return a string with all text after last . removed
@@ -5838,9 +5905,9 @@ public class EditProblemPane extends JPanePlugin {
      * Displays the specified message in a modal YES_NO_CANCEL JOptionPane with a WARNING_MESSAGE icon and with the specified title, and with the specified JCheckBox displayed on the dialog. Since the
      * caller provides the checkbox, the caller can determine after the dialog returns whether or not the user checked the checkbox. This is useful for displaying things like message boxes with a "Do
      * not show this again" checkbox. Note that it is the CALLER's responsibility to implement logic to avoid displaying the message dialog in the future.
-     * 
+     *
      * The value returned by this method is exactly the value returned by the displayed JOptionPane, which is determined by the button the user uses to close the dialog (Yes, No, or Cancel).
-     * 
+     *
      * @param parentFrame
      *            a JFrame which is the parent associated with the displayed JOptionPane
      * @param msg
@@ -5849,7 +5916,7 @@ public class EditProblemPane extends JPanePlugin {
      *            a JCheckBox to be displayed on the dialog, with message text set by the caller
      * @param title
      *            the title to be displayed on the dialog
-     * 
+     *
      * @return either JOptionPane.YES, JOptionPane.NO, or JOptionPane.CANCEL
      */
     private int displayWarningDialogWithCheckbox(JFrame parentFrame, String msg, JCheckBox checkbox, String title) {
@@ -5864,9 +5931,9 @@ public class EditProblemPane extends JPanePlugin {
 
     /**
      * Replace all instances of beforeString with afterString.
-     * 
+     *
      * If before string is not found, then returns original string.
-     * 
+     *
      * @param origString
      *            string to be modified
      * @param beforeString
@@ -5917,7 +5984,7 @@ public class EditProblemPane extends JPanePlugin {
 //
 //    /**
 //     * Updates the Input Validation Status for the current problem to reflect the state of the specified result.
-//     * 
+//     *
 //     * If the received result is null the problem Input Validation Status is set to "ERROR".
 //     */
 //    private void updateProblemValidationStatus(Problem prob, InputValidationResult result) {
@@ -5949,12 +6016,12 @@ public class EditProblemPane extends JPanePlugin {
 //    /**
 //     * Returns a new InputValidationStatus for a problem based on combining the current problem Input Validation Status with the specified new status, assumed to be the result of having tested a new
 //     * input data file by running an Input Validator on the input data file.
-//     * 
+//     *
 //     * @param currentStatus
 //     *            the Input Validation Status currently assigned to the problem
 //     * @param newStatus
 //     *            a new Input Validation Result status to be merged with the current status
-//     * 
+//     *
 //     * @return the InputValidationStatus which should be assigned to the problem based on its current status and the received new Input Validator run status
 //     */
 //    private InputValidationStatus getNewStatus(InputValidationStatus currentStatus, InputValidationStatus newStatus) {
@@ -5993,26 +6060,26 @@ public class EditProblemPane extends JPanePlugin {
 //
 //        return retStatus;
 //   }
-    
+
     private void logWarning(String message, Exception e) {
         if (log != null){
             log.log(Log.WARNING, message, e);
-        } 
+        }
 
         System.err.println(message);
         if (e != null){
             e.printStackTrace();
-            
-            
+
+
         }
     }
-    
+
     //main() method for testing only
     public static void main (String [] args) {
 
         //build an EditProblemFrame containing an EditProblemPane containing an EditProblemSandboxPane
         EditProblemFrame frame = new EditProblemFrame();
-        
+
 //        //put a contest and controller in the frame (which also puts it in the panes)
 //        IInternalContest contest;
 //        IInternalController controller;
@@ -6032,7 +6099,7 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * Returns the name of the last directory from which a file was selected/loaded
      * by a component of this EditProblemPane.
-     * 
+     *
      * @return a String containing the last directory name
      */
     public String getLastDirectory() {
@@ -6042,20 +6109,20 @@ public class EditProblemPane extends JPanePlugin {
     /**
      * Saves the name of the last directory from which a file was selected/loaded
      * by a component of this EditProblemFrame.
-     * 
+     *
      * @param directory the name of the last directory from which a file was selected/loaded.
      */
     public void setLastDirectory(String directory) {
         lastDirectory = directory;
-        
+
     }
-    
+
     /**
      * This method accepts an {@link Iterable} set of {@link InputValidationResult}s and returns an array
      * containing those results.
-     * 
+     *
      * @param results an Iterable collection of InputValidationResults.
-     * 
+     *
      * @return an array containing the elements of the received Iterable.
      */
     private InputValidationResult[] convertIterableInputValidationResultToArray(Iterable<InputValidationResult> results) {
@@ -6065,9 +6132,9 @@ public class EditProblemPane extends JPanePlugin {
             temp.add(res);
         }
         //convert the Vector to an array
-        InputValidationResult [] array = temp.toArray(new InputValidationResult[temp.size()]); 
+        InputValidationResult [] array = temp.toArray(new InputValidationResult[temp.size()]);
 
         return array;
     }
-    
+
 }

--- a/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
@@ -39,7 +39,7 @@ import edu.csus.ecs.pc2.ui.cellRenderer.MCLBInputValidationStatusCellRenderer;
 
 /**
  * View Problems.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -48,7 +48,7 @@ import edu.csus.ecs.pc2.ui.cellRenderer.MCLBInputValidationStatusCellRenderer;
 public class ProblemsPane extends JPanePlugin {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7483784815760107250L;
 
@@ -84,7 +84,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes
-     * 
+     *
      */
     public ProblemsPane() {
         super();
@@ -93,7 +93,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes this
-     * 
+     *
      */
     private void initialize() {
         this.setLayout(new BorderLayout());
@@ -113,7 +113,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes problemButtonPane
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getProblemButtonPane() {
@@ -135,7 +135,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes problemListBox
-     * 
+     *
      * @return edu.csus.ecs.pc2.core.log.MCLB
      */
     private MCLB getProblemListBox() {
@@ -185,6 +185,7 @@ public class ProblemsPane extends JPanePlugin {
 
     public void updateProblemRow(final Problem problem) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 Object[] objects = buildProblemRow(problem);
                 int rowNumber = problemListBox.getIndexByKey(problem.getElementId());
@@ -201,6 +202,7 @@ public class ProblemsPane extends JPanePlugin {
 
     public void updateRunInputValidatorsProblemRow(final Problem problem) {
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
 
                 // build a row of InputValidatorResults for the specified problem
@@ -254,6 +256,8 @@ public class ProblemsPane extends JPanePlugin {
         String inputMethod = "";
         if (problem.isInteractive()) {
             inputMethod = "Interactive";
+        } else if (problem.isMultipass()) {
+            inputMethod = "Multipass";
         } else if (problem.isReadInputDataFromSTDIN()) {
             inputMethod = "STDIN";
         } else if (problem.getDataFileName() != null) {
@@ -298,13 +302,13 @@ public class ProblemsPane extends JPanePlugin {
         }
         c[i++] = Long.toString(outputLimit);
 
-        
+
         // problem memory limit
         c[i++] = Integer.toString(problem.getMemoryLimitMB());
 
         //input validator type (NONE/VIVA/CUSTOM)
         c[i++] = problem.getCurrentInputValidatorType();
-        
+
         // input validation status
         INPUT_VALIDATOR_TYPE currentIV = problem.getCurrentInputValidatorType();
         switch (currentIV) {
@@ -344,7 +348,7 @@ public class ProblemsPane extends JPanePlugin {
             validatorCommandLine = problem.getOutputValidatorCommandLine();
         }
         c[i++] = validatorCommandLine;
-        
+
         String groupsSelectedText = "All";
         if (!problem.isAllView()) {
             groupsSelectedText = problem.getGroups().size() + " groups";
@@ -403,14 +407,14 @@ public class ProblemsPane extends JPanePlugin {
     }
 
     /**
-     * This method returns a String of the form "passCount/failCount" indicating the number of input test data files which passed 
+     * This method returns a String of the form "passCount/failCount" indicating the number of input test data files which passed
      * Input Validation, versus the number of input test data files which failed Input Validation, for the specified problem.
-     * The pass/fail count is based on the currently selected Input Validator for the Problem; if the problem has no Input Validator 
+     * The pass/fail count is based on the currently selected Input Validator for the Problem; if the problem has no Input Validator
      * currently associated with it then the empty string ("") is returned. If the problem has an associated Input Validator but
      * the Input Validator has not been run, or if an error was generated when it was run, the String "N/A" is returned.
-     * 
+     *
      * @param problem the Problem whose Pass/Fail count is to be returned.
-     * 
+     *
      * @return a String of the form "passCount/failCount" for the specified problem.
      */
     private String getPassFailCount(Problem problem) {
@@ -503,6 +507,7 @@ public class ProblemsPane extends JPanePlugin {
         problemListBox.autoSizeAllColumns();
     }
 
+    @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         super.setContestAndController(inContest, inController);
 
@@ -518,6 +523,7 @@ public class ProblemsPane extends JPanePlugin {
         initializePermissions();
 
         SwingUtilities.invokeLater(new Runnable() {
+            @Override
             public void run() {
                 updateGUIperPermissions();
                 populateGUI();
@@ -541,7 +547,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes addButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getAddButton() {
@@ -551,6 +557,7 @@ public class ProblemsPane extends JPanePlugin {
             addButton.setMnemonic(KeyEvent.VK_A);
             addButton.setToolTipText("Add new Problem definition");
             addButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     try {
                         addProblem();
@@ -584,6 +591,7 @@ public class ProblemsPane extends JPanePlugin {
             copyButton.setToolTipText("Copy settings from an existing problem to a new problem");
             copyButton.setActionCommand("Copy");
             copyButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     copySelectedProblem();
                 }
@@ -594,7 +602,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes editButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getEditButton() {
@@ -604,6 +612,7 @@ public class ProblemsPane extends JPanePlugin {
             editButton.setMnemonic(KeyEvent.VK_E);
             editButton.setToolTipText("Edit existing Problem definition");
             editButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     editSelectedProblem();
                 }
@@ -651,7 +660,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes messagePanel
-     * 
+     *
      * @return javax.swing.JPanel
      */
     private JPanel getMessagePanel() {
@@ -672,7 +681,7 @@ public class ProblemsPane extends JPanePlugin {
     }
 
     /**
-     * 
+     *
      * @author ICPC
      *
      */
@@ -717,14 +726,16 @@ public class ProblemsPane extends JPanePlugin {
     }
 
     /**
-     * 
+     *
      * @author pc2@ecs.csus.edu
-     * 
+     *
      */
     private class ProblemListenerImplementation implements IProblemListener {
 
+        @Override
         public void problemAdded(final ProblemEvent event) {
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     updateProblemRow(event.getProblem());
                     updateRunInputValidatorsProblemRow(event.getProblem());
@@ -733,24 +744,30 @@ public class ProblemsPane extends JPanePlugin {
             });
         }
 
+        @Override
         public void problemChanged(final ProblemEvent event) {
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     updateProblemRow(event.getProblem());
                 }
             });
         }
 
+        @Override
         public void problemRemoved(ProblemEvent event) {
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     populateGUI();
                 }
             });
         }
 
+        @Override
         public void problemRefreshAll(ProblemEvent event) {
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     populateGUI();
                 }
@@ -795,16 +812,18 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * Account Listener Implementation.
-     * 
+     *
      * @author pc2@ecs.csus.edu
      * @version $Id$
      */
     public class AccountListenerImplementation implements IAccountListener {
 
+        @Override
         public void accountAdded(AccountEvent accountEvent) {
             // ignored
         }
 
+        @Override
         public void accountModified(AccountEvent accountEvent) {
             // check if is this account
             Account account = accountEvent.getAccount();
@@ -815,6 +834,7 @@ public class ProblemsPane extends JPanePlugin {
                 // They modified us!!
                 initializePermissions();
                 SwingUtilities.invokeLater(new Runnable() {
+                    @Override
                     public void run() {
                         updateGUIperPermissions();
                     }
@@ -823,10 +843,12 @@ public class ProblemsPane extends JPanePlugin {
             }
         }
 
+        @Override
         public void accountsAdded(AccountEvent accountEvent) {
             // ignore
         }
 
+        @Override
         public void accountsModified(AccountEvent accountEvent) {
             Account[] accounts = accountEvent.getAccounts();
             for (Account account : accounts) {
@@ -838,6 +860,7 @@ public class ProblemsPane extends JPanePlugin {
                     // They modified us!!
                     initializePermissions();
                     SwingUtilities.invokeLater(new Runnable() {
+                        @Override
                         public void run() {
                             updateGUIperPermissions();
                         }
@@ -846,11 +869,13 @@ public class ProblemsPane extends JPanePlugin {
             }
         }
 
+        @Override
         public void accountsRefreshAll(AccountEvent accountEvent) {
 
             initializePermissions();
 
             SwingUtilities.invokeLater(new Runnable() {
+                @Override
                 public void run() {
                     updateGUIperPermissions();
                 }
@@ -860,7 +885,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * This method initializes reportButton
-     * 
+     *
      * @return javax.swing.JButton
      */
     private JButton getReportButton() {
@@ -870,6 +895,7 @@ public class ProblemsPane extends JPanePlugin {
             reportButton.setMnemonic(KeyEvent.VK_R);
             reportButton.setToolTipText("View Problems Report");
             reportButton.addActionListener(new java.awt.event.ActionListener() {
+                @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     viewReports();
                 }
@@ -907,6 +933,7 @@ public class ProblemsPane extends JPanePlugin {
             setJudgesDataPathButton = new JButton("Set Judge's Data Path");
             setJudgesDataPathButton.setMnemonic(KeyEvent.VK_S);
             setJudgesDataPathButton.addActionListener(new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     editJudgesDataFilePath();
                 }
@@ -927,7 +954,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * Returns a singleton instance of the Frame used to edit the CDP path(s).
-     * 
+     *
      * @return the EditCDPPathFrame
      */
     private EditJudgesDataFilePathFrame getEditCDPFrame() {
@@ -939,7 +966,7 @@ public class ProblemsPane extends JPanePlugin {
 
     /**
      * Returns a singleton instance of the Frame used to display the results of running the input validators.
-     * 
+     *
      * @return a RunInputValidatorFrame
      */
     private RunInputValidatorsFrame getRunInputValidatorsFrame() {
@@ -972,6 +999,7 @@ public class ProblemsPane extends JPanePlugin {
         if (runInputValidatorsButton == null) {
             runInputValidatorsButton = new JButton("Run Input Validators...");
             runInputValidatorsButton.addActionListener(new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent e) {
                     runInputValidators();
                 }

--- a/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ProblemsPane.java
@@ -257,7 +257,7 @@ public class ProblemsPane extends JPanePlugin {
         if (problem.isInteractive()) {
             inputMethod = "Interactive";
         } else if (problem.isMultipass()) {
-            inputMethod = "Multipass";
+            inputMethod = "Multi-pass/" + problem.getCustomOutputValidatorSettings().getMaxMultipassValidationPasses();
         } else if (problem.isReadInputDataFromSTDIN()) {
             inputMethod = "STDIN";
         } else if (problem.getDataFileName() != null) {

--- a/src/edu/csus/ecs/pc2/validator/customValidator/CustomValidatorSettings.java
+++ b/src/edu/csus/ecs/pc2/validator/customValidator/CustomValidatorSettings.java
@@ -1,11 +1,11 @@
-// Copyright (C) 1989-2023 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 /**
  * This class encapsulates settings for configuring a "custom validator".
  * Settings include the validator program name (that is, the program which acts as
  * the custom validator) and the validator command line (that is, the command line
- * used to invoke the validator, including whatever options need to be passed to the 
- * validator program). 
- * 
+ * used to invoke the validator, including whatever options need to be passed to the
+ * validator program).
+ *
  * Custom Validators must be written to use one of two "Interfaces" to the PC2 system --
  * either the "PC2 Interface" or the "CLICS" interface.  Since the "Interface mode" can be
  * changed by the user at any time, this class maintains TWO versions of the "Validator Command Line"
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import edu.csus.ecs.pc2.core.Constants;
+import edu.csus.ecs.pc2.imports.ccs.IContestLoader;
 
 /**
  * @author pc2@ecs.csus.edu
@@ -28,33 +29,37 @@ import edu.csus.ecs.pc2.core.Constants;
 public class CustomValidatorSettings implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
-    
+
     //the name of the custom validator (the program which is to be executed)
     private String customValidatorProgramName;
-    
+
     //the command which is used to invoke the validator (typically includes the validator program name)
-    // Note that there are two variables, to hold two versions of the Command Line: one for Validators 
+    // Note that there are two variables, to hold two versions of the Command Line: one for Validators
     // using the PC2 Interface standard and one for Validators using the CLICS Interface standard
     private String customPC2InterfaceValidatorCommandLine;
     private String customCLICSInterfaceValidatorCommandLine;
-    
-    // flags indicating which validator interface this validator is using - that is, which 
+
+    // flags indicating which validator interface this validator is using - that is, which
     // "Interface mode" is currently active
     private boolean usePC2ValidatorInterface ;
     private boolean useCLICSValidatorInterface ;
-    
+
     /**
      * should the problem be judged interactively.  requires a custom CLICS compliant validator
      */
     private boolean useInteractiveValidatorInterface;
 
-
+    /**
+     * is this problem to be judged as multipass (output validate must be multi-pass aware)
+     */
+    private boolean useMultipassValidatorInterface;
+    private int maxValidationPasses;
 
     /**
      * Constructs a CustomValidatorSettings object with default values of the empty string
      * for the Validator executable program name, the default PC2 Validator and CLICS Validator
      * invocation command lines, and with a default setting of "usePC2ValidatorInterface".
-     * 
+     *
      * @see {@link Constants}
      */
     public CustomValidatorSettings() {
@@ -64,12 +69,14 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
         this.usePC2ValidatorInterface = false ;
         this.useCLICSValidatorInterface = true;
         this.useInteractiveValidatorInterface = false;
+        this.useMultipassValidatorInterface = false;
+        this.maxValidationPasses = IContestLoader.DEFAULT_VALIDATION_PASSES;
     }
 
 
     /**
      * Returns the name of the custom validator program.
-     * 
+     *
      * @return a String containing the name of the custom validator program
      */
     public String getCustomValidatorProgramName() {
@@ -80,9 +87,9 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
      * Sets the name for the custom validator program to the specified value.
      * Note that the validator program name does not include command line options; those
      * are specified via the separate "customValidatorCommand".
-     * 
+     *
      * @see {@link #setValidatorCommandLine(String)}
-     * 
+     *
      * @param progName -- the custom validator program name
      */
     public void setValidatorProgramName(String progName) {
@@ -94,18 +101,18 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
      * Returns the current Custom Validator command line; that is, the command used to invoke the Custom Validator.
      * This typically includes the name of the validator program as the first element, followed by any arguments
      * to be passed to the custom validator.
-     * 
+     *
      * Note that the returned Custom Validator Command Line depends on the current Validator Interface
-     * mode. That is, if the settings in this CustomValidatorSettings object indicate "usePC2ValidatorInterface", 
+     * mode. That is, if the settings in this CustomValidatorSettings object indicate "usePC2ValidatorInterface",
      * this method returns the current PC2 Validator Command Line; if the settings indicate "useCLICSValidatorInterface",
      * this method returns the current CLICS Validator Command Line.
-     * 
+     *
      * @see {@link #setValidatorCommandLine(String)}
      * @see {@link #setUseClicsValidatorInterface()}
      * @see {@link #setUsePC2ValidatorInterface()}
-     * 
+     *
      * @return the command line used to invoke the custom validator when using the currently-set Validator Interface mode
-     * 
+     *
      * @throws {@link RuntimeException} if the settings do not contain a valid Validator Interface mode setting
      */
     public String getCustomValidatorCommandLine() {
@@ -122,26 +129,26 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
      * Sets the command line to be used to invoke the Custom Validator when using the currently-defined Validator Interface mode.
      * The command typically includes the name of the custom validator program as the first element, followed by
      * any arguments to be passed to the custom validator.
-     * 
+     *
      * Note that this class internally maintains two representations of the Validator Command Line, depending on
      * the Validator Interface mode (that is, whether the Validator uses the PC2 Interface Standard or the
      * CLICS Interface Standard).  Calling this method sets the Validator Command Line associated with the currently-set
      * Validator Interface mode.
-     * 
+     *
      * It is the caller's responsibility to insure that this CustomValidatorSettings object
-     * is in the desired Validator Interface mode (that is, set to use either the PC2 Interface Standard or 
+     * is in the desired Validator Interface mode (that is, set to use either the PC2 Interface Standard or
      * the CLICS Interface Standard as desired) prior to invoking this method.  This method ONLY updates
      * the CustomValidatorCommandLine corresponding to the currently-specified Validator Interface mode.
-     * 
+     *
      * @see {@link #setUseClicsValidatorInterface()}
-     * @see {@link #setUsePC2ValidatorInterface()} 
-     * 
+     * @see {@link #setUsePC2ValidatorInterface()}
+     *
      * @param commandString -- a String defining the command line used to invoke the Custom Validator when
      * the Validator is set to use the currently-set Validator Interface Standard.
-     * 
+     *
      * @throws {@link RuntimeException} if this settings object has neither the PC2Validator Interface mode
      *              nor the CLICSValidator Interface mode set
-     * 
+     *
      */
     public void setValidatorCommandLine(String commandString) {
         if (this.isUseClicsValidatorInterface() || this.isUseInteractiveValidatorInterface()) {
@@ -162,18 +169,18 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
      */
     @Override
     public boolean equals(Object obj) {
-        
+
         //are they the exact same object?
         if (this==obj) {
             return true;
         }
-        
+
         if (!(obj instanceof CustomValidatorSettings)) {
             return false;
         }
-        
+
         CustomValidatorSettings other = (CustomValidatorSettings) obj;
-        
+
         //check the validator program name
         //First, check whether one is null while the other is not, using the Java XOR ("^") operator
         if (this.getCustomValidatorProgramName()==null ^ other.getCustomValidatorProgramName()==null) {
@@ -185,7 +192,7 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
                 return false;
             }
         }
-        
+
         //check whether the flags specifying which validator interface to use are identical
         if (this.isUsePC2ValidatorInterface() != other.isUsePC2ValidatorInterface()) {
             return false;
@@ -196,7 +203,13 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
         if (this.isUseInteractiveValidatorInterface() != other.isUseInteractiveValidatorInterface()) {
             return false;
         }
-        
+        if (this.isUseMultipassValidatorInterface() != other.isUseMultipassValidatorInterface()) {
+            return false;
+        }
+        if (this.getMaxMultipassValidationPasses() != other.getMaxMultipassValidationPasses()) {
+            return false;
+        }
+
         //check the PC2 validator interface invocation command strings
         //First, check whether one is null while the other is not, using the Java XOR ("^") operator
         if (this.customPC2InterfaceValidatorCommandLine==null ^ other.customPC2InterfaceValidatorCommandLine==null) {
@@ -208,7 +221,7 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
                 return false;
             }
         }
-        
+
         //check the Clics validator interface invocation command strings
         //First, check whether one is null while the other is not, using the Java XOR ("^") operator
         if (this.customCLICSInterfaceValidatorCommandLine==null ^ other.customCLICSInterfaceValidatorCommandLine==null) {
@@ -223,37 +236,40 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
         // remember to update hashCode if new fields are added here
 
         return true;
-        
+
     }
-    
+
     @Override
     public int hashCode() {
-        return Objects.hash(customValidatorProgramName,usePC2ValidatorInterface,useCLICSValidatorInterface,useInteractiveValidatorInterface,
-                customPC2InterfaceValidatorCommandLine,customCLICSInterfaceValidatorCommandLine);
+        return Objects.hash(customValidatorProgramName,usePC2ValidatorInterface,useCLICSValidatorInterface,
+                useInteractiveValidatorInterface,customPC2InterfaceValidatorCommandLine,
+                customCLICSInterfaceValidatorCommandLine,useMultipassValidatorInterface, maxValidationPasses);
     }
-    
+
     /**
      * Returns a CustomValidatorSettings object which is a copy of this object.
-     * 
+     *
      */
+    @Override
     public CustomValidatorSettings clone() {
         //create a clone with default values
         CustomValidatorSettings clone = new CustomValidatorSettings();
-        
+
         //update the validator program name
         clone.setValidatorProgramName(this.getCustomValidatorProgramName());
-        
+
         //update the interface mode settings
         clone.useCLICSValidatorInterface = this.isUseClicsValidatorInterface();
         clone.usePC2ValidatorInterface = this.isUsePC2ValidatorInterface();
         clone.useInteractiveValidatorInterface = this.isUseInteractiveValidatorInterface();
-        
+        clone.useMultipassValidatorInterface = this.isUseMultipassValidatorInterface();
+
         //update the validator command lines. (Note that this should NOT be done with accessors because the
         // getters return a string that depends on the current Validator Interface mode; we need to
         // set BOTH strings.)
         clone.customPC2InterfaceValidatorCommandLine = this.customPC2InterfaceValidatorCommandLine;
         clone.customCLICSInterfaceValidatorCommandLine = this.customCLICSInterfaceValidatorCommandLine;
-        
+
         return clone;
     }
 
@@ -270,13 +286,14 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
      * Sets the flag indicating that this validator expects to use the PC2 Validator Interface.
      * This method should be called prior to attempting to use {@link #setValidatorCommandLine(String)}
      * to set a PC2 Validator Command Line.
-     * 
+     *
      * @see {@link #setValidatorCommandLine(String)}
-     * 
+     *
      */
     public void setUsePC2ValidatorInterface() {
         this.usePC2ValidatorInterface = true;
         this.useCLICSValidatorInterface = false;
+        this.useMultipassValidatorInterface = false;
     }
 
 
@@ -294,20 +311,20 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
      * Sets the flag indicating that this validator expects to use the CLICS Validator Interface.
      * This method should be called prior to attempting to use {@link #setValidatorCommandLine(String)}
      * to set a CLICS Validator Command Line.
-     * 
+     *
      * @see {@link #setValidatorCommandLine(String)}
-     * 
+     *
      */
     public void setUseClicsValidatorInterface() {
         this.useCLICSValidatorInterface = true;
         this.usePC2ValidatorInterface = false;
     }
 
-    
+
     /**
      * Sets the flag indicating that this validator expects to use the CLICS Interactive Validator Interface.
      * @see {@link #setValidatorCommandLine(String)}
-     * 
+     *
      */
     public void setUseInteractiveValidatorInterface() {
         this.useCLICSValidatorInterface = false;
@@ -322,23 +339,60 @@ public class CustomValidatorSettings implements Serializable, Cloneable {
         return useInteractiveValidatorInterface;
     }
 
-    
+    /**
+     * Sets the flag indicating that this validator is expected to use the CLICS Multipass Validator Interface.
+     * @see {@link #setValidatorCommandLine(String)}
+     *
+     */
+    public void setUseMultipassValidatorInterface() {
+        this.useCLICSValidatorInterface = true;
+        this.usePC2ValidatorInterface = false;
+        this.useInteractiveValidatorInterface = false;
+        this.useMultipassValidatorInterface = true;
+    }
+
+    /**
+     * @return the useInteractiveValidatorInterface flag setting
+     */
+    public boolean isUseMultipassValidatorInterface() {
+        return useMultipassValidatorInterface;
+    }
+
+
+    /**
+     * Sets the maximum number of validation passes to expect for multipass problems
+     *
+     */
+    public void setMaxMultipassValidationPasses(int passes) {
+        maxValidationPasses = passes;
+    }
+
+    /**
+     * @return the useInteractiveValidatorInterface flag setting
+     */
+    public int getMaxMultipassValidationPasses() {
+        return maxValidationPasses;
+    }
+
+
     @Override
     public String toString() {
         String retStr = "CustomValidatorSettings[";
-        
+
         retStr += "ValidatorProgramName=" + customValidatorProgramName;
-        
+
         retStr += "; usePC2ValidatorInterface=" + usePC2ValidatorInterface;
         retStr += "; useCLICSValidatorInterface=" + useCLICSValidatorInterface;
         retStr += "; useInteractiveValidatorInterface=" + useInteractiveValidatorInterface;
+        retStr += "; useMultipassValidatorInterface=" + useMultipassValidatorInterface;
+        retStr += "; maxValidationPasses=" + maxValidationPasses;
 
         retStr += "; PC2InterfaceValidatorCommandLine=" + customPC2InterfaceValidatorCommandLine;
         retStr += "; CLICSInterfaceValidatorCommandLine=" + customCLICSInterfaceValidatorCommandLine;
-        
+
         retStr += "]";
         return retStr ;
-        
+
     }
 
 }


### PR DESCRIPTION
### Description of what the PR does
Adds support for multi-pass problems.

From the Problem Package Format specification 2023-07draft:

> Multi-pass validation
> A multi-pass validator can be used for problems that should run the submission multiple times sequentially, using a new input generated by output validator during the previous invocation of the submission.
> 
> The time and memory limit apply for each invocation separately.
> 
> To signal that the submission should be run again, the output validator must exit with code 42 and output the new input in the file nextpass.in in the feedback directory. Judging stops if no nextpass.in was created or the output validator exited with any other code. Note that the nextpass.in will be removed before the next pass.
> 
> It is a judge error to create the nextpass.in file and exit with any other code than 42. It is a judge error to run more passes than specified by the limits.validation_passes value in problem.yaml.
> 
> All other files inside the feedback directory are guaranteed to persist between passes. In particular, the validator should only append text to the judgemessage.txt to provide combined feedback for all passes.

### Issue which the PR addresses
Fixes #1189 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11/Ubuntu 24.04.3
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
PR has been tested in 2 live contests:  NWERC2025 Practice and NWERC2025 Regional.

@johnbrvc will put together a sample contest based upon one of the problems from the NWERC contests.  This will allow easy testing.