### PR TITLE
I_1217 Source unavailable in some cases for submissions from API and a primary.

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -506,9 +506,9 @@ public class SubmissionService implements Feature {
                 return Response.status(Status.BAD_REQUEST).entity("invalid json supplied").build();
             }
 
-            // These next three are for admin users only
+            // These next two are for admin users only
             long overrideTimeMS = -1;
-            long overrideSubmissionID = -1;
+            long overrideSubmissionID = 0;
 
             Log log = controller.getLog();
             String user = sc.getUserPrincipal().getName();
@@ -591,7 +591,7 @@ public class SubmissionService implements Feature {
                 }
                 overrideSubmissionID = Utilities.stringToLong(sub.getId());
                 if(overrideSubmissionID < 0) {
-                    overrideSubmissionID = -1;
+                    overrideSubmissionID = 0;
                 }
             }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.io.File;
@@ -53,7 +53,6 @@ import edu.csus.ecs.pc2.convert.EventFeedUtilities;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
-import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException.SubmissionRejectionReason;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
@@ -358,21 +357,34 @@ public class SubmissionService implements Feature {
 
                     SerializedFile mainFile = runFiles.getMainFile();
                     SerializedFile[] otherFiles = runFiles.getOtherFiles();
+                    int fileIndex = 0;
+
                     java.nio.file.Path tmpDir = null;
                     try {
                         tmpDir = Files.createTempDirectory("subService");
                         // dump mainFile and otherFiles to tmpDir
                         HashMap<Integer, String> filesToWrite = new HashMap<Integer, String>();
-                        if (mainFile != null) {
-                            filesToWrite.put(Integer.valueOf(0), mainFile.getName());
+                        // Do not add entry for an empty mainfile name - could be it's included as otherFiles
+                        if (mainFile != null && !mainFile.getName().isEmpty()) {
+                            filesToWrite.put(Integer.valueOf(fileIndex), mainFile.getName());
+                            fileIndex++;
                             mainFile.buffer2file(mainFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + mainFile.getName());
                         }
                         if (otherFiles != null) {
                             for (int j = 0; j < otherFiles.length; j++) {
                                 SerializedFile serializedFile = otherFiles[j];
-                                filesToWrite.put(Integer.valueOf(j + 1), serializedFile.getName());
-                                serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
+                                // Do not add filenames that are empty strings.
+                                if(!serializedFile.getName().isEmpty()) {
+                                    filesToWrite.put(Integer.valueOf(fileIndex), serializedFile.getName());
+                                    fileIndex++;
+                                    serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
+                                }
                             }
+                        }
+                        // Make sure we're returning a valid source zip - that is, it must have files in it.
+                        if(fileIndex == 0) {
+                            controller.getLog().log(Log.INFO, "Returned runFiles was empty or all file names were empty strings; returning 'NOT_FOUND'");
+                            return Response.status(Status.NOT_FOUND).build();
                         }
                         String zipFileName = tmpDir.toAbsolutePath().toString() + File.pathSeparator + "files.zip";
                         createZip(submission, tmpDir, filesToWrite, zipFileName);

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.convert;
 
 import java.io.ByteArrayInputStream;
@@ -167,23 +167,24 @@ public final class EventFeedUtilities {
 
                 String entryName = entry.getName();
 
-//                ByteOutputStream byteOutputStream = new ByteOutputStream();
-                ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+                // Only add the file to the list if the file name is not an empty string.
+                // and it's not a directory entry.
+                if(!entryName.isEmpty() && !entryName.endsWith("/")) {
+                    ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 
-                byte[] buffer = new byte[8096];
-                int bytesRead = 0;
-                while ((bytesRead = zipStream.read(buffer)) != -1)
-                {
-                    byteOutputStream.write(buffer, 0, bytesRead);
+                    byte[] buffer = new byte[8096];
+                    int bytesRead = 0;
+                    while ((bytesRead = zipStream.read(buffer)) != -1)
+                    {
+                        byteOutputStream.write(buffer, 0, bytesRead);
+                    }
+
+                    String base64Data = getBase64Data(byteOutputStream.toByteArray());
+                    IFile iFile = new IFileImpl(entryName, base64Data);
+                    files.add(iFile);
+
+                    byteOutputStream.close();
                 }
-
-//                String base64Data = getBase64Data(byteOutputStream.getBytes());
-                String base64Data = getBase64Data(byteOutputStream.toByteArray());
-                IFile iFile = new IFileImpl(entryName, base64Data);
-                files.add(iFile);
-
-                byteOutputStream.close();
-
                 zipStream.closeEntry();
             }
             zipStream.close();


### PR DESCRIPTION
### Description of what the PR does
Fix `EventFeedUtilities.java` to ignore zip file names that are empty or are directories (end in a /).
CI: Somewhat related, but do not create a zip file for an API submission source file request with entries that have empty filenames.
CI: Fix errant comment.
CI: Change `overrideSubmissionID `to default of 0 since a submission will not have an ID of 0.  A negative submission ID is special and will get converted to a positive number, so -1 is really submission 1, hence we can't use that as a default.

### Issue which the PR addresses
#1217 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

Linux Ubuntu 24.04.3 (for testing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Unzip the attached zip (`pr1217files.zip`) file into a new directory someplace convenient.  BTW, you'll need **python3** installed for this test procedure to work, otherwise --- you're on your own. 
[pr1217files.zip](https://github.com/user-attachments/files/25271705/pr1217files.zip)
2. Load up a clean copy of the **sumithello** contest
3. Start the contest
4. Start an administrator client.
5. On the **Configuration->Accounts** tab, **Generate** a single _EventFeeder_ account.
6. On the **Configuration->Accounts** tab, edit the **feeder1** account just created and in the **Permissions/Abilities** pane on the right, scroll down to **Shadow Proxy Team** and check the box next to it.  This allows the CLICS api to make submissions on behalf of a team.
7. On the **Configuration->Settings** tab, under **Remote CCS Settings**, check both the "**Enable CCS Test Mode**" and "**Enable Shadow Mode**" check boxes.  (This is more of a historical thing, but is required for the CLICS API submit to work.)
8. Start an event feeder client (`pc2ef`) or from eclipse, just start a pc<sup>2</sup> client and use the login **ef1**.
9. Press the **Start** button on the event feeder.  This will start the CLICS API reader on port 50443.
10. Navigate to where your `~/.netrc` file is located (either `$HOME/.netrc` on Linux or `C:\Users\USERNAME\.netrc` on Windows)
11. Edit the .netrc file and make sure there are no lines that refer to **localhost** in there.  If there are, remove them, or the script below will use those credentials to log into PC<sup>2</sup>, which is NOT what you want here.
12. From a command prompt, change to the directory where you extracted the `pr1217file.zip` file.
13. Execute either `doplayback1.sh` (Linux) or `doplayback1.bat `(Windows).  This will make a submission using the `1.zip` file included in `pr1217file.zip`.  `1.zip` contains a hierarchy which aggravated the bug previously.
14. After the submission completes successfully, go to the administrator **Run Contest->Runs** tab.
15. Select the only run there (Run id 1).
16. Press the **View Source** button.  You should see some source code pop up and NOT receive an error.



