### PR TITLE
i_1195 Handle escapes in institution names

### DIFF
--- a/src/edu/csus/ecs/pc2/core/util/TabSeparatedValueParser.java
+++ b/src/edu/csus/ecs/pc2/core/util/TabSeparatedValueParser.java
@@ -1,11 +1,11 @@
-// Copyright (C) 1989-2019 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.util;
 
 import java.util.Vector;
 
 /**
  * Tab delimited parser.
- * 
+ *
  * @author pc2@ecs.csus.edu
  * @version $Id$
  */
@@ -17,9 +17,11 @@ public final class TabSeparatedValueParser {
 
     private static final String TAB_STRING = String.valueOf(TAB_CHAR);
 
+    private static final char ESC_CHAR = '\\';
+
     /**
      * Return array of containing the Tab Separated Values from the input string.
-     * 
+     *
      * @return java.lang.String[]
      * @param line
      *            java.lang.String
@@ -27,11 +29,11 @@ public final class TabSeparatedValueParser {
      *             if there was a problem parsing the line
      */
     public static String[] parseLine(String line) throws Exception {
-        
+
         if (line == null) {
             throw new IllegalArgumentException("null String not allowed");
         }
-        
+
         String[] array = new String[1];
         array[0] = "";
         int fieldCount = 1;
@@ -39,6 +41,7 @@ public final class TabSeparatedValueParser {
         Vector<String> v = new Vector<String>();
         int i;
         boolean inQuote = false;
+        boolean inEscape = false;
         char current;
         char next;
         int length = line.length();
@@ -46,6 +49,15 @@ public final class TabSeparatedValueParser {
         int ignoredTerminatingQuote = 0; // SOMEDAY can this be removed??
         for (i = 0; i < line.length(); i++) {
             current = line.charAt(i);
+            if(inEscape) {
+                currentField = currentField + current;
+                inEscape = false;
+                continue;
+            }
+            if(current == ESC_CHAR) {
+                inEscape = true;
+                continue;
+            }
             if (current == '"') {
                 if (inQuote) {
                     if (i + 1 >= length) {
@@ -105,7 +117,7 @@ public final class TabSeparatedValueParser {
 
     /**
      * Return String of the Tab Separated Values made from the input array
-     * 
+     *
      * @return java.lang.String
      * @param array
      *            java.lang.String[]
@@ -141,7 +153,7 @@ public final class TabSeparatedValueParser {
     }
 
     /**
-     * 
+     *
      */
     private TabSeparatedValueParser() {
         super();

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1454,16 +1454,16 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         // So, the value may be a double (IE contains a decimal pt), or an integer.
         Object oValue = map.get(key);
         Double value = null;
-        if(oValue instanceof Double) {
-            value = (Double) map.get(key);
-        } else {
-            value = new Double(((Integer)oValue).doubleValue());
-        }
-        if (value != null) {
+        if (oValue != null) {
             try {
+                if(oValue instanceof Double) {
+                    value = (Double) oValue;
+                } else {
+                    value = new Double(((Integer)oValue).doubleValue());
+                }
                 return value;
             } catch (Exception e) {
-                syntaxError("Expecting double number after " + key + ": field, found '" + value + "'");
+                syntaxError("Expecting double number after " + key + ": field, found '" + oValue + "'");
             }
         }
         return null;

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1459,7 +1459,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                 if(oValue instanceof Double) {
                     value = (Double) oValue;
                 } else {
-                    value = new Double(((Integer)oValue).doubleValue());
+                    value = Double.valueOf(((Integer)oValue).doubleValue());
                 }
                 return value;
             } catch (Exception e) {

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1446,6 +1446,29 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         return null;
     }
 
+    private Double fetchDoubleValue(Map<String, Object> map, String key) {
+        if (map == null) {
+            // SOMEDAY figure out why map would every be null
+            return null;
+        }
+        // So, the value may be a double (IE contains a decimal pt), or an integer.
+        Object oValue = map.get(key);
+        Double value = null;
+        if(oValue instanceof Double) {
+            value = (Double) map.get(key);
+        } else {
+            value = new Double(((Integer)oValue).doubleValue());
+        }
+        if (value != null) {
+            try {
+                return value;
+            } catch (Exception e) {
+                syntaxError("Expecting double number after " + key + ": field, found '" + value + "'");
+            }
+        }
+        return null;
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> fetchMap(Map<String, Object> content, String key) {
         Object object = content.get(key);
@@ -1668,9 +1691,9 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
             //check for a timeout limit within the CLICS "limits:" section.
             // Note that the presence of a "timeout:" entry within a CLICS
             // "limits:" section is non-CLICS standard -- but we want to support it in PC2.
-            Integer clicsTimeout = fetchIntValue(limitsContent, TIMEOUT_KEY);
+            Double clicsTimeout = fetchDoubleValue(limitsContent, TIMEOUT_KEY);
             if (clicsTimeout != null) {
-                problem.setTimeOutInSeconds(clicsTimeout);
+                problem.setTimeOutInSeconds(clicsTimeout.intValue());
             }
 
             //check for a CLICS maxoutput limit - the value is in MiB

--- a/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ICPCTSVLoader.java
@@ -159,6 +159,9 @@ public final class ICPCTSVLoader {
             institutionCode = fields[fieldnum++];
             String[] fieldArray = getInstitutionNames(institutionCode);
             if (fieldArray != null) {
+                if(fieldArray.length < 3) {
+                    throw new InvalidValueException("Bad institution code '" + institutionCode + "' on line " + originalLine + " (need at least 3 fields, but there are only " + fieldArray.length + ")");
+                }
                 institutionFormalName = fieldArray[1];
                 institutionName = fieldArray[2];
             }
@@ -386,7 +389,7 @@ public final class ICPCTSVLoader {
 //            String formalName = fields[1];
 //            String name = fields[2];
             institutionsMap.put(icpcId, fields);
-            
+
             // We also add the institution ID minus the INST- "Due to the non-specificity of the format of an inst code
             if(icpcId.startsWith("INST-")) {
                 institutionsMap.put(icpcId.substring(5), fields);


### PR DESCRIPTION

### Description of what the PR does
Fix `TabSeparatedValueParser `to allow backslash escaping of characters in fields.
CI: Allow the `timelimit ` property in the CLICS section to be a `Double ` (SEERC contest did this)
CI: Add better exception handling if invalid institution information is returned

### Issue which the PR addresses
Fixes #1195 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
TBD