### PR TITLE
I1224 point score decimal format

### DIFF
--- a/projects/WTI-API/src/main/controllers/ContestController.java
+++ b/projects/WTI-API/src/main/controllers/ContestController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package controllers;
 
 import java.io.IOException;
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -36,6 +37,7 @@ import edu.csus.ecs.pc2.api.exceptions.LoginFailureException;
 import edu.csus.ecs.pc2.api.exceptions.NotLoggedInException;
 import edu.csus.ecs.pc2.core.IniFile;
 import edu.csus.ecs.pc2.core.StringUtilities;
+import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.ClientId;
@@ -930,11 +932,116 @@ public class ContestController extends MainController {
 		
 		JSONObject jsonStandingsObject = XML.toJSONObject(xmlStandings);
 	
+		changeScoresToStrings(jsonStandingsObject);
+		
 		logger.fine("Standings JSON: " + jsonStandingsObject.toString(2));
 
 		return jsonStandingsObject.toString();
 	}
 
+    /**
+     * Scan the supplied JSONObject for problemSummaryInfo's that have numeric "score" properties and
+     * reformat them and put them back as Strings.  By default, the XML.toJSONObject() will attempt to determine
+     * what type a value is and create JSON that uses that type.  So, for example, an XML attribute such as:
+     * score="12.340000"
+     * would be converted to this JSON:
+     * "score": 12.34
+     *  
+     * The structure of the original XML we are interested in is:
+     * <contestStandings ...>
+     *  <standingsHeader ...>
+     *   <problem ...>
+     *  </standingsHeader>
+     *  <teamStanding ... >
+     *   <problemSummaryInfo ...>
+     *  </teamStanding>
+     *  <teamStanding ... >
+     *   <problemSummaryInfo ...>
+     *  </teamStanding>
+     *  ...
+     * </contestStandings>
+     *
+     * We will check the "probemSummaryInfo" json objects for "score" properties, fetch them, reformat them, and
+     * put them back in the json as Strings.
+     * 
+     * It should be noted that XML.toJSONObject() does have a mechansism to convert ALL values to Strings, but we
+     * do not want that.  We wish to keep other numeric properties as numbers and booleans and whatnot.
+     *
+     * @param xmlJSONObj The main JSONObject obtained from XML.toJSONObject()
+     */
+    private void changeScoresToStrings(JSONObject xmlJSONObj) {
+        JSONObject currentObj = xmlJSONObj;
+
+        String CONTEST_STANDINGS = "contestStandings";
+        String TEAM_STANDING = "teamStanding";
+
+        // Find top level
+        currentObj = currentObj.optJSONObject(CONTEST_STANDINGS);
+        if (currentObj == null) {
+            logger.warning(CONTEST_STANDINGS + " object not found in standings XML");
+            return;
+        }
+        Object teamStandings = currentObj.opt(TEAM_STANDING);
+        
+        // if there's more than one teamStanding, it's in a JSONArray
+        if(teamStandings instanceof JSONArray) {
+        	JSONArray jArray = (JSONArray)teamStandings;
+        	int nStandings = jArray.length();
+        	for(int idx = 0; idx < nStandings; idx++) {
+                fixProblemSummaryInfo(jArray.optJSONObject(idx));
+            }
+        } else if(teamStandings instanceof JSONObject){
+            // Only one teamStandings
+            fixProblemSummaryInfo((JSONObject) teamStandings);
+        }
+    }
+
+    /**
+     * Iterates through a (possible) array of a teamStanding's problemSummaryInfo's and change the "score" property
+     * to a string.
+     *
+     * @param teamStanding - use this teamStanding's problemSummaryInfo's
+     */
+    void fixProblemSummaryInfo(JSONObject teamStanding) {
+        String PROBLEM_SUMMARY_INFO = "problemSummaryInfo";
+
+        // The teamStanding record has the total score in it, so it has to be fixed as well
+        fixScore(teamStanding);
+        
+        // Find childElement that contains the itemElement
+        Object psis = teamStanding.opt(PROBLEM_SUMMARY_INFO);
+
+        if(psis instanceof JSONArray) {
+        	JSONArray jArray = (JSONArray)psis;
+        	int nStandings = jArray.length();
+        	for(int idx = 0; idx < nStandings; idx++) {
+                fixScore(jArray.optJSONObject(idx));
+            }
+        } else if(psis instanceof JSONObject) {
+            fixScore((JSONObject)psis);
+        }
+    }
+
+    /**
+     * Check if the supplied ProblemSummaryInfo contains a score key that is a double, if so,
+     * convert it to string.
+     * 
+     * @param psi - the ProblemSummaryInfo of interest
+     */
+    void fixScore(JSONObject psi) {
+        String SCORE_PROPERTY = "score";
+        
+        try {
+            double score = psi.getDouble(SCORE_PROPERTY);
+            String formattedScore = Utilities.formatScore(score);
+            // Overwrite existing property with string version for formatted score.
+            psi.put(SCORE_PROPERTY, formattedScore);
+        } catch(Exception e) {
+            // If any exception occurs, that is, the property isn't there, or it's not a double,
+            // just leave it as is - this would be the normal case for non-scoring contests.
+        } 
+    }
+    
 	/**
 	 * Returns the flag indicating whether the cached copy of the contest standings are current (true),
 	 * or instead that some event has occured which potentially makes the standings out of date (false).

--- a/projects/WTI-API/src/main/controllers/TeamsController.java
+++ b/projects/WTI-API/src/main/controllers/TeamsController.java
@@ -18,6 +18,7 @@ import javax.ws.rs.GET;
 
 import edu.csus.ecs.pc2.api.exceptions.NotLoggedInException;
 import edu.csus.ecs.pc2.api.implementation.ProblemImplementation;
+import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.api.IClient;
@@ -455,7 +456,7 @@ public class TeamsController extends MainController {
 							run.isFinalJudged(),
 							run.isSolved(),
 							String.format("%s-%s", run.getSiteNumber(), run.getNumber()),
-							run.getScore()));
+							Utilities.formatScore(run.getScore())));
 				}
 				
 			}

--- a/projects/WTI-API/src/main/models/RunModel.java
+++ b/projects/WTI-API/src/main/models/RunModel.java
@@ -10,10 +10,10 @@ public class RunModel {
 	public long time;
 	public boolean isTestRun, isPreliminary, isFinal, isSolved;
 	public String id;
-	public double score;
+	public String score;
 
 	public RunModel(String teamID, String language, String problem, String judgement, List<File> result, long time, 
-			boolean isTestRun, boolean isPreliminary, boolean isFinal, boolean isSolved, String id, double score) {
+			boolean isTestRun, boolean isPreliminary, boolean isFinal, boolean isSolved, String id, String score) {
 		this.teamID = teamID;
 		this.language = language;
 		this.problem = problem;

--- a/projects/WTI-UI/src/app/modules/runs/components/new-run-alert/new-run-alert.component.html
+++ b/projects/WTI-UI/src/app/modules/runs/components/new-run-alert/new-run-alert.component.html
@@ -4,7 +4,7 @@
     <!-- <p>Type: {{ type }}</p> -->
     <p>Problem: {{ problem }}</p>
     <p>Judgement: {{ judgement }}</p>
-    <p *ngIf="showScore" class="score-animate">Score: {{ score | number:'1.3-3' }}</p>
+    <p *ngIf="showScore" class="score-animate">Score: {{ score }}</p>
     <p *ngIf='isPreliminary' style="color:red">This is a preliminary judgement!</p> 
 </div>
 <div mat-dialog-actions>

--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.html
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.html
@@ -88,7 +88,7 @@
 					<ng-container *ngIf="isPassFail"> {{ run.time }} </ng-container>					
 					<ng-container *ngIf="isPointScoring"> 
 						<ng-container *ngIf="hasAcceptedJudgement(run); else noScore"> 
-							{{ run.score | number:'1.3-3' }} <!-- format numbers with at least one whole digit and exactly 3 decimal digits -->
+							{{ run.score }}
 						</ng-container> 
 						<ng-template #noScore> 
 							<span title="Score shown only for accepted runs">--</span>

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -61,7 +61,7 @@
   							</ng-container>
 
   							<ng-container *ngIf="isPointScoring">
-    							{{ problem.attempts }}/{{ problem.score | number:'1.3-3' }} <!-- At least one whole digit; exactly 3 fractional digits -->
+    							{{ problem.attempts }}/{{ problem.score }}
   							</ng-container>
 
 						</ng-container>
@@ -83,8 +83,8 @@
   				</ng-container>
   				
 				<ng-container *ngIf="isPointScoring"> 
-					<!-- display total score, number-formatted with at least one whole digit and exactly 3 decimal digits-->
-					<td style="text-align: center"> {{ team.score | number:'1.3-3' }} </td>
+					<!-- display total score -->
+					<td style="text-align: center"> {{ team.score }} </td>
 				</ng-container>
 				
             </tr>

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -506,9 +506,9 @@ public class SubmissionService implements Feature {
                 return Response.status(Status.BAD_REQUEST).entity("invalid json supplied").build();
             }
 
-            // These next three are for admin users only
+            // These next two are for admin users only
             long overrideTimeMS = -1;
-            long overrideSubmissionID = -1;
+            long overrideSubmissionID = 0;
 
             Log log = controller.getLog();
             String user = sc.getUserPrincipal().getName();
@@ -591,7 +591,7 @@ public class SubmissionService implements Feature {
                 }
                 overrideSubmissionID = Utilities.stringToLong(sub.getId());
                 if(overrideSubmissionID < 0) {
-                    overrideSubmissionID = -1;
+                    overrideSubmissionID = 0;
                 }
             }
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.io.File;
@@ -53,7 +53,6 @@ import edu.csus.ecs.pc2.convert.EventFeedUtilities;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
-import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException.SubmissionRejectionReason;
 import edu.csus.ecs.pc2.core.log.Log;
 import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
@@ -358,21 +357,34 @@ public class SubmissionService implements Feature {
 
                     SerializedFile mainFile = runFiles.getMainFile();
                     SerializedFile[] otherFiles = runFiles.getOtherFiles();
+                    int fileIndex = 0;
+
                     java.nio.file.Path tmpDir = null;
                     try {
                         tmpDir = Files.createTempDirectory("subService");
                         // dump mainFile and otherFiles to tmpDir
                         HashMap<Integer, String> filesToWrite = new HashMap<Integer, String>();
-                        if (mainFile != null) {
-                            filesToWrite.put(Integer.valueOf(0), mainFile.getName());
+                        // Do not add entry for an empty mainfile name - could be it's included as otherFiles
+                        if (mainFile != null && !mainFile.getName().isEmpty()) {
+                            filesToWrite.put(Integer.valueOf(fileIndex), mainFile.getName());
+                            fileIndex++;
                             mainFile.buffer2file(mainFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + mainFile.getName());
                         }
                         if (otherFiles != null) {
                             for (int j = 0; j < otherFiles.length; j++) {
                                 SerializedFile serializedFile = otherFiles[j];
-                                filesToWrite.put(Integer.valueOf(j + 1), serializedFile.getName());
-                                serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
+                                // Do not add filenames that are empty strings.
+                                if(!serializedFile.getName().isEmpty()) {
+                                    filesToWrite.put(Integer.valueOf(fileIndex), serializedFile.getName());
+                                    fileIndex++;
+                                    serializedFile.buffer2file(serializedFile.getBuffer(), tmpDir.toAbsolutePath().toString() + File.pathSeparator + serializedFile.getName());
+                                }
                             }
+                        }
+                        // Make sure we're returning a valid source zip - that is, it must have files in it.
+                        if(fileIndex == 0) {
+                            controller.getLog().log(Log.INFO, "Returned runFiles was empty or all file names were empty strings; returning 'NOT_FOUND'");
+                            return Response.status(Status.NOT_FOUND).build();
                         }
                         String zipFileName = tmpDir.toAbsolutePath().toString() + File.pathSeparator + "files.zip";
                         createZip(submission, tmpDir, filesToWrite, zipFileName);

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.convert;
 
 import java.io.ByteArrayInputStream;
@@ -167,23 +167,24 @@ public final class EventFeedUtilities {
 
                 String entryName = entry.getName();
 
-//                ByteOutputStream byteOutputStream = new ByteOutputStream();
-                ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+                // Only add the file to the list if the file name is not an empty string.
+                // and it's not a directory entry.
+                if(!entryName.isEmpty() && !entryName.endsWith("/")) {
+                    ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 
-                byte[] buffer = new byte[8096];
-                int bytesRead = 0;
-                while ((bytesRead = zipStream.read(buffer)) != -1)
-                {
-                    byteOutputStream.write(buffer, 0, bytesRead);
+                    byte[] buffer = new byte[8096];
+                    int bytesRead = 0;
+                    while ((bytesRead = zipStream.read(buffer)) != -1)
+                    {
+                        byteOutputStream.write(buffer, 0, bytesRead);
+                    }
+
+                    String base64Data = getBase64Data(byteOutputStream.toByteArray());
+                    IFile iFile = new IFileImpl(entryName, base64Data);
+                    files.add(iFile);
+
+                    byteOutputStream.close();
                 }
-
-//                String base64Data = getBase64Data(byteOutputStream.getBytes());
-                String base64Data = getBase64Data(byteOutputStream.toByteArray());
-                IFile iFile = new IFileImpl(entryName, base64Data);
-                files.add(iFile);
-
-                byteOutputStream.close();
-
                 zipStream.closeEntry();
             }
             zipStream.close();

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.File;
@@ -224,7 +224,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
     /**
      * Load and Save configuration to disk
      */
-    private boolean saveCofigurationToDisk = true;
+    private boolean saveConfigurationToDisk = true;
 
     /**
      * Evaluations log (evals.log).
@@ -788,6 +788,20 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
     }
 
     /**
+     * If there are any DecimalFormats defined in the ini file(s) for scores, eg. for formatting scoreboard, runs, etc then
+     * Make sure those formats are valid, if not it's a fatal error.  We do this by simply trying to format a value
+     * and checking for an exception.
+     */
+    private void validateScoreFormats() {
+        try {
+            String szTestFormat = Utilities.formatScore(3.14159265358979);
+        } catch(Exception e) {
+            StaticLog.getLog().log(Log.SEVERE, "FATAL ERROR - Invalid scoring format in INI file", e);
+            fatalError("The scoring format specified in the INI file is invalid: " + e.getMessage());
+        }
+    }
+    
+    /**
      * Login to contest server.
      *
      * @param id
@@ -1160,7 +1174,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
 
             inContest.storeConfiguration(getLog());
         } else {
-            if (saveCofigurationToDisk) {
+            if (saveConfigurationToDisk) {
                 inContest.initializeSubmissions(inContest.getSiteNumber());
             }
             info("Loaded configuration from disk");
@@ -1171,7 +1185,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 logException(e);
             }
 
-            if (saveCofigurationToDisk) {
+            if (saveConfigurationToDisk) {
                 // save newly merged profiles
                 inContest.storeConfiguration(getLog());
             }
@@ -3004,7 +3018,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
 
 
 
-                    if (saveCofigurationToDisk) {
+                    if (saveConfigurationToDisk) {
                         // save newly merged profiles
                         contest.storeConfiguration(getLog());
                     }
@@ -3239,11 +3253,12 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 String currentDirectory = Utilities.getCurrentDirectory();
                 fatalError("Cannot start PC^2, " + IniFile.getINIFilename() + " file not found in " + currentDirectory);
             }
+            validateScoreFormats();
         }
-
+        
         // SOMEDAY code add NO_SAVE_OPTION_STRING
         if (parseArguments.isOptPresent(AppConstants.NO_SAVE_OPTION_STRING)) {
-            saveCofigurationToDisk = false;
+            saveConfigurationToDisk = false;
         }
 
         if (parseArguments.isOptPresent(AppConstants.SERVER_OPTION_STRING)) {
@@ -4177,7 +4192,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
     public boolean readConfigFromDisk(int siteNum) {
 
         boolean loadedConfiguration = false;
-        if (saveCofigurationToDisk) {
+        if (saveConfigurationToDisk) {
             try {
                 loadedConfiguration = contest.readConfiguration(siteNum, getLog());
 

--- a/src/edu/csus/ecs/pc2/core/Utilities.java
+++ b/src/edu/csus/ecs/pc2/core/Utilities.java
@@ -112,7 +112,7 @@ public final class Utilities {
      * and the key: format in the [scoring] section
      */
     private static final String POINT_SCORING_FORMAT_INI_KEY = "scoring.format";
-    private static final String DEFAULT_POINT_SCORING_FORMAT = "0.0##";
+    private static final String DEFAULT_POINT_SCORING_FORMAT = "0.000";
     private static DecimalFormat dfPointScore = null;
 
 

--- a/src/edu/csus/ecs/pc2/core/Utilities.java
+++ b/src/edu/csus/ecs/pc2/core/Utilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.BufferedReader;
@@ -14,6 +14,7 @@ import java.io.RandomAccessFile;
 import java.security.InvalidParameterException;
 import java.text.CharacterIterator;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
@@ -105,6 +106,15 @@ public final class Utilities {
      * SimpleDateFormat for iso8601 including milliseconds
      */
     private static SimpleDateFormat iso8601formatterWithMS = new SimpleDateFormat(ISO_8601_TIMEDATE_FORMAT_WITH_MS);
+    
+    /**
+     * Allows changing of the point scoring score format from the default using the pc2v9.ini file
+     * and the key: format in the [scoring] section
+     */
+    private static final String POINT_SCORING_FORMAT_INI_KEY = "scoring.format";
+    private static final String DEFAULT_POINT_SCORING_FORMAT = "0.0##";
+    private static DecimalFormat dfPointScore = null;
+
 
     /**
      * List of extensions for files considered to be executable.
@@ -2126,5 +2136,26 @@ public final class Utilities {
         return newArray;
     }
 
-
+    /**
+     * Format a score according to the format specified in the INI file.
+     * If no format found in the ini file, use the default.
+     * Note: You may ask "Why this isn't a "Setting" in ContestInformation (or something similar)?"
+     *     The answer is that some applications may wish to format the point scoring score differently.  This
+     *     allows those apps to set a specific format in the pc2v9.ini file.  (pc2board, pc2feeder, pc2admin to name a few).
+     * 
+     * @param score the score to format
+     * @return formatted score string
+     */
+    public static String formatScore(double score) {
+        
+        // first time through, create the formatter
+        if(dfPointScore == null) {
+            String scoreFormatString = IniFile.getValue(POINT_SCORING_FORMAT_INI_KEY);
+            if(StringUtilities.isEmpty(scoreFormatString)) {
+                scoreFormatString = DEFAULT_POINT_SCORING_FORMAT;
+            }
+            dfPointScore = new DecimalFormat(scoreFormatString);
+        }
+        return(dfPointScore.format(score));
+    }
 }

--- a/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/DefaultScoringAlgorithm.java
@@ -139,7 +139,6 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
 
     private boolean obeyFreeze = false;
 
-
     /**
      * @return the obeyFreeze
      */
@@ -877,8 +876,7 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
             standingsRecordMemento.putLong("lastSolved", standingsRecord.getLastSolved());
 
             if(contestInformation.isScoreboardTypeScore()) {
-                DecimalFormat df = new DecimalFormat("0.0###");
-                standingsRecordMemento.putString("score", df.format(standingsRecord.getScore()));
+                standingsRecordMemento.putString("score", Utilities.formatScore(standingsRecord.getScore()));
             } else {
                 standingsRecordMemento.putLong("points", standingsRecord.getPenaltyPoints());
             }
@@ -974,7 +972,7 @@ public class DefaultScoringAlgorithm implements IScoringAlgorithm {
                     psiMemento.putString("shortName", problems[problemsIndexHash.get(psi.getProblemId())-1].getShortName());
                     psiMemento.putInteger("attempts", psi.getNumberSubmitted());
                     psiMemento.putInteger("points", psi.getPenaltyPoints());
-                    psiMemento.putDouble("score", psi.getScore());
+                    psiMemento.putString("score", Utilities.formatScore(psi.getScore()));
                     psiMemento.putLong("solutionTime", psi.getSolutionTime());
                     psiMemento.putBoolean("isSolved", psi.isSolved());
                     psiMemento.putBoolean("isPending", psi.isUnJudgedRuns());

--- a/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
+++ b/src/edu/csus/ecs/pc2/core/scoring/NewScoringAlgorithm.java
@@ -67,7 +67,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
     private PermissionList permissionList = new PermissionList();
 
     private boolean isPointScoring = false;
-
+    
     /**
      * Return a list of regional winners.
      *
@@ -576,8 +576,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         standingsRecordMemento.putLong("lastSolved", standingsRecord.getLastSolved());
 
         if(contestInformation.isScoreboardTypeScore()) {
-            DecimalFormat df = new DecimalFormat("0.0###");
-            standingsRecordMemento.putString("score", df.format(standingsRecord.getScore()));
+            standingsRecordMemento.putString("score", Utilities.formatScore(standingsRecord.getScore()));
         } else {
             standingsRecordMemento.putLong("points", standingsRecord.getPenaltyPoints());
         }
@@ -887,7 +886,7 @@ public class NewScoringAlgorithm extends Plugin implements INewScoringAlgorithm 
         summaryInfoMemento.putString("shortName", summaryInfo.getShortName());
         summaryInfoMemento.putInteger("attempts", summaryInfo.getNumberSubmitted());
         summaryInfoMemento.putInteger("points", summaryInfo.getPenaltyPoints());
-        summaryInfoMemento.putDouble("score", summaryInfo.getScore());
+        summaryInfoMemento.putString("score", Utilities.formatScore(summaryInfo.getScore()));
         summaryInfoMemento.putLong("solutionTime", summaryInfo.getSolutionTime());
         summaryInfoMemento.putBoolean("isSolved", summaryInfo.isSolved());
         summaryInfoMemento.putBoolean("isPending", summaryInfo.isUnJudgedRuns());

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1459,7 +1459,7 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
                 if(oValue instanceof Double) {
                     value = (Double) oValue;
                 } else {
-                    value = new Double(((Integer)oValue).doubleValue());
+                    value = Double.valueOf(((Integer)oValue).doubleValue());
                 }
                 return value;
             } catch (Exception e) {

--- a/src/edu/csus/ecs/pc2/ui/RunsTablePane.java
+++ b/src/edu/csus/ecs/pc2/ui/RunsTablePane.java
@@ -9,6 +9,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
@@ -252,7 +253,7 @@ public class RunsTablePane extends JPanePlugin {
 
             if(isScoring) {
                 if(jrec != null) {
-                    score = Double.toString(jrec.getScore());
+                    score = Utilities.formatScore(jrec.getScore());
                 } else {
                     score = "0";
                 }


### PR DESCRIPTION
### Description of what the PR does
Allows configuring of the display format (`DecimalFormat`) used to format scores from a point scoring contest.

### Issue which the PR addresses
Fixes #1224 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
Ubuntu 24.04.3

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Load up any point scoring contest that is complete, eg. NAC2026 **challenge2024_test**, for example.  Details of obtaining the completed contest results can be directed to @johnbrvc .   Suffice to say, I have tested it with three different apps (**pc2admin**, **pc2board**, **pc2feeder**) all using different `pc2v9.ini` files with different formats for the point scores, and it appears to work as described in the issue.
#### The following additional details may also be helpful in testing the PR
- The "completed scoring contest" mentioned above, which can be used for testing, can be found at [this repo location](https://drive.google.com/drive/folders/11i55pRYbh4rJB4Vj2pCAY2TkK9eINysB?usp=drive_link). To use it:
  - Download the NAC2026-Challenge2024-test.zip contest from that link and unzip it.
  - Copy the `profiles` folder and the `profiles.properties` file into the PC2 folder where your PC2 distribution (what you are going to test) resides.  Be sure you have NOT started the PC2 Server before copying the profiles into PC2.
  - Start the PC2 Server.  This will automatically load the NAC2026-Challenge2024-test contest into PC2.
- Suggested testing steps:
1. **Verify that every Point Score display contains the correct default format, which is `0.000` (at least one whole digit and exactly 3 decimal digits), as follows:**
  - Start a PC2 Admin and look at the `Run Contest>Scoreboard` tab; ensure that the scores all have exactly three decimal places (this is the default).
  - Test that the PC2 scoreboard displays default-formatted scores properly:
    - On the PC2 Admin, check the `Configure Contest>Settings` tab and make sure the `Output HTML dir for Judges` and `Output Public HTML dir` paths point to a valid location on your machine (typically you'd want them pointing to locations under the PC2 distribution you are testing).
    - Start a PC2 Board client and verify that the point scores shown on the Board Client GUI all have exactly three decimal places.
    - In a browser, open the file `index_ps.html` in the "Judge's HTML" ("secret") folder.
    - Verify that the values in the "Score" column (next to each team name) all have exactly three decimal places.
  - Test that the PC2 Event Feed contains properly-formatted default scores:
    - Start feeder 1 client (**pc2ef --login ef1**), then press the Start button to start the feeder.
    - From a browser, open **https://localhost:50443/contests/nac25chall24practice/scoreboard**. When it prompts for user/password, use: **administrator1:administrator1**, or **admin:admin (from the realm.properties file, assuming you have one)**.
    - Execute the following command from a command line: 
        ```
           curl -k https://admin:admin@localhost:50443/contests/nac25chall24practice/scoreboard 
        ```
        (you can also use **administrator1:administrator1**. If you're using a pc2 account it must have the View Event Feeds permission. )
    - Verify that the "score" values in the resulting Event Feed output which are not integer numbers (e.g. 50.0) have exactly three decimal places.  (The CLICS API specifies that scores are _numbers_, which means that whole numbers will display in the event feed without decimal places.)
  - Test that the WTI displays default-formatted scores properly:
    - In the PC2 `projects` folder, unzip the WebTeamInterface.zip file.
    - In the resulting WebTeamInterface folder, start the WTI Server (`./bin/pc2wti`).
    - Open a browser and login to the WTI as a team (e.g. `team1` with password `decoy-sled-dwarf-idly`).
    - On the WTI `Runs` page, verify that every "Accepted" run has a score containing exactly 3 decimal digits.
    - On the WTI `Scoreboard` page, verify that:
      - Every green box (indicating an Accepted/Solved problem) has a score that contains exactly 3 decimal digits.
      - Every entry in the rightmost `Score` column has exactly 3 decimal digits.
2. **Verify that a bad `format` causes a client to fail to start, as follows:**
  - Shut down the PC2 Admin.
  - Edit the `pc2v9.ini` file in the root PC2 distribution folder by adding the following lines at the end:
    ```
    [scoring]
    format=0.00,00
    ```
    (The comma makes this an illegal format pattern.)
  - Restart the PC2 Admin, and verify that it fails to start and gives an error message that the format is illegal.
  
3. **Verify that changing to a non-default score format results in every Point Score display containing the correct (specified) format, as follows:**
  - Shut down the WTI browser, the WTI Server, and the PC2 Admin, Board, and Event Feed clients.
  - Edit the `pc2v9.ini` file in the root PC2 distribution folder by adding the following lines at the end:
    ```
    [scoring]
    format=0.00000
    ```
    (This forces the formatting of scores so that they have 5 decimal digits, regardless of the actual numeric value being displayed).
  - Restart the PC2 Admin, Board, and Event Feed clients (as described above), and verify that all the places where scores are displayed (as described above) now show FIVE decimal digits.
  - Edit the `pc2v9.ini` file under the `projects/WebTeamInterface` folder in a similar manner, except _use format `0.0000`_ (only **four** decimal digits).
  - Restart the WTI Server, then re-login to a team.
  - Verify that the `Runs` and `Scoreboard` pages now show scores containing exactly _four_ decimal digits.

4. **If you want to really go crazy:**
  - Start each of the PC2 Admin, Board, and EF clients in their own separate folder, each with its own `pc2v9.ini` file containing a different `format=x.xxx` value, and verify that each client displays its scores according to its own format specification.  Most people would consider this "overkill-testing"...
