### PR TITLE
i_1227 Workaround ZipStreamer zero length file bug

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -659,6 +659,11 @@ public class SubmissionService implements Feature {
                 }
 
                 srcFiles = EventFeedUtilities.getIFiles(firstFile.getData());
+                // handle empty list of src files.
+                if(srcFiles.isEmpty()) {
+                    log.info(user + " Attempt to submit empty source file in archive for problem " + prob.getShortName() + " on behalf of team " + team_id);
+                    return Response.status(Response.Status.BAD_REQUEST).entity("submission source files are empty").build();
+                }
             }
             String entry = sub.getEntry_point();
             IFile mainFile = srcFiles.get(0);

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -14,6 +14,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
+import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.core.model.IFileImpl;
 
@@ -27,6 +28,8 @@ public final class EventFeedUtilities {
 
     public static final long MS_PER_SECOND = 1000;
     public static final String ZIP_DEFLATE_EXT_ERROR = "only DEFLATED entries can have EXT descriptor";
+    // Somewhat arbitrary - more of a sentinel with a touch of paranoia.
+    public static final int MAX_ZIP_ENTRIES_TO_PROCESS = 1000;
 
     private EventFeedUtilities() {
         super();
@@ -162,13 +165,15 @@ public final class EventFeedUtilities {
         try {
             zipStream = new ZipInputStream(new ByteArrayInputStream(bytes));
             ZipEntry entry = null;
+            int nEnt;
+            
             /**
              * Read each zip entry, add IFile.
              * We use a separate try block here since there is a deficiency with Java 8 ZipInputStream where
              * you'll get a: "only DEFLATED entries can have EXT descriptor" ZipException if an entry is 0 bytes in length.
              * So we check that specifically, since it is legal.
              */
-            for(;;) {
+            for(nEnt = 0; nEnt < MAX_ZIP_ENTRIES_TO_PROCESS; nEnt++) {
                 try {
                     entry = zipStream.getNextEntry();
                     if(entry == null) {
@@ -207,6 +212,10 @@ public final class EventFeedUtilities {
                     }
                 } 
                 zipStream.closeEntry();
+            }
+            // If we maxed out on reading entries, log it in case someone cares later.
+            if(nEnt >= MAX_ZIP_ENTRIES_TO_PROCESS) {
+                StaticLog.warning(ZIP_DEFLATE_EXT_ERROR);
             }
             zipStream.close();
         } catch (Exception e) {

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
 import edu.csus.ecs.pc2.core.model.IFile;
@@ -25,6 +26,7 @@ import edu.csus.ecs.pc2.core.model.IFileImpl;
 public final class EventFeedUtilities {
 
     public static final long MS_PER_SECOND = 1000;
+    public static final String ZIP_DEFLATE_EXT_ERROR = "only DEFLATED entries can have EXT descriptor";
 
     private EventFeedUtilities() {
         super();
@@ -162,33 +164,51 @@ public final class EventFeedUtilities {
             ZipEntry entry = null;
             /**
              * Read each zip entry, add IFile.
+             * We use a separate try block here since there is a deficiency with Java 8 ZipInputStream where
+             * you'll get a: "only DEFLATED entries can have EXT descriptor" ZipException if an entry is 0 bytes in length.
+             * So we check that specifically, since it is legal.
              */
-            while ((entry = zipStream.getNextEntry()) != null) {
-
-                String entryName = entry.getName();
-
-                // Only add the file to the list if the file name is not an empty string.
-                // and it's not a directory entry.
-                if(!entryName.isEmpty() && !entryName.endsWith("/")) {
-                    ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-
-                    byte[] buffer = new byte[8096];
-                    int bytesRead = 0;
-                    while ((bytesRead = zipStream.read(buffer)) != -1)
-                    {
-                        byteOutputStream.write(buffer, 0, bytesRead);
+            for(;;) {
+                try {
+                    entry = zipStream.getNextEntry();
+                    if(entry == null) {
+                        break;
                     }
-
-                    String base64Data = getBase64Data(byteOutputStream.toByteArray());
-                    IFile iFile = new IFileImpl(entryName, base64Data);
-                    files.add(iFile);
-
-                    byteOutputStream.close();
-                }
+                    String entryName = entry.getName();
+                    
+                    // Only add the file to the list if the file name is not an empty string.
+                    // and it's not a directory entry.
+                    if(!entryName.isEmpty() && !entryName.endsWith("/")) {
+                        ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+    
+                        byte[] buffer = new byte[8096];
+                        int bytesRead = 0;
+                        while ((bytesRead = zipStream.read(buffer)) != -1)
+                        {
+                            byteOutputStream.write(buffer, 0, bytesRead);
+                        }
+    
+                        String base64Data = getBase64Data(byteOutputStream.toByteArray());
+                        IFile iFile = new IFileImpl(entryName, base64Data);
+                        files.add(iFile);
+    
+                        byteOutputStream.close();
+                    }
+                } catch (ZipException e) {
+                    String msg = e.getLocalizedMessage();
+                    // If not the single exception we ignore, then abort like we used to
+                    if(msg == null || !msg.equals(ZIP_DEFLATE_EXT_ERROR)) {
+                        try {
+                            zipStream.close();
+                        } catch (Exception ze) {
+                            ; // problem closing stream, ignore.
+                        }
+                        throw new RuntimeException(e);
+                    }
+                } 
                 zipStream.closeEntry();
             }
             zipStream.close();
-
         } catch (Exception e) {
             if (zipStream != null){
                 try {


### PR DESCRIPTION
### Description of what the PR does
Catch the `ZipException` caused by reading a zip file that has a zero length file in it.  We look at the error message string generated by the `ZipStreamer` in the `ZipException`.  If it is the error message of interest, eg. "**only DEFLATED entries can have EXT descriptor**", ignore it, and return with whatever files have been accumulated so far.  Any other error will cause an exception as it did previously.

The issue, #1227 has a description of what is going on and a reference to a Stack Overflow article describing it.  This PR simply works around this problem.

### Issue which the PR addresses
Fixes #1227 
Fixes #1217 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
The attached zip file, [i_1227.zip](https://github.com/user-attachments/files/26715162/i_1227.zip), contains files the allows you to test this PR in the quickest way possible (without replaying an entire Kattis contest).  The zip file contains the following structure:
```
i_1227\
   13706813.zip - The Kattis submission that aggravates the original issue
           (it contains 2 files, one OK, the other is zero length)
   hello.java - copy of the samps/src/hello.java - really a dummy placeholder as you'll see
   pc2submit - special version of the Python pc2submit command that will use the
            Kattis submission zip (above) instead of making a new zip.
```

1. Start a clean contest using the **pointscoring** sample contest.
2. Start an **administrator1** client.
3. Add a single team account using the **Generate** button on the **Accounts** tab.
4. On the administrator **Settings** tab , scroll all the way down to the **Remote CCS Settings** and check the **Enable CCS Test Mode** box.
5. Start the **feeder1** event feeder client.
6. Start the contest on the administrator **Times** tab, press **Start All**.
7. Extract the attached zip file, preserving the structure described above.  The zip expects to be extracted into `/tmp` (`\tmp`), since the custom `pc2submit `in the zip has a hardcoded path.  If you use a different folder, you'll have to update the `pc2submit `extracted from the zip to use whatever path you extracted to.
8. Create a command prompt and change to the extracted `i_1227` folder.
9. Execute the following command:
     `py pc2submit -y -p a hello.java -t 1 -u https://administrator1:administrator1@localhost:50443`
     The `hello.java `program is a dummy to satisfy the requirement of supplying a source code file.  In reality, the special version of **pc2submit** ignores this file, and simply submits the supplied `13706813.zip` Kattis file which contains a zero length file.
10. You should get an error back that says: **Submission failed (code 400 - submission source files are empty)**

```
C:\tmp\i_1227>py pc2submit -y -p a hello.java -t 1 -u https://administrator1:administrator1@localhost:50443
Warning: 'hello.java' has not been modified for 1118226 minutes!
Submission information:
  filename:    hello.java
  contest:     pointscoring
  problem:     A
  language:    Java
  url:         https://administrator1:administrator1@localhost:50443/
There are warnings for this submission!
Submission failed (code 400 - submission source files are empty)
```
11. If you want to set a breakpoint and trace through the new code, in pc2/convert/EventFeedUtilities.java, set it at line 198.

If the **pc2submit** command complains about bad credentials or other connection nonsense, you will have to diagnose that yourself.  The credential information on Windows is kept in `\users\USERNAME\.netrc`.  My `.netrc` contains the following:
`machine localhost login administrator1 password administrator1`
The PR author will not provide assistance in tracking down credential errors, firewall issues or other "user related" problems on your system.





