### PR TITLE
i_1269 fix scoreboard endpoint to comply with the intent of the Information Access Policy

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/CLICSScoreboard.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/CLICSScoreboard.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.io.IOException;
@@ -59,10 +59,17 @@ public class CLICSScoreboard {
     }
 
     /**
-     * Fill in the scoreboard information
-     *
+     * Fill in the scoreboard information for reports and exports.
+     * These are internal (staff) related things, and we do not obey the freeze.
      */
     public CLICSScoreboard(IInternalContest model, Group group, Integer division)  throws IllegalContestState, JAXBException, IOException {
+        this(model, group, division, false);
+    }
+
+    /**
+     * Fill in the scoreboard information possibly obeying the freeze.
+     */
+    public CLICSScoreboard(IInternalContest model, Group group, Integer division, boolean obeyFreeze)  throws IllegalContestState, JAXBException, IOException {
 
         DefaultScoringAlgorithm scoringAlgorithm = new DefaultScoringAlgorithm();
 
@@ -74,6 +81,8 @@ public class CLICSScoreboard {
             groupList = new ArrayList<Group>();
             groupList.add(group);
         }
+        scoringAlgorithm.setObeyFreeze(obeyFreeze);
+
         // legacy - standings are created as XML, and we convert that to JSON.
         String xml = scoringAlgorithm.getStandings(model, null, division, groupList, properties, StaticLog.getLog());
 

--- a/src/edu/csus/ecs/pc2/clics/API202306/ScoreboardService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/ScoreboardService.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.io.IOException;
@@ -69,6 +69,7 @@ public class ScoreboardService implements Feature {
         // check contest id
         if(contestId.equals(model.getContestIdentifier()) == true) {
             ContestTime contestTime = model.getContestTime();
+
             // verify contest has started or user is special
             if (contestTime.getElapsedMS() > 0 ||
                 ((sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) ||
@@ -77,6 +78,10 @@ public class ScoreboardService implements Feature {
 
                 Group specificGroup = null;
                 Integer divNumber = null;
+
+                // only staff and judges get an unabridged scoreboard
+                boolean obeyFreeze = !(sc.isUserInRole(WebServer.WEBAPI_ROLE_ADMIN) ||
+                    sc.isUserInRole(WebServer.WEBAPI_ROLE_JUDGE));
 
                 // if a specific group was requested, let's look for that so we can pass it to the standings routine
                 if(!StringUtilities.isEmpty(group_id)) {
@@ -104,7 +109,7 @@ public class ScoreboardService implements Feature {
 
                 // ok to return scoreboard
                 try {
-                    CLICSScoreboard scoreboard = new CLICSScoreboard(model, specificGroup, divNumber);
+                    CLICSScoreboard scoreboard = new CLICSScoreboard(model, specificGroup, divNumber, obeyFreeze);
                     return Response.ok(scoreboard.toJSON(), MediaType.APPLICATION_JSON).build();
                 } catch (IllegalContestState | JAXBException | IOException e) {
                     controller.getLog().log(Log.WARNING, "Exception creating PC2 scoreboard JSON: " + e.getMessage(), e);


### PR DESCRIPTION
### Description of what the PR does
Create a new chained constructor that accepts an additional `boolean `argument which indicates if the _freeze_ should be obeyed when generating the scoreboard for the endpoint.  The original constructor chains to the new one and supplies `false`.  The original constructor is now only  used when generating reports and results files, so we always want _unfrozen_ scoreboards for that. 
Update the `ScoreboardService `to pass a `boolean `indicating if a frozen scoreboard is desired (basically, if the role of the requestor is not administrator and not judge).

### Issue which the PR addresses
Fixes #1269 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
These steps are more or less lifted from the issue:

1. Load an existing contest that has not been unfrozen such as [wf46prefinalize.zip](https://drive.google.com/file/d/1r0FKRCBPk2Cix3NhvNpKIm-QL97pDXuQ/view?usp=sharing).  This zip will extract to the `wf46prefinalize `folder so you'll have to copy the `profiles `and `profiles.propertie`s into your `pc2v9 `folder.
After loading the contest, close the server and reopen it.  This has to be done because there were some runs in a funny state that had to be cleaned up with the first load.  There's bug in PC2 where, when this happens, the Runs table does not get populated.  Reloading fixes that issue.
2. Start an event feeder (**feeder1**) and press the **Start** button to start the feed.
3. Edit **team46001**'s account (_ADA University_) and add the "**View Event Feeds**" permission.
4. Change the password for **team46001** to be **team** as well (this will make it easier later to test).
5. Be sure to press **Update** to save the changes you made to the team.
6. Start a **pc2board** client up, and wait for it to be ready.
7. Navigate to the `public_html` folder produced by the **pc2board**.
8. Open the "`index.html`" file and notice the top teams.  This is a _frozen_ scoreboard.  Massachusetts Institute of Technology (team 46054) is in first place and National Research University Higher School of Economics (team 46061) is in second place.

<img width="1421" height="104" alt="Image" src="https://github.com/user-attachments/assets/61a6916e-553d-4534-9f6a-2d13c6693b9d" />

9. Navigate to the html folder produced by the pc2board.
10. Open the "index.html" file that's there and notice the top teams.  This is an unfrozen scoreboard (final results).  Peking University (team 46069) is in first place and Massachusetts Institution of Technology (team 46054) is in second place.

<img width="1483" height="101" alt="Image" src="https://github.com/user-attachments/assets/965b3d94-69a5-4f7d-b19b-7c80e461f032" />

11. From a web browser, enter: [https://team46001:team@localhost:50443/contests/Default--7404674021536391858/scoreboard](https://team46001:team@localhost:50443/contests/Default--7404674021536391858/scoreboard)
12. Check out the first place team "rank 1" is MIT (46054) and the second place team is National Research University Higher School of Economics (team 46061) (eg it matches the frozen results above from step 8).  This is the frozen scoreboard since a team made the request.
<img width="356" height="701" alt="image" src="https://github.com/user-attachments/assets/1cbf1285-a218-48ae-8a10-554614550004" />

13. From a web browser, enter: [https://admin:admin@localhost:50443/contests/Default--7404674021536391858/scoreboard](https://admin:admin@localhost:50443/contests/Default--7404674021536391858/scoreboard)
14. Check out the first place team "rank 1" is team 46069 (Peking University) and "rank 2" is MIT (46054).  This is the _unfrozen_ (final) scoreboard and is correct since the role of the requesting account is **admin**.
<img width="324" height="706" alt="image" src="https://github.com/user-attachments/assets/7cd00a9a-9c9a-420b-9b64-b655c747cd4f" />

