### PR TITLE
Added unlimited stacksize ulimit to sandbox scripts

### DIFF
--- a/scripts/pc2sandbox.sh
+++ b/scripts/pc2sandbox.sh
@@ -380,6 +380,9 @@ MAXPROCS=$((MAXPROCS+`ps -T -u $USER | wc -l`))
 REPORT_DEBUG Setting maximum user processes to $MAXPROCS
 ulimit -u $MAXPROCS
 
+REPORT_DEBUG Setting stack size to unlimited
+ulimit -s unlimited
+
 # Keep track of details for reports
 REPORT_BRIEF ${JUDGEIN}
 REPORT_BRIEF ${JUDGEANS}

--- a/scripts/pc2sandbox_interactive.sh
+++ b/scripts/pc2sandbox_interactive.sh
@@ -543,6 +543,10 @@ MAXPROCS=$((MAXPROCS+`ps -T -u $USER | wc -l`))
 REPORT_DEBUG Setting maximum user processes to $MAXPROCS 
 ulimit -u $MAXPROCS
 
+
+REPORT_DEBUG Setting stack size to unlimited
+ulimit -s unlimited
+
 # Keep track of details for reports
 REPORT_BRIEF ${JUDGEIN}
 REPORT_BRIEF ${JUDGEANS}


### PR DESCRIPTION
### Description of what the PR does
Overrides the Linux system default of 8MB for stack size in the sandbox scripts.  The Sandbox scripts will set an "unlimited" stack size, allowing the stack to grow to maximum memory limit allocated to the problem.  If the problem has a 2GB memory limit, then, of course, the stack will never be bigger than 2GB.  This PR just allows the stack to consume as much of the allowed memory as it wants.
### Issue which the PR addresses
Fixes #1192 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Ubuntu 24.04
openjdk 21.0.8 2025-07-15
OpenJDK Runtime Environment (build 21.0.8+9-Ubuntu-0ubuntu124.04.1)
OpenJDK 64-Bit Server VM (build 21.0.8+9-Ubuntu-0ubuntu124.04.1, mixed mode, sharing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
The scripts in this PR have been used in several regionals, including NAC2024, NAC2025 and World Finals (49/Baku) as well as Greater NY and PacNW.  It's just that they never made it into the Repo.
