### PR TITLE
i1236 point scoring point display fix

### DIFF
--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
@@ -145,7 +145,7 @@ export class RunsPageComponent implements OnInit, OnDestroy {
 	}
 
 	hasAcceptedJudgement(run: Run): boolean {
-		return !!run.judgement && (run.judgement.toLowerCase() === 'accepted' || run.judgement.toLowerCase() === 'yes');
-	}
+    return (run.score ?? 0) > 0 && ['accepted', 'yes'].includes(run.judgement?.toLowerCase() ?? '');	
+  }
 
 }

--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
@@ -145,7 +145,7 @@ export class RunsPageComponent implements OnInit, OnDestroy {
 	}
 
 	hasAcceptedJudgement(run: Run): boolean {
-		return !!run.judgement && run.judgement.toLowerCase() === 'accepted';
+		return !!run.judgement && (run.judgement.toLowerCase() === 'accepted' || run.judgement.toLowerCase() === 'yes');
 	}
 
 }

--- a/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/runs/components/runs-page/runs-page.component.ts
@@ -145,7 +145,7 @@ export class RunsPageComponent implements OnInit, OnDestroy {
 	}
 
 	hasAcceptedJudgement(run: Run): boolean {
-    return (run.score ?? 0) > 0 && ['accepted', 'yes'].includes(run.judgement?.toLowerCase() ?? '');	
+    return (run.score ?? 0) > 0 || ['accepted', 'yes'].includes(run.judgement?.toLowerCase() ?? '');	
   }
 
 }


### PR DESCRIPTION

### Description of what the PR does
Previously Score would show "--" for correct judgements. With this PR score shows the numeric score number.
Implementation basically checks the run judgement object to show if it should show the points and if it needs to it shows it by reading the correct field. 


Previously:
<img width="968" height="329" alt="588968267-19fa0fc9-4e98-45e6-97fb-e28de8a2e065" src="https://github.com/user-attachments/assets/04401180-50b3-44d1-9035-3406486ceefa" />

After: 
<img width="959" height="317" alt="588968670-031cc452-ed89-400b-9f7b-963c2cac7650" src="https://github.com/user-attachments/assets/442d534b-4417-4ce0-98ca-4d8f8cfe91eb" />


### Issue which the PR addresses
fixes_ #1236


### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, java version "1.8.0_381", Chrome Version 148.0.7778.96 (Official Build) (64-bit)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
- Start a point scoring contest. You can use NAC2026 challenge discussed below. 
- Login as one of the contestants. 
- Submit a correct answer to a problem as a contestant.
- Notice that in runs page instead of '--' there is your score attached to it.

### Additional Information
This issue was discovered at the NAC2026 contest.  It turned out to be because there was a validator which was returning the response string "Yes" for accepted runs, but the TypeScript code in the WTI-UI `runs-page.component` was only checking for the string "Accepted". An on-the-fly patch to check also for "Yes" was added during the contest, which fixed the problem.
