### PR TITLE
i_1232 Add pc2v9.ini config settings for throttle strategies

### DIFF
--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -42,7 +42,7 @@ apiVersionsSupported=2023-06,2020-03
 # accounts configured by the CDS.  This is not desirable.
 disable-collections=accounts
 
-#[throttle-strategies]
+#[throttle-strategy-settings]
 #maxSubmissionsPerMinute=5
 
 # eof 

--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -41,4 +41,8 @@ apiVersionsSupported=2023-06,2020-03
 # since the CDS will interpret a collection as a complete list of accounts and remove any
 # accounts configured by the CDS.  This is not desirable.
 disable-collections=accounts
+
+#[throttle-strategies]
+#maxSubmissionsPerMinute=5
+
 # eof 

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -636,7 +636,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
             sendToLocalServer(packet);
         } else {
-            throw new SubmissionRejectedException("Submission threshold exceeded", 
+            throw new SubmissionRejectedException("Submission threshold exceeded - wait a minute and try again", 
                                                     SubmissionRejectedException.SubmissionRejectionReason.THROTTLE_EXCEEDED);
         }
     }
@@ -5063,7 +5063,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideSubmissionId);
             sendToLocalServer(packet);
         } else {
-            throw new SubmissionRejectedException("Submission threshold exceeded",
+            throw new SubmissionRejectedException("Submission threshold exceeded - wait a minute and try again",
                                                     SubmissionRejectedException.SubmissionRejectionReason.THROTTLE_EXCEEDED);
         }
     }

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core;
 
 import java.io.File;
@@ -622,7 +622,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 // GUI (such as the PC2 Admin)
     //            IThrottleStrategy strategy = new AcceptAllStrategy();
     //            IThrottleStrategy strategy = new RejectAllStrategy();
-                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,6);
+                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest);
     //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
     //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest); //uses DEFAULT_MAX_SUBMISSIONS_PER_MINUTE; same as prev line
                 accept = strategy.accept(run);
@@ -5025,7 +5025,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 // GUI (such as the PC2 Admin)
     //            IThrottleStrategy strategy = new AcceptAllStrategy();
     //            IThrottleStrategy strategy = new RejectAllStrategy();
-                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 6);
+                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest);
     //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
 
                 accept = strategy.accept(run);

--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -636,7 +636,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideSubmissionTimeMS, overrideRunId, overrideStopOnFailure);
             sendToLocalServer(packet);
         } else {
-            throw new SubmissionRejectedException("Submission threshhold exceeded", 
+            throw new SubmissionRejectedException("Submission threshold exceeded", 
                                                     SubmissionRejectedException.SubmissionRejectionReason.THROTTLE_EXCEEDED);
         }
     }
@@ -786,6 +786,28 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
         }
         return s;
     }
+    
+    /**
+     * Check INI file settings specific sub-systems.  These settings may not actually be
+     * used until the system is up, so we have to validate them at startup time.
+     */
+    private void validateIniSubSystemSettings() {
+        if(!validateThrottleStrategySettings()) {
+            StaticLog.getLog().log(Log.SEVERE, "FATAL ERROR - Invalid throttle strategy setting in INI file");
+            // Put up the standard fatal pop-up with the famous "check logs" message.  The details
+            // of the bad setting will be in the log.
+            fatalError("Throttle strategy settings specified in the INI file are invalid");
+            // No return
+        }
+    }
+    
+    /**
+     * Validate the settings for throttling strategies
+     */
+    private boolean validateThrottleStrategySettings() {
+        return MaxSubmissionsPerMinuteStrategy.validateConfigurationSettings();
+    }
+    
 
     /**
      * Login to contest server.
@@ -3239,6 +3261,9 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 String currentDirectory = Utilities.getCurrentDirectory();
                 fatalError("Cannot start PC^2, " + IniFile.getINIFilename() + " file not found in " + currentDirectory);
             }
+            // Check specific settings for sub-systems.  In the event of a bad setting,
+            // this will not return since it would call fatalError().
+            validateIniSubSystemSettings();
         }
 
         // SOMEDAY code add NO_SAVE_OPTION_STRING
@@ -5038,7 +5063,7 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
             Packet packet = PacketFactory.createSubmittedRun(contest.getClientId(), serverClientId, run, runFiles, overrideTimeMS, overrideSubmissionId);
             sendToLocalServer(packet);
         } else {
-            throw new SubmissionRejectedException("Submission threshhold exceeded",
+            throw new SubmissionRejectedException("Submission threshold exceeded",
                                                     SubmissionRejectedException.SubmissionRejectionReason.THROTTLE_EXCEEDED);
         }
     }

--- a/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
+++ b/src/edu/csus/ecs/pc2/core/exception/SubmissionRejectedException.java
@@ -1,11 +1,11 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.exception;
 
 import edu.csus.ecs.pc2.core.IThrottleStrategy;
 
 /**
  * This exception is intended to be thrown when a team makes a submission ("submits a Run" in PC2 terminology)
- * but the system refuses to accept the run, for example due to the team having exceeded the submission threshhold
+ * but the system refuses to accept the run, for example due to the team having exceeded the submission threshold
  * defined by the current {@link IThrottleStrategy}.
  *
  * @author John Clevenger

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -37,8 +37,10 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
             String maxSubsPerMin = IniFile.getValue(MAX_SUBS_PER_MINUTE_KEY);
             maxPerMinute = StringUtilities.getIntegerValue(maxSubsPerMin, DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
         } catch(Exception e) {
-            // if there is any problem reading the INI or a bad integer conversion, this does not warrant a complete failure
-            // of the submission.  Rather, we'll use the default and log the error.
+            // this should not happen, tammy, since we validated this setting at startup.
+            // However, if there is any problem reading the INI for some reason, or a bad integer conversion,
+            // this does not warrant a complete failure of the submission.  Rather, we'll use the default
+            // and log the error.
             maxPerMinute = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE;
             StaticLog.warning("MaxSubmissionsPerMinuteStrategy: Bad INI file setting '" + MAX_SUBS_PER_MINUTE_KEY + "': " + e);
         }
@@ -61,7 +63,7 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
     public boolean accept(Run run) {
         return !numSubmittedInTheLastMinuteExceedsMaximum(contest, run);
     }
-
+    
     /**
      * Queries the specified contest to obtain the complete list of runs, then determines whether 
      * the count of runs previously submitted in the last minute by the new-run submitter
@@ -114,6 +116,29 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
         }
         
         return limitReached ;
+    }
+
+    /**
+     * Check ini file settings for validity.
+     * This is typically called at client startup time to make sure any settings this
+     * class needs from the INI file are valid.
+     */
+    public static boolean validateConfigurationSettings() {
+        // by default, settings are valid
+        boolean valid = true;
+        try {
+            String maxSubsPerMin = IniFile.getValue(MAX_SUBS_PER_MINUTE_KEY);
+            int maxPerMinute = StringUtilities.getIntegerValue(maxSubsPerMin, DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+            if(maxPerMinute <= 0) {
+                StaticLog.warning("MaxSubmissionsPerMinuteStrategy: The value for INI file setting '" + MAX_SUBS_PER_MINUTE_KEY + "' is invalid: " + maxPerMinute);
+                valid = false;
+            }
+        } catch(Exception e) {
+            // if there is any problem reading the INI or a bad integer conversion, then the setting is bad.
+            valid = false;
+            StaticLog.warning("MaxSubmissionsPerMinuteStrategy: Bad INI file setting '" + MAX_SUBS_PER_MINUTE_KEY + "': " + e);
+        }
+        return valid;
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -20,7 +20,7 @@ import edu.csus.ecs.pc2.core.model.Run;
 public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
     
     public static int DEFAULT_MAX_SUBMISSIONS_PER_MINUTE = 6 ;
-    public static final String MAX_SUBS_PER_MINUTE_KEY = "throttle-strategies.maxSubmissionsPerMinute";
+    public static final String MAX_SUBS_PER_MINUTE_KEY = "throttle-strategy-settings.maxSubmissionsPerMinute";
 
     private  IInternalContest contest;
     private int maxPerMinute;

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinuteStrategy.java
@@ -1,7 +1,10 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.strategies;
 
 import edu.csus.ecs.pc2.core.IThrottleStrategy;
+import edu.csus.ecs.pc2.core.IniFile;
+import edu.csus.ecs.pc2.core.StringUtilities;
+import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
@@ -16,7 +19,8 @@ import edu.csus.ecs.pc2.core.model.Run;
  */
 public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
     
-    public static int DEFAULT_MAX_SUBMISSIONS_PER_MINUTE = 10 ;
+    public static int DEFAULT_MAX_SUBMISSIONS_PER_MINUTE = 6 ;
+    public static final String MAX_SUBS_PER_MINUTE_KEY = "throttle-strategies.maxSubmissionsPerMinute";
 
     private  IInternalContest contest;
     private int maxPerMinute;
@@ -28,7 +32,16 @@ public class MaxSubmissionsPerMinuteStrategy implements IThrottleStrategy {
      */
     public MaxSubmissionsPerMinuteStrategy (IInternalContest inContest) {
         this.contest = inContest ;
-        this.maxPerMinute = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE ;
+        
+        try {
+            String maxSubsPerMin = IniFile.getValue(MAX_SUBS_PER_MINUTE_KEY);
+            maxPerMinute = StringUtilities.getIntegerValue(maxSubsPerMin, DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
+        } catch(Exception e) {
+            // if there is any problem reading the INI or a bad integer conversion, this does not warrant a complete failure
+            // of the submission.  Rather, we'll use the default and log the error.
+            maxPerMinute = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE;
+            StaticLog.warning("MaxSubmissionsPerMinuteStrategy: Bad INI file setting '" + MAX_SUBS_PER_MINUTE_KEY + "': " + e);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description of what the PR does
Add ability to set number of submissions per second in the `pc2v9.ini` file for the `core.strategies.MaxSubmissionsPerMinuteStrategy`.
The only throttling strategies that are implemented in PC2 are:
```
1. AcceptAllStrategy
2. RejectAllStrategy
3. MaxSubmissionsPerMinuteStrategy
```
At this time, it only makes sense to configure the `MaxSubmissionsPerMinuteStrategy`'s maximum number of submissions per second, rather than having it hard-coded and unchangeable after a contest is configured.  The `AcceptAllStrategy `and `RejectAllStrategy `do not have / need any configurable values.

The way to implement throttling strategy settings in the `pc2v9.ini` file is to place keys in the (new) `[throttle-strategy-settings]` section.  It is up to the specific strategy implementation to decide on meaningful names for any setting's key(s).  For the `MaxSubmissionsPerMinuteStrategy` strategy, the `maxSubmissionsPerMinute `key allows changing the maximum number of submissions permitted per minute (by a team, per problem).  At some point, it may be desirable to modify the `MaxSubmissionsPerMinuteStrategy` strategy to allow setting different limits on a _per-problem_ basis, or perhaps, a limit on total _overall_ submissions per minute. Here is an example section that may appear in the `pc2v9.ini` file to set the maximum number of submissions per minute per problem per team to **3**:

```
[throttle-strategy-settings]
maxSubmissionsPerMinute=3
```

CI: Remove hard-coded constants in `InternalController `used to instantiate `MaxSubmissionsPerMinuteStrategy`.

This PR was included in the PC2 that was used at NAC2026.

Note: This PR is **NOT** meant to address the issue of dynamic selection of throttling algorithms as discussed in the comments for #1232.  This PR is meant to address the parameters that any throttling strategy may need.  A separate issue will be created for allowing dynamic configuration of which throttling strategies to use and how to allow selection of those strategies in PC2.

### Issue which the PR addresses
Fixes #1232 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

Also tested using Ubuntu 24.04.3:
openjdk version "21.0.8" 2025-07-15
OpenJDK Runtime Environment (build 21.0.8+9-Ubuntu-0ubuntu124.04.1)
OpenJDK 64-Bit Server VM (build 21.0.8+9-Ubuntu-0ubuntu124.04.1, mixed mode, sharing)


### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
The test procedure is arduous and takes a great deal of precision.  If you make a mistake, thinks won't work, so be very careful when testing.  Any issue you run into will almost certainly be a "user error".  It took a GREAT deal of time (2+ hours) to generate this test procedure, so please don't just dismiss it and say "it's too much work to test".  Please go through the steps and test it.

1. Start up a clean server using the sample **clics_sumithello** contest.
2. Start up an administrator client and sign in using **administrator1**
3. On the **Configure Contest** -> **Accounts** tab, select the **Generate** button.
4. Generate 1 **FEEDER** account (select **FEEDER** from the combo-box, and enter a **1** in the box to the right of it.
5. Press the **Generate Accounts for Site 1** button.
6. Close the **Generate Account** dialog
7. Select the newly added "**feeder1**" account and press the **Edit** button.
8. In the **Permissions/Abilities** pane on the right, check the "**Shadow Proxy Team**" check box, and press **Update**.
9. On the administrator **Configure Contest** -> **Settings** tab, scroll all the way to the bottom, and check the "**Enable CCS Test Mode**" in the **CCS Test Mode** group box, then press the **Update** button.
10. Start an event feeder client and log in using the newly created "**feeder1**" account.
11. On the **Web Services** tab, press the **Start** button to start the CLICS event feeder.
12. Start the contest using the administrator client, **Configure Contest** -> **Times** tab and press **Start All**.
13. Switch to the **Run Contest** -> **Runs** tab on the administrator client.
14. From a command prompt, navigate to the where you installed PC2 or from the main pc2v9 source folder.
15. Run: `python bin/pc2submit -u https://localhost:50443 -t 1 -p a -y samps/src/hello.cpp` 
     (Your mileage may vary w/r/t python.  You may need to use **python3** or **py** to run the `pc2submit `script).  This will make a submission for team 1 (`-t 1`) to problem A (`-p a`) using source file `samps/src/hello.cpp`.  We do not need any judges running.  We are only interested in making submissions - not judging them.
16. Assuming the submission was a success, you should see it on the **Runs** tab.  If the submission failed, it probably means there is some problem with your system login account's `.netrc` file found in your home directory.  There should be a line in it that looks like this:
`machine localhost login administrator1 password administrator1`
It is beyond the scope of this PR to teach you how to configure your `.netrc `on whatever OS you are on.  That is left as an exercise to the tester and no additional help will be provided (so, don't ask).
17. Now, re-execute that command 7 (or more) additional times in quick succession (in < 1 minute).
18. After the 6th submission, you should receive an error indicating "**Submission threshold exceeded - wait a minute and try again.**"
19. We have just proven that you can make submissions successfully and, the default limit of 6 submissions per minute is in effect.
20. Edit the `pc2v9.ini `file and uncomment and change the lines toward the end of the file as shown:
```
[throttle-strategy-settings]
maxSubmissionsPerMinute=1
```
This will limit you to 1 submission per minute.

21. Close and restart the "**feeder1**" event feed client.  This will cause it to re-read the **pc2v9.ini** file to use the new settings.
22. Press the **Start** button on the event feeder client to start the CLICS API.
23. Now try to make 2 submissions (as described above) in quick succession.  Since we set the limit to 1 per minute, only the first one should succeed, the second should get an error indicating "**Submission threshold exceeded - wait a minute and try again.**" as shown below:
```
C:\MyNetProjects\ICPC\pc2ccs\pc2v9>python bin/pc2submit -u https://localhost:50443 -t 1 -p a -y samps/src/hello.cpp
Warning: `samps/src/hello.cpp' has not been modified for 1109792 minutes!
Submission threshold exceeded - wait a minute and try again.
```
24. If you are so inclined, you can also start up a **pc2team** team client, and make 2 quick submissions that way - you should get an error on the second submission.  
25. If you are so inclined, you can start up the WTI and make submissions using the WTI as well (that process is not described here).











