### PR TITLE
I1223 handle empty score.txt

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -506,9 +506,9 @@ public class SubmissionService implements Feature {
                 return Response.status(Status.BAD_REQUEST).entity("invalid json supplied").build();
             }
 
-            // These next three are for admin users only
+            // These next two are for admin users only
             long overrideTimeMS = -1;
-            long overrideSubmissionID = -1;
+            long overrideSubmissionID = 0;
 
             Log log = controller.getLog();
             String user = sc.getUserPrincipal().getName();
@@ -591,7 +591,7 @@ public class SubmissionService implements Feature {
                 }
                 overrideSubmissionID = Utilities.stringToLong(sub.getId());
                 if(overrideSubmissionID < 0) {
-                    overrideSubmissionID = -1;
+                    overrideSubmissionID = 0;
                 }
             }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.io.File;
@@ -53,7 +53,6 @@ import edu.csus.ecs.pc2.convert.EventFeedUtilities;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
-import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException.SubmissionRejectionReason;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
@@ -358,21 +357,34 @@ public class SubmissionService implements Feature {
 
                     SerializedFile mainFile = runFiles.getMainFile();
                     SerializedFile[] otherFiles = runFiles.getOtherFiles();
+                    int fileIndex = 0;
+
                     java.nio.file.Path tmpDir = null;
                     try {
                         tmpDir = Files.createTempDirectory("subService");
                         // dump mainFile and otherFiles to tmpDir
                         HashMap<Integer, String> filesToWrite = new HashMap<Integer, String>();
-                        if (mainFile != null) {
-                            filesToWrite.put(Integer.valueOf(0), mainFile.getName());
+                        // Do not add entry for an empty mainfile name - could be it's included as otherFiles
+                        if (mainFile != null && !mainFile.getName().isEmpty()) {
+                            filesToWrite.put(Integer.valueOf(fileIndex), mainFile.getName());
+                            fileIndex++;
                             mainFile.buffer2file(mainFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + mainFile.getName());
                         }
                         if (otherFiles != null) {
                             for (int j = 0; j < otherFiles.length; j++) {
                                 SerializedFile serializedFile = otherFiles[j];
-                                filesToWrite.put(Integer.valueOf(j + 1), serializedFile.getName());
-                                serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
+                                // Do not add filenames that are empty strings.
+                                if(!serializedFile.getName().isEmpty()) {
+                                    filesToWrite.put(Integer.valueOf(fileIndex), serializedFile.getName());
+                                    fileIndex++;
+                                    serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
+                                }
                             }
+                        }
+                        // Make sure we're returning a valid source zip - that is, it must have files in it.
+                        if(fileIndex == 0) {
+                            controller.getLog().log(Log.INFO, "Returned runFiles was empty or all file names were empty strings; returning 'NOT_FOUND'");
+                            return Response.status(Status.NOT_FOUND).build();
                         }
                         String zipFileName = tmpDir.toAbsolutePath().toString() + File.pathSeparator + "files.zip";
                         createZip(submission, tmpDir, filesToWrite, zipFileName);

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.convert;
 
 import java.io.ByteArrayInputStream;
@@ -167,23 +167,24 @@ public final class EventFeedUtilities {
 
                 String entryName = entry.getName();
 
-//                ByteOutputStream byteOutputStream = new ByteOutputStream();
-                ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+                // Only add the file to the list if the file name is not an empty string.
+                // and it's not a directory entry.
+                if(!entryName.isEmpty() && !entryName.endsWith("/")) {
+                    ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 
-                byte[] buffer = new byte[8096];
-                int bytesRead = 0;
-                while ((bytesRead = zipStream.read(buffer)) != -1)
-                {
-                    byteOutputStream.write(buffer, 0, bytesRead);
+                    byte[] buffer = new byte[8096];
+                    int bytesRead = 0;
+                    while ((bytesRead = zipStream.read(buffer)) != -1)
+                    {
+                        byteOutputStream.write(buffer, 0, bytesRead);
+                    }
+
+                    String base64Data = getBase64Data(byteOutputStream.toByteArray());
+                    IFile iFile = new IFileImpl(entryName, base64Data);
+                    files.add(iFile);
+
+                    byteOutputStream.close();
                 }
-
-//                String base64Data = getBase64Data(byteOutputStream.getBytes());
-                String base64Data = getBase64Data(byteOutputStream.toByteArray());
-                IFile iFile = new IFileImpl(entryName, base64Data);
-                files.add(iFile);
-
-                byteOutputStream.close();
-
                 zipStream.closeEntry();
             }
             zipStream.close();

--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.BufferedInputStream;
@@ -1140,30 +1140,38 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
                    String scoreLine = reader.readLine();
                    reader.close();
                    
-                   double scoreVal;
-                   try {
-                       scoreVal = Double.parseDouble(scoreLine);
-                   } catch (NumberFormatException e) {
-                       log.log(Level.WARNING, "Number format exception: '" + scoreLine + "' while reading '" 
-                               + scoreFileName + "'; returning score = 0.0");
-                       return 0; 
-                   }
-                   
-                   //make sure the score is legal (scores cannot be negative)
-                   if (scoreVal >= 0) {
-                       return scoreVal ;
-                   } else {
-                       log.log(Level.WARNING, "Found illegal score value '" + scoreVal + "' while reading '" 
-                               + scoreFileName + "' (scores cannot be negative); returning score = 0.0");
+                   // Make sure it wasn't an empty file - some sloppy validators will create empty files
+                   if(!StringUtilities.isEmpty(scoreLine)) {
+                       double scoreVal = 0;
+                       boolean scoreValid = false;
+                       
+                       try {
+                           scoreVal = Double.parseDouble(scoreLine);
+                           scoreValid = true;
+                       } catch (Exception e) {
+                           log.log(Level.WARNING, "Exception converting score: '" + scoreLine + "' while reading '" 
+                                   + scoreFileName + "'; returning TestDataGroup Reject score", e);
+                       }
+                       
+                       //if the score was successfully converted to a Double, make sure the score is legal (scores cannot be negative)
+                       //note: if there was exception converting the score, scoreValid will be false, and the log message above would
+                       //      have been printed.
+                       if (scoreValid) {
+                           if(scoreVal >= 0) {
+                               return scoreVal ;
+                           } else {
+                               log.log(Level.WARNING, "Found illegal score value '" + scoreVal + "' while reading '" 
+                                       + scoreFileName + "' (scores cannot be negative); returning TestDataGroup Reject score");
+                           }
+                       }
                    }
                } catch (IOException e) {
                    log.log(Level.WARNING, "IOException reading '" + scoreFileName, e);
                }
-               return 0;
             }  
         }
             
-        //no, there's no "score.txt" file (or we didn't validate); try getting the score from the ranges defined in the test case
+        //no, there's no valid "score.txt" file (or we didn't validate); try getting the score from the ranges defined in the test case
         ProblemDataFiles probDataFiles = controller.getProblemDataFiles(problem); 
         TestDataGroup testGroup = probDataFiles.getJudgesDataGroups()[testCaseNumber-1];  //testCaseNumber is 1-based but the array is 0-based
         

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1459,7 +1459,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                 if(oValue instanceof Double) {
                     value = (Double) oValue;
                 } else {
-                    value = new Double(((Integer)oValue).doubleValue());
+                    value = Double.valueOf(((Integer)oValue).doubleValue());
                 }
                 return value;
             } catch (Exception e) {


### PR DESCRIPTION
### Description of what the PR does
Fixes the handling of an empty or bad score.txt file for point scoring contests.

### Issue which the PR addresses
Fixed #1223 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ubuntu 24.04.3

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
See the Issue.  The setup is quite elaborate to test this.  I have tested it using the NAC2026 challenge2025_test contest and it works as described in the issue.  If necessary, we can discuss a test bed for this.

Some notes to help testing on Windows...

If you are testing with the NAC2026/contests/challenge2024_test contest, the problem that causes this issue is **treasurepacking** (the only one with a custom validator).
It turns out, the validator is a _python_ program.  PC2 does not know how to simply "execute" a python validator; on Linux it's easy because of the _shebang_ (`#!`) at the beginning of the python script.  On Windows, you have to tell PC2 to execute: `python validate.py ... ` , however, there's more to it than just that.

You'll have to edit the problem, turn off the "sandbox" option (**Sandbox** tab, select **Do not use a Sandbox**)
Then on the **Output Validator** tab, at the bottom, for the "**Validator Command Line**", **_prepend_** what is there already with: `..\..\..\..\..\..\..\..\<full path of where python is>\python.exe`  so on my system the full **Validator Command Line**, looks like this:
`..\..\..\..\..\..\..\..\Users\John Buck\AppData\Local\Programs\Python\Python312\python.exe {:validator} {:infile} {:ansfile} {:feedbackdir}`

You will also have to modify the "**Judge's Data Path**" (on the **Problems** tab) to be wherever you extracted the contest repo to, so if you extracted it to "`\MyRepos`", you would **Set Judge's Data Path** to:
`\MyRepos\NAC2026\contests\challenge2024_test\config`

Next, on the  **Auto Judge** tab, pick whatever autojudge you're going to use (presumably **judge1**), and edit it.  Uncheck all but "**Treasure Packing**".
<img width="403" height="214" alt="image" src="https://github.com/user-attachments/assets/f6ffbb5f-745a-4238-ad5f-5259be0af2a7" />
If you don't do this... well... you'll see what happens...  It's not a catastrophe, but it's annoying.

You can then bring up a **pc2team** client, log in as **team1** with password "**frill-equity**" and submit ANY "cpp" file for problem **treasurepacking**.  The idea is to get a **WA**.  I used: **samps/src/hello.cpp**

