### PR TITLE
i_1231 Handle ignore_sample if no sample folder in root

### DIFF
--- a/src/edu/csus/ecs/pc2/core/execute/Executable.java
+++ b/src/edu/csus/ecs/pc2/core/execute/Executable.java
@@ -925,7 +925,8 @@ public class Executable extends Plugin implements IExecutable, IExecutableNotify
         }
         
         //we've recursed to the lowest level in the test case tree; create a Grader to get a Result (acronym and score) for this level
-        LegacyGrader grader = new LegacyGrader(prefixExecuteDirname("graderLog-" + tdg.getGroupName().replace(File.separator, "_") + ".txt"));
+        boolean isRoot= (tdg.getParent() == null);
+        LegacyGrader grader = new LegacyGrader(prefixExecuteDirname("graderLog-" + tdg.getGroupName().replace(File.separator, "_") + ".txt"), isRoot);
         
         //set the arguments for the grader based on the grader flags in the currently specified TestDataGroup.
         //TODO:  it seems like there SHOULD be separate "scoringMode" and "verdictMode" attributes defined in a TestDataGroup -- ,

--- a/src/edu/csus/ecs/pc2/graders/LegacyGrader.java
+++ b/src/edu/csus/ecs/pc2/graders/LegacyGrader.java
@@ -53,6 +53,7 @@ public class LegacyGrader {
     private boolean ignoreSample = false;
     private int graderError = 0;
 
+    private boolean isRootGrader = false;
     private String logFile = null;
     private PrintWriter debugStream = null;
     
@@ -60,8 +61,15 @@ public class LegacyGrader {
         
     }
     
-    public LegacyGrader(String logFile) {
+    /**
+     * Construct a grader
+     * 
+     * @param logFile
+     * @param isRoot - if this is the topmost level, since there are slightly different rules
+     */
+    public LegacyGrader(String logFile, boolean isRoot) {
         this.logFile = logFile;
+        this.isRootGrader = isRoot;
         try {
             debugStream = new PrintWriter(logFile, "UTF-8");
         } catch(Exception e) {
@@ -216,17 +224,27 @@ public class LegacyGrader {
              * with the next line, which will be secret.
              */
             if(ignoreSampleGroup) {
-                // Ignore sample group which is the first one.  There better be exactly one more
-                // group in the list, or it's a judging error.
-                if(testCaseResults.size() != 2) {
+                // ignore_sample is only allowed at topmost level
+                if(!isRootGrader) {
                     graderError = GRADER_ERROR_IGNORE_SAMPLE;
+                    if(debugStream != null) {
+                        debugStream.println("Grader Error: " + IGNORE_SAMPLE_FLAG + " is only allowed at top data level.");
+                    }
                     break;
                 }
-                ignoreSampleGroup = false;
-                if(debugStream != null) {
-                    debugStream.println("Ignored previous line due to ignore_sample");
+                // Ignore sample group which is the first one if there are 2 groups (eg sample, secret).  We know
+                // we're at the root level at this point so there can only be 1 or 2 groups: secret or (sample & secret)
+                if(testCaseResults.size() == 2) {
+                    ignoreSampleGroup = false;
+                    if(debugStream != null) {
+                        debugStream.println("Ignored previous line due to ignore_sample.");
+                    }
+                    continue;
+                } else {
+                    if(debugStream != null) {
+                        debugStream.println("Notice: " + IGNORE_SAMPLE_FLAG + " specified, but no sample group - ignoring it.");
+                    }
                 }
-                continue;
             }
             String [] values = line.trim().split("\\s+");
             if(values.length != 2) {


### PR DESCRIPTION
### Description of what the PR does
If a misconfigured contest specifies `ignore_sample ` and there is no sample folder we log a message and handle it as if the **ignore_sample** was not present.  That is, this is no loner a fatal error.

Noticed during the NAC2026 Challenge.  This PR was (successfully) used during the NAC2026 Challenge to address this issue.

### Issue which the PR addresses
Fixes #1231 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

Ubuntu 24.04.3

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
Preface:  It took me a GREAT DEAL of time to write and configure this test procedure.  I am trying to take the difficultly out of the testing equation by supplying as much "turn-key" testing tools as possible now.  This test procedure includes a [ZIP File attached here](https://github.com/user-attachments/files/26755942/i1231-contest.zip).   The zip file is "_Windows_" centric, meaning, it is meant to be used on **Windows**.  This is not to say you can't test this on **Linux**, of course you can, but you will have to make some changes to the configuration: specifically, the `problem.yaml`, to make use of the non-windows, non-.exe version of the output validator.  In addition, you'll have to modify the judge's data path accordingly.  Also, you'll have to copy the `system-linux.yaml` over `system.yaml` so you use Linux compilers instead of Windows based ones.  The mode of the "`validate`" program in the `output_validators/validator` folder will likely have to be changed to make it executable.

If you are going to test on Windows, nothing in the configuration has to be changed unless you choose NOT to locate the extracted ZIP file in `C:\tmp`.  If you want this test procedure to be as painless as possible, I suggest you extract [this ZIP File](https://github.com/user-attachments/files/26755942/i1231-contest.zip) in a folder called `C:\tmp`.  Extracting it there will create: `C:\tmp\i1231-contest `which is a FULL one problem contest to test this PR.  The problem came from the NAC2026 Challenge (specifically, the "**ComputeAllocation**" problem.)  I have precompiled the validator and preconfigured the `problem.yaml `to use the validator.  All that being said, if you have problems testing this PR I will be extremely surprised.

Prerequisite: You must have g++ installed on your PC.  From a command prompt, you should be able to type `g++ --version` and get valid output.  If not, good luck and all bets are off and you are on your own:

```
C:\tmp>g++ --version
g++ (x86_64-win32-seh-rev2, Built by MinGW-Builds project) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

1. Extract the attached zip in the `C:\tmp` folder to produce: `C:\tmp\i1231-contest`
2. Start a clean server using the extracted contest - you can paste this command line into Eclipse's arguments for the server: `--server --login s --contestpassword contest --load /tmp/i1231-contest`
3. Start the contest from the **Times** tab on the server by pressing **Start All**
4. Start up a **pc2team** client and log in as **team1** with password **team1**.
5. On the team client **Submit Run** tab, choose the only problem, language **C++** and select the main file: `C:\tmp\i1231-contest\config\computeallocation\submissions\accepted\tourist.cpp` - this is one of the judge's accepted solutions.
6. Press the **Submit** button.  You should get back an submitted acknowledgment.
7. Start up a **pc2judge** client and log in as **judge1** with password **judge1**.
8. Immediately, the judge should start judging the submissions.   The team should get back an _Accepted_ judgment.
9. In the **pc2v9** main folder (where the judge is run from), you should find the execute folder for the run.  It will be called: `ex_1_A_computeallocation_1_cpp_judge1`
10. Browse to this folder and find the `graderLog-data.txt` file and open it with notepad or cat or whatever viewing program you want.  You should see the following, indicating the PR has worked properly.  (Note the Notice: message.)
```

Grader Settings:
  verdictMode = worst_error
  scoringMode = sum
  acceptIfAnyAccepted = false
  ignoreSample = true
TestCases:
  1:AC 50.0
Notice: ignore_sample specified, but no sample group - ignoring it.

RESULT:AC 50.0

```



