### PR TITLE
I1265 add per problem per minute throttling strategy

### DIFF
--- a/src/edu/csus/ecs/pc2/core/InternalController.java
+++ b/src/edu/csus/ecs/pc2/core/InternalController.java
@@ -77,8 +77,9 @@ import edu.csus.ecs.pc2.core.report.ContestSummaryReports;
 import edu.csus.ecs.pc2.core.security.FileSecurity;
 import edu.csus.ecs.pc2.core.security.FileSecurityException;
 import edu.csus.ecs.pc2.core.security.Permission;
+import edu.csus.ecs.pc2.core.strategies.MaxSubmissionsPerMinutePerProblemStrategy;
 //import edu.csus.ecs.pc2.core.strategies.AcceptAllStrategy;
-import edu.csus.ecs.pc2.core.strategies.MaxSubmissionsPerMinuteStrategy;
+//import edu.csus.ecs.pc2.core.strategies.MaxSubmissionsPerMinuteStrategy;
 //import edu.csus.ecs.pc2.core.strategies.RejectAllStrategy;
 import edu.csus.ecs.pc2.core.transport.ConnectionHandlerID;
 import edu.csus.ecs.pc2.core.transport.IBtoA;
@@ -618,13 +619,16 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 //Determine the throttling strategy to be applied to team submissions.
                 //The following shows several alternative strategy selections, with only one being enabled.
                 //A preferable extension would be to allow external (e.g. run-time) selection of the desired strategy,
-                // chosen from among a list of available strategies and specified by, e.g. a YAML file or an interactive
-                // GUI (such as the PC2 Admin)
+                // chosen from among a list of available strategies and specified by, e.g. a YAML file and/or an interactive
+                // GUI (such as the PC2 Admin); see Issue #1232
     //            IThrottleStrategy strategy = new AcceptAllStrategy();
     //            IThrottleStrategy strategy = new RejectAllStrategy();
-                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,6);
+    //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,6);
     //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
     //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest); //uses DEFAULT_MAX_SUBMISSIONS_PER_MINUTE; same as prev line
+
+                IThrottleStrategy strategy = new MaxSubmissionsPerMinutePerProblemStrategy(contest);
+                
                 accept = strategy.accept(run);
             }
         }
@@ -5025,9 +5029,11 @@ public class InternalController implements IInternalController, ITwoToOne, IBtoA
                 // GUI (such as the PC2 Admin)
     //            IThrottleStrategy strategy = new AcceptAllStrategy();
     //            IThrottleStrategy strategy = new RejectAllStrategy();
-                IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 6);
+    //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest, 6);
     //            IThrottleStrategy strategy = new MaxSubmissionsPerMinuteStrategy(contest,MaxSubmissionsPerMinuteStrategy.DEFAULT_MAX_SUBMISSIONS_PER_MINUTE);
-
+                
+                IThrottleStrategy strategy = new MaxSubmissionsPerMinutePerProblemStrategy(contest);
+                
                 accept = strategy.accept(run);
             }
         }

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinutePerProblemStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinutePerProblemStrategy.java
@@ -1,0 +1,118 @@
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+package edu.csus.ecs.pc2.core.strategies;
+
+import edu.csus.ecs.pc2.core.IThrottleStrategy;
+import edu.csus.ecs.pc2.core.model.ClientId;
+import edu.csus.ecs.pc2.core.model.ContestTime;
+import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.IInternalContest;
+import edu.csus.ecs.pc2.core.model.Run;
+
+/**
+ * This class implements an {@link IThrottleStrategy} which rejects runs when the submitting team
+ * has submitted more than "N" runs in the last minute for the specified problem
+ * (that is, it only considers previous submissions for the same problem rather then for all problems).  
+ * The value of N is set either to a default value or a value passed to the constructor
+ * when the class is instantiated.
+ * 
+ * @author John Clevenger
+ *
+ */
+public class MaxSubmissionsPerMinutePerProblemStrategy implements IThrottleStrategy {
+    
+    public static int DEFAULT_MAX_SUBMISSIONS_PER_MINUTE_PER_PROBLEM = 6 ;
+
+    private  IInternalContest contest;
+    private int maxPerMinutePerProblem;
+    
+    /**
+     * Construct a strategy with a default limit on submissions per minute.
+     * 
+     * @param inContest the {@link IInternalContest} with which this strategy is associated.
+     */
+    public MaxSubmissionsPerMinutePerProblemStrategy (IInternalContest inContest) {
+        this.contest = inContest ;
+        this.maxPerMinutePerProblem = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE_PER_PROBLEM ;
+    }
+
+    /**
+     * Construct a strategy with a caller-specified limit on submissions per minute per problem.
+     * 
+     * @param inContest the {@link IInternalContest} with which this strategy is associated.
+     */
+    public MaxSubmissionsPerMinutePerProblemStrategy (IInternalContest inContest, int maxAllowed) {
+        this.contest = inContest ;
+        this.maxPerMinutePerProblem = maxAllowed ;
+    }
+
+    @Override
+    /**
+     * Rejects the specified run if the submitting team has already submitted the maximum allowed number of runs 
+     *  for the problem specified in the specified Run in the past minute. 
+     */
+    public boolean accept(Run run) {
+        return !numSubmittedForProblemInLastMinuteExceedsMaximum(contest, run);
+    }
+
+    /**
+     * Queries the specified contest to obtain the complete list of runs, then determines whether 
+     * the count of runs previously submitted for the specified problem in the last minute by the new-run submitter
+     * has already reached the maximum allowed.
+     * 
+     * @param contest the contest containing runs submitted by teams.
+     * @param newRun the (new) {@link Run} submitted by a team about which a strategy decision (i.e. whether or not
+     *                  to forward the run to the PC2 Server) is to be made.  
+     * 
+     * @return true if the number of runs which the team has submitted in the last minute for the specified problem
+     *          has already reached the maximum; false if not.
+     */
+    private boolean numSubmittedForProblemInLastMinuteExceedsMaximum(IInternalContest contest, Run newRun) {
+        
+        //get the clientId for the new Run
+        ClientId newSubmitter = newRun.getSubmitter();
+        
+        //get the problemId for the new Run
+        ElementId newRunProbId = newRun.getProblemId();
+
+        //get the current contest time so we can check run submission times against current time
+        ContestTime contestTime = contest.getContestTime();
+        long contestElapsedSecs = contestTime.getElapsedSecs();
+        
+        //get all the runs in the contest
+        Run[] allRuns = contest.getRuns();
+        
+        //count the number of runs previously submitted in the last minute by the same client for the same problem
+        int countSoFar = 0;
+        boolean limitReached = false;
+        
+        //check each contest run 
+        for (Run curRun : allRuns) {
+
+            // see if the new run came from the same submitter
+            if (curRun.getSubmitter().equals(newSubmitter)) {
+
+                // yes, same submitter; see if the problem in the new run is the same as the problem in the curRun
+                if (curRun.getProblemId().equals(newRunProbId)) {
+
+                    // yes, same submitter and same problem; get the submission time (in seconds) for the current run
+                    long runSubmisionTimeSecs = curRun.getOriginalElapsedMS() / 1000;
+
+                    // check if the curRun submission time was within the last minute (60 seconds)
+                    if (runSubmisionTimeSecs >= contestElapsedSecs - 60) {
+
+                        // the curRun was submitted in the last minute ; count it
+                        countSoFar++;
+
+                        // if the submitter has already reached or exceeded the limit, no need to check any more runs
+                        if (countSoFar >= maxPerMinutePerProblem) {
+                            limitReached = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        
+        return limitReached ;
+    }
+}

--- a/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinutePerProblemStrategy.java
+++ b/src/edu/csus/ecs/pc2/core/strategies/MaxSubmissionsPerMinutePerProblemStrategy.java
@@ -2,6 +2,9 @@
 package edu.csus.ecs.pc2.core.strategies;
 
 import edu.csus.ecs.pc2.core.IThrottleStrategy;
+import edu.csus.ecs.pc2.core.IniFile;
+import edu.csus.ecs.pc2.core.StringUtilities;
+import edu.csus.ecs.pc2.core.log.StaticLog;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.ElementId;
@@ -10,10 +13,10 @@ import edu.csus.ecs.pc2.core.model.Run;
 
 /**
  * This class implements an {@link IThrottleStrategy} which rejects runs when the submitting team
- * has submitted more than "N" runs in the last minute for the specified problem
+ * has submitted more than "N" runs in the last minute *for the specified problem*
  * (that is, it only considers previous submissions for the same problem rather then for all problems).  
- * The value of N is set either to a default value or a value passed to the constructor
- * when the class is instantiated.
+ * The value of N is set to a value read from the pc2.ini file if present; otherwise it is set to a default value,
+ * or a value passed to the constructor when the class is instantiated.
  * 
  * @author John Clevenger
  *
@@ -21,7 +24,8 @@ import edu.csus.ecs.pc2.core.model.Run;
 public class MaxSubmissionsPerMinutePerProblemStrategy implements IThrottleStrategy {
     
     public static int DEFAULT_MAX_SUBMISSIONS_PER_MINUTE_PER_PROBLEM = 6 ;
-
+    public static final String MAX_SUBS_PER_MINUTE_PER_PROBLEM_KEY = "throttle-strategy-settings.maxSubmissionsPerMinutePerProblem";
+    
     private  IInternalContest contest;
     private int maxPerMinutePerProblem;
     
@@ -32,7 +36,17 @@ public class MaxSubmissionsPerMinutePerProblemStrategy implements IThrottleStrat
      */
     public MaxSubmissionsPerMinutePerProblemStrategy (IInternalContest inContest) {
         this.contest = inContest ;
-        this.maxPerMinutePerProblem = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE_PER_PROBLEM ;
+        
+        //try to get a max-per-minute value from the INI file (credit:  @johnbrvc)
+        try {
+            String maxSubsPerMinString = IniFile.getValue(MAX_SUBS_PER_MINUTE_PER_PROBLEM_KEY);
+            maxPerMinutePerProblem = StringUtilities.getIntegerValue(maxSubsPerMinString, DEFAULT_MAX_SUBMISSIONS_PER_MINUTE_PER_PROBLEM);
+        } catch(Exception e) {
+            // if there is any problem reading the INI or a bad integer conversion, this does not warrant a complete failure
+            // of the submission.  Rather, we'll use the default and log the error.      
+            this.maxPerMinutePerProblem = DEFAULT_MAX_SUBMISSIONS_PER_MINUTE_PER_PROBLEM ;
+            StaticLog.warning("MaxSubmissionsPerMinutePerProblemStrategy: Bad INI file setting '" + MAX_SUBS_PER_MINUTE_PER_PROBLEM_KEY + "': " + e);
+        }        
     }
 
     /**
@@ -56,7 +70,7 @@ public class MaxSubmissionsPerMinutePerProblemStrategy implements IThrottleStrat
 
     /**
      * Queries the specified contest to obtain the complete list of runs, then determines whether 
-     * the count of runs previously submitted for the specified problem in the last minute by the new-run submitter
+     * the count of runs previously submitted *for the specified problem* in the last minute by the new-run submitter
      * has already reached the maximum allowed.
      * 
      * @param contest the contest containing runs submitted by teams.
@@ -94,7 +108,7 @@ public class MaxSubmissionsPerMinutePerProblemStrategy implements IThrottleStrat
                 // yes, same submitter; see if the problem in the new run is the same as the problem in the curRun
                 if (curRun.getProblemId().equals(newRunProbId)) {
 
-                    // yes, same submitter and same problem; get the submission time (in seconds) for the current run
+                    // yes, same submitter and same problem; get the submission time (in seconds) for the curRun
                     long runSubmisionTimeSecs = curRun.getOriginalElapsedMS() / 1000;
 
                     // check if the curRun submission time was within the last minute (60 seconds)


### PR DESCRIPTION
### Description of what the PR does
- Implements a new Throttling Strategy `MaxSubmissionsPerMinutePerProblem` which supports submission threshholds on a Per-Problem basis.
- Makes the new Strategy the default PC2 strategy.

### Issue which the PR addresses
Fixes #1265

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11, java version "1.8.0_381"

### Precise steps for _testing_ the PR:

1. Download and unzip the PR distribution.
1. Start a PC2 Server using `--load sumithello`.
1. Start a PC2 Admin client and login as administrator1.
1. Create a new "FEEDER" account with the `Shadow Proxy Team` permission.  This is done as follows:
    - On the `Configure Contest -> Accounts` tab, select the `Generate` button.
    - Generate 1 FEEDER account (select FEEDER from the combo-box, and enter a 1 in the box to the right of it.)
    - Press the `Generate Accounts for Site 1` button.
    - Close the `Generate Account` dialog
    - Select the newly added "feeder1" account and press the `Edit` button.
    - In the Permissions/Abilities pane on the right, check the `Shadow Proxy Team` check box, and press Update.
5. Enable `CCS Test Mode`.  This is done as follows:
    - On the administrator `Configure Contest -> Settings` tab, scroll all the way to the bottom, and check the `Enable CCS Test Mode` in the CCS Test Mode group box, then press the `Update` button.
6. Start an event feeder client and log in using the newly created "feeder1" account.
1. On the `Web Services` tab, press the `Start` button to start the CLICS event feeder.
1. On the PC2 Admin, use the `Times` tab to start the contest running.
1. Switch to the `Run Contest -> Runs` tab on the administrator client.
1. From a command prompt, navigate to the folder where you installed PC2 (or to the main pc2v9 source folder if you're running PC2 from an IDE).
1. Run: `python bin/pc2submit -u https://localhost:50443 -t 1 -p a -y samps/src/hello.cpp`.  
    - Note that this requires Python on your machine.
    - This makes a submission from Team 1 (`-t 1`) for Problem A (`-p a`).
1. Verify the submission appears on the PC2 Admin's `Runs` tab.
1. Re-execute the submission command 7 more times in quick succession (<1 minute).  After the 6th submission verify that you get an error message on the console like `Submission threshold exceeded - wait a minute and try again.`
1. Edit the `pc2v9.ini` file and add (or change) the lines toward the end of the file as shown:
    ```
    [throttle-strategy-settings]
    maxSubmissionsPerMinutePerProblem=1
    ```
    This will limit the system to one submission PER PROBLEM per minute (**_be sure to note carefully the full spelling in the second line!_**)
15. Close and restart the "feeder1" event feed client. This will cause it to re-read the `pc2v9.ini` file to use the new throttle settings.
1. Press the `Start` button on the event feeder client to start the CLICS API.
1. Now try to make 2 submissions (as described above) in quick succession. Since we set the limit to 1 per minute, only the first one should succeed, the second should get an error indicating `Submission threshold exceeded - wait a minute and try again.` 
1. Quickly re-execute the submission command, but change the `-p a` to `-p b`.  This will make a submission in the same minute BUT FOR A DIFFERENT PROBLEM (B).
1. Verify that the submission for problem B is accepted even though the limit for problem A has been reached.
1. Open a command prompt (terminal) in the PC2 Distribution's "projects" folder and unzip the WebTeamInterface.zip folder.
1. Change to the unzipped WTI distribution folder and start the WTI Server, using the command `./bin/pc2wti`.
1. Open a browser and login to the WTI using a URL like `http://localhost:8080` and login credentials "team1/team1".
1. Watch the system time clock on your machine and wait until it clicks over to a new wall-time minute, then use the WTI GUI to quickly submit SEVEN submissions in a row for the same problem.  (It's challenging but it's doable...).
1. Verify that the 7th submission is rejected with a red message like `Submission threshhold exceeded`.
	(If you don't get the rejection message on the 7th submission, look at the WTI `Runs` tab and verify that all seven have the SAME "Time" value.  If not, you didn't get all the submissions in during the same wall-time minute and therefore you might not have gotten them all within the same 60-second threshhold.)
1. Log out of the WTI and close the WTI browser window.
1. Kill the WTI Server.
1. Edit the `pc2v9.ini` file **IN THE WTI DISTRIBUTION FOLDER** by adding the following to the bottom:
    ```
    [throttle-strategy-settings]
    maxSubmissionsPerMinutePerProblem=1
    ```
1. Restart the WTI Server.
1. Open a new browser window and login to the WTI client.
1. Quickly submit two runs for the same problem one after another.  
1. Verify that the second run is rejected (because the threshhold is now 1 per problem per minute).
1. Quickly submit another run for a DIFFERENT problem.
1. Verify that the new submission is accepted.  (If you submitted the run for a different problem in the same minute as the first two submission, this verifies that the WTI enforces threshhold limits PER PROBLEM.)
