### PR TITLE
i_1219 default rankings and configure medals

### DIFF
--- a/samps/contests/clics_sumithello/config/contest.yaml
+++ b/samps/contests/clics_sumithello/config/contest.yaml
@@ -8,3 +8,7 @@ duration:  05:00:00
 scoreboard_freeze_duration: 01:00:00
 penalty_time: 20
 scoreboard_type: pass-fail
+medals:
+  gold: 2
+  silver: 3
+  bronze: 4

--- a/samps/contests/clics_sumithello/config/system.pc2.yaml
+++ b/samps/contests/clics_sumithello/config/system.pc2.yaml
@@ -1,6 +1,8 @@
 
 max-output-size-K: 137
 
+wf_honors_ranking: false
+
 sites:
  - number: 1
    name: Site 1

--- a/src/edu/csus/ecs/pc2/core/model/FinalizeData.java
+++ b/src/edu/csus/ecs/pc2/core/model/FinalizeData.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.model;
 
 import java.io.Serializable;
@@ -198,5 +198,21 @@ public class FinalizeData implements Serializable {
      */
     public int getHonorSolvedCount() {
         return honorSolvedCount;
+    }
+
+
+    /**
+     * Generate some default finalize data
+     * @return FinalizeData object
+     */
+    public static FinalizeData getDefaultFinalizeData()
+    {
+        FinalizeData finalizeData = new FinalizeData();
+        finalizeData.setGoldRank(1);
+        finalizeData.setSilverRank(3);
+        finalizeData.setBronzeRank(6);
+        finalizeData.setCertified(false);
+        finalizeData.setUseWFGroupRanking(false);
+        return(finalizeData);
     }
 }

--- a/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
+++ b/src/edu/csus/ecs/pc2/exports/ccs/ResultsFile.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.exports.ccs;
 
 import java.util.ArrayList;
@@ -170,7 +170,8 @@ public class ResultsFile {
         int highHonorSolvedCount = 0;
 
         if (finalizeData == null) {
-            finalizeData = GenDefaultFinalizeData();
+            finalizeData = FinalizeData.getDefaultFinalizeData();
+            finalizeData.setComment("Preliminary Results - Contest not Finalized");
         }
         // Only use Bill honors WF ranking rules if not for a specific group and we're doing WF ranks
         // Calculating the Bill honors rules doesn't make sense for sub-groups
@@ -305,7 +306,8 @@ public class ResultsFile {
 
         finalizeData = contest.getFinalizeData();
         if (finalizeData == null) {
-            finalizeData = GenDefaultFinalizeData();
+            finalizeData = FinalizeData.getDefaultFinalizeData();
+            finalizeData.setComment("Preliminary Results - Contest not Finalized");
         }
 
         // The medal counts are fixed and are based solely on the order of finishing
@@ -507,21 +509,5 @@ public class ResultsFile {
         String xsltFileName = "results.tsv.xsl";
 
         return XMLUtilities.transformToArray(xmlString, xsltFileName);
-    }
-
-    /**
-     * Generate some default finalize data so we can make a results.tsv before the contest is finalized.
-     * @return FinalizeData object
-     */
-    private FinalizeData GenDefaultFinalizeData()
-    {
-        finalizeData = new FinalizeData();
-        finalizeData.setGoldRank(4);
-        finalizeData.setSilverRank(8);
-        finalizeData.setBronzeRank(12);
-        finalizeData.setCertified(false);
-        finalizeData.setComment("Preliminary Results - Contest not Finalized");
-        finalizeData.setUseWFGroupRanking(true);
-        return(finalizeData);
     }
 }

--- a/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/ContestSnakeYAMLLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.imports.ccs;
 
 import java.io.ByteArrayInputStream;
@@ -47,6 +47,7 @@ import edu.csus.ecs.pc2.core.model.ClientType;
 import edu.csus.ecs.pc2.core.model.ContestInformation;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.Filter;
+import edu.csus.ecs.pc2.core.model.FinalizeData;
 import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.InternalContest;
@@ -477,11 +478,11 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         //set allow-multiple-team-logins mode
         boolean allowMultipleTeamLogins = fetchBooleanValue(content, ALLOW_MULTIPLE_TEAM_LOGINS_KEY, contestInformation.isAllowMultipleLoginsPerTeam());
         contestInformation.setAllowMultipleLoginsPerTeam(allowMultipleTeamLogins);
-        
+
         //set allow-zero-length-submission-files mode
         boolean allowZeroLengthSubmissionFiles = fetchBooleanValue(content, ALLOW_ZERO_LENGTH_SUBMISSION_FILES_KEY, contestInformation.isAllowZeroLengthSubmissionFiles());
         contestInformation.setAllowZeroLengthSubmissionFiles(allowZeroLengthSubmissionFiles);
-        
+
         // Load team scoreboard string (the one with variables)
         String teamScoreboadDisplayString = fetchValue(content, TEAM_SCOREBOARD_DISPLAY_FORMAT_STRING, contestInformation.getTeamScoreboardDisplayFormat());
         contestInformation.setTeamScoreboardDisplayFormat(teamScoreboadDisplayString);
@@ -692,6 +693,59 @@ public class ContestSnakeYAMLLoader implements IContestLoader {
         if(scoreType != null && !scoreType.equals("pass-fail")) {
             throw new YamlLoadException("Invalid " + CLICS_CONTEST_SCOREBOARD_TYPE + ": " + scoreType + ", expected pass-fail");
         }
+
+        //get the map (if any) of the CLICS "medals" section in the contest.yaml file
+        Map<String, Object> medalsContent = fetchMap(content, CLICS_CONTEST_MEDALS);
+        boolean updateFinalizeData = false;
+        FinalizeData finalizeData = contest.getFinalizeData();
+        if(finalizeData == null) {
+            finalizeData = FinalizeData.getDefaultFinalizeData();
+        }
+        //if there is a CLICS "medals" section in the contest.yaml, read any values in that section and use
+        // them to override defaults
+        if (medalsContent != null) {
+            // get current (system default) ranks
+            int grank = finalizeData.getGoldRank();
+            int srank = finalizeData.getSilverRank();
+            int brank = finalizeData.getBronzeRank();
+            // get current medal counts
+            int gcnt = grank;
+            int scnt = srank - grank;
+            int bcnt = brank - srank;
+            // see if new counts specified in the "medals" object
+            Integer goldCount = fetchIntValue(medalsContent, CLICS_CONTEST_MEDAL_GOLD);
+            if(goldCount != null) {
+                gcnt = goldCount.intValue();
+            }
+            Integer silverCount = fetchIntValue(medalsContent, CLICS_CONTEST_MEDAL_SILVER);
+            if(silverCount != null) {
+                scnt = silverCount.intValue();
+            }
+            Integer bronzeCount = fetchIntValue(medalsContent, CLICS_CONTEST_MEDAL_BRONZE);
+            if(bronzeCount != null) {
+                bcnt = bronzeCount.intValue();
+            }
+            // new gold rank = gc, just saying...
+            int newsrank = gcnt + scnt;
+            int newbrank = newsrank + bcnt;
+            // if any ranks change, then we have to update them
+            if(gcnt != grank || newsrank != srank || newbrank != brank) {
+                updateFinalizeData = true;
+                finalizeData.setGoldRank(gcnt);
+                finalizeData.setSilverRank(newsrank);
+                finalizeData.setBronzeRank(newbrank);
+            }
+        }
+        boolean wfRankings = fetchBooleanValue(content, CONTEST_USE_WF_RANKING);
+        if(wfRankings != finalizeData.isUseWFGroupRanking()) {
+            finalizeData.setUseWFGroupRanking(wfRankings);
+            updateFinalizeData = true;
+        }
+        // if any finalize data has changed from the defaults, update the model
+        if(updateFinalizeData) {
+            contest.setFinalizeData(finalizeData);
+        }
+
         Object privatehtmlOutputDirectory = fetchObjectValue(content, OUTPUT_PRIVATE_SCORE_DIR_KEY);
         if (privatehtmlOutputDirectory != null) {
             if (privatehtmlOutputDirectory instanceof String) {

--- a/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
+++ b/src/edu/csus/ecs/pc2/imports/ccs/IContestLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.imports.ccs;
 
 import java.io.File;
@@ -66,6 +66,10 @@ public interface IContestLoader {
     final String CLICS_CONTEST_DURATION = "duration";
     final String CLICS_CONTEST_FREEZE_DURATION = "scoreboard_freeze_duration";
     final String CLICS_CONTEST_SCOREBOARD_TYPE = "scoreboard_type";
+    final String CLICS_CONTEST_MEDALS = "medals";
+    final String CLICS_CONTEST_MEDAL_GOLD = "gold";
+    final String CLICS_CONTEST_MEDAL_SILVER = "silver";
+    final String CLICS_CONTEST_MEDAL_BRONZE = "bronze";
     // This is not currently used, but penalty_time SHOULD be used instead of
     // reading it from properties. It is here for completeness, and, it happens
     // to be a required value in the yaml, but we do not enforce that.
@@ -106,6 +110,8 @@ public interface IContestLoader {
     String DEFAULT_CLARS_KEY = "default-clars";
 
     String CLAR_CATEGORIES_KEY = "clar-categories";
+
+    final String CONTEST_USE_WF_RANKING = "wf_honors_ranking";
 
     /**
      * Name for problem set in contest.yaml

--- a/src/edu/csus/ecs/pc2/ui/FinalizePane.java
+++ b/src/edu/csus/ecs/pc2/ui/FinalizePane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2024 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -199,20 +199,10 @@ public class FinalizePane extends JPanePlugin {
         return Integer.parseInt(s);
     }
 
-    private void populateDefaults() {
-        getGoldCountTextField().setText("4");
-        getSilverCountTextField().setText("4");
-        getBronzeCountTextField().setText("4");
-        getUseWFGroupRankingsCheckBox().setSelected(true);
-        getCustomizeHonorsSolvedCountCheckBox().setSelected(false);
-        getCustomizeHonorsSolvedCountWhatsThisButton().setEnabled(true);
-        setEnableHonorsCountFields(false);
-    }
-
     /**
      * This method Enables/Disables Honors solved count text fields
-     * 
-     * @param isEnabled 
+     *
+     * @param isEnabled
      */
     private void setEnableHonorsCountFields(boolean isEnabled) {
         getHighestHonorSolvedCountTextField().setText("");
@@ -229,6 +219,9 @@ public class FinalizePane extends JPanePlugin {
     protected void reloadFrame() {
 
         FinalizeData data = getContest().getFinalizeData();
+        if(data == null) {
+            data = FinalizeData.getDefaultFinalizeData();
+        }
         if (data != null) {
             int gr = data.getGoldRank();
             int sr = data.getSilverRank();
@@ -270,16 +263,16 @@ public class FinalizePane extends JPanePlugin {
             if (data.isCertified()) {
                 certificationCommentLabel.setText("Contest Finalized (Certified done)");
                 certificationCommentLabel.setToolTipText("Certified at: " + data.getCertificationDate());
+            } else {
+                certificationCommentLabel.setText("Contest not finalized");
+                certificationCommentLabel.setToolTipText("");
             }
 
+            enableButtons();
         } else {
-            certificationCommentLabel.setText("Contest not finalized");
-            certificationCommentLabel.setToolTipText("");
-            populateDefaults();
+            // Tammy, data can not be null, if it is, something really bad is going on, and we will therefore, do nothing.
+            getLog().log(Level.WARNING, "FinalizePane: finalizedata is null");
         }
-
-        enableButtons();
-
     }
 
     /**
@@ -649,7 +642,7 @@ public class FinalizePane extends JPanePlugin {
     private JTextField getCommentTextField() {
         if (commentTextField == null) {
             commentTextField = new JTextField();
-            commentTextField.setBounds(new Rectangle(250, 168, 207, 20));
+            commentTextField.setBounds(new Rectangle(250, 168, 307, 20));
         }
         return commentTextField;
     }
@@ -782,7 +775,7 @@ public class FinalizePane extends JPanePlugin {
             + "\nThen both Highest Honors and Honors by default will be 7 problems and High Honors is 6 problems solved." //
             + "\nAll teams (except medalists) solving 7 problems will get Highest Honors and the team solving 6 problems get High Honors" //
             + " \n\n";
-    
+
     private Image getScaledImage(Image srcImg, int w, int h) {
         BufferedImage resizedImg = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2 = resizedImg.createGraphics();


### PR DESCRIPTION
### Description of what the PR does
Make the default rankings be for non-_World Finals Honors_ type events and medal counts of 1 gold, 2 silver, 3 bronze instead of 4G/4S/4S.
Allow configuration of medals in the `contest.yaml` using the non-standard **medals**: object.  Many contests appear to include the medal counts in the `contest.yaml`, so it seems harmless to support this extension to the specification.
Add boolean config parameter **wf_honors_ranking** to `system.pc2.yaml` for using _World Finals Honors_ rankings (default is **false**).

NOTE: The code in this PR branch was used at NAC2026.

### Issue which the PR addresses
Fixes #1219

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

Also tested using Ubuntu 24.04.3:
openjdk version "21.0.8" 2025-07-15
OpenJDK Runtime Environment (build 21.0.8+9-Ubuntu-0ubuntu124.04.1)
OpenJDK 64-Bit Server VM (build 21.0.8+9-Ubuntu-0ubuntu124.04.1, mixed mode, sharing)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

__Test defaults__

1. Start a clean contest using the sample **sumithello**.
2. Start an administrator client and log in using **administrator1**.
3. Select the **Run Contest**->**Finalize** tab.
4. Note that the defaults for the medals 1 gold, 2 silvers, 3 bronzes.  Before this PR they were 4 gold, 4 silvers and 4 bronzes.
5. Note that the "**Use World Finals group rankings for results**" is not checked.  Before this PR it was checked by default.

__Test reading medal counts from `contest.yaml`__

1. Start a clean contest using the sample **clics_sumithello**.
2. Start an administrator client and log in using **administrator1**.
3. Select the **Run Contest**->**Finalize** tab.
4. Note that the medal counts are 2 golds, 3 silvers, 4 bronzes.  Before this PR they were 4 gold, 4 silvers and 4 bronzes.  These new medal counts came from the `contest.yaml` file in the **clics_sumithello** sample contest.
5. Note that the "**Use World Finals group rankings for results**" is not checked.  Before this PR it was checked by default.

__Test reading medal counts and **World Finals Honors** ranking flag from `contest.yaml` and `system.pc2.yaml`__
1. Make a temporary edit to the `samps/contests/clics_sumithello/config/system.pc2.yaml` file by changing the line:
`wf_honors_ranking: false`
to
`wf_honors_ranking: true`
2. Start a clean contest using the sample **clics_sumithello**
3. Start an administrator client and log in using **administrator1**.
4. Select the **Run Contest**->**Finalize** tab.
5. Note that the medal counts are 2 golds, 3 silvers, 4 bronzes.  Before this PR they were 4 gold, 4 silvers and 4 bronzes.  These new medal counts came from the `contest.yaml` file in the **clics_sumithello** sample contest.
6. Note that the "**Use World Finals group rankings for results**" is now checked due to the setting that was just changed in `system.pc2.yaml`.
7. Revert the change you made to the `system.pc2.yaml` file do it does not accidentally get pushed back to the repo.







