### PR TITLE
i_1247 Preserve autostop contest setting

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -1185,6 +1185,7 @@ public class ContestInformationPane extends JPanePlugin {
 
             newContestInformation.setLastRunNumberSubmitted(savedContestInformation.getLastRunNumberSubmitted());
             newContestInformation.setAutoStartContest(savedContestInformation.isAutoStartContest());
+            newContestInformation.setAutoStopContest(savedContestInformation.isAutoStopContest());
         }
 
         newContestInformation.setScoringProperties(scoringPropertiesPane.getProperties());
@@ -1994,7 +1995,7 @@ public class ContestInformationPane extends JPanePlugin {
         }
         return rigidArea3;
     }
-    
+
     private Component getRigidArea4() {
         if (rigidArea4==null) {
             rigidArea4 = Box.createRigidArea(new Dimension(20,20));


### PR DESCRIPTION
### Description of what the PR does
Saves the original contest's autostop contest setting in the newly created **ContestInformation** when changes are applied.

### Issue which the PR addresses
Fixes #1247 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1. Bring up a contest - any contest will do.
2. Bring up an administrator client.
3. On the **Configure Contest** -> **Times** tab, select the contest and press the **Edit** button.
4. Check the **Stop contest automatically** check box, and press the **Update** button.
5. Close the **Edit Contest Time** dialog.
6. Select the **Configure Contest** -> **Settings** tab.
7. Change the **Scoreboard Freeze Length** to something like: `1:10:00` (just to affect a change on the **ContestInformation**).  
8. Press the **Update** button to save the setting.
9. Go back to the **Configure Contest** -> **Times** tab, and select the contest and press the **Edit** button.
10. Note that the **Stop contest automatically** checkbox is still checked.
