### PR TITLE
I_104 Add SSL support to WTI

### DIFF
--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -42,13 +42,4 @@ apiVersionsSupported=2023-06,2020-03
 # accounts configured by the CDS.  This is not desirable.
 disable-collections=accounts
 
-# For WebTeamInterface server
-wtiport=8443
-wtiwsName=/websocket
-wtiscoreboardaccount=scoreboard2
-wtiscoreboardpassword=scoreboard2
-
-# For SSL
-keyStoreFilePath=/MyNetProjects/ICPC/wtikeystore/keystore.jks
-keyStorePassword=contest
 # eof 

--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -41,5 +41,4 @@ apiVersionsSupported=2023-06,2020-03
 # since the CDS will interpret a collection as a complete list of accounts and remove any
 # accounts configured by the CDS.  This is not desirable.
 disable-collections=accounts
-
 # eof 

--- a/pc2v9.ini
+++ b/pc2v9.ini
@@ -41,4 +41,14 @@ apiVersionsSupported=2023-06,2020-03
 # since the CDS will interpret a collection as a complete list of accounts and remove any
 # accounts configured by the CDS.  This is not desirable.
 disable-collections=accounts
+
+# For WebTeamInterface server
+wtiport=8443
+wtiwsName=/websocket
+wtiscoreboardaccount=scoreboard2
+wtiscoreboardpassword=scoreboard2
+
+# For SSL
+keyStoreFilePath=/MyNetProjects/ICPC/wtikeystore/keystore.jks
+keyStorePassword=contest
 # eof 

--- a/projects/WTI-API/pc2v9.ini
+++ b/projects/WTI-API/pc2v9.ini
@@ -22,15 +22,15 @@ server=localhost:50002
 #remoteServer=localhost:50002
 
 # For WebTeamInterface server
-useSSL=1
-#wtiport=8080
-wtiport=8443
+useSSL=0
+wtiport=8080
+#wtiport=8443
 wtiwsName=/websocket
 wtiscoreboardaccount=scoreboard2
 wtiscoreboardpassword=scoreboard2
 
 # For SSL
-keyStoreFilePath=/MyNetProjects/ICPC/wtikeystore/keystore.jks
+keyStoreFilePath=/Users/Public/WebTeamInterface-1.2/wtikeystore.jks
 keyStorePassword=contest
 
 # eof 

--- a/projects/WTI-API/pc2v9.ini
+++ b/projects/WTI-API/pc2v9.ini
@@ -22,9 +22,13 @@ server=localhost:50002
 #remoteServer=localhost:50002
 
 # For WebTeamInterface server
-wtiport=8080
+wtiport=8443
 wtiwsName=/websocket
 wtiscoreboardaccount=scoreboard2
 wtiscoreboardpassword=scoreboard2
+
+# For SSL
+keyStoreFilePath=/MyNetProjects/ICPC/wtikeystore/keystore.jks
+keyStorePassword=contest
 
 # eof 

--- a/projects/WTI-API/pc2v9.ini
+++ b/projects/WTI-API/pc2v9.ini
@@ -22,6 +22,8 @@ server=localhost:50002
 #remoteServer=localhost:50002
 
 # For WebTeamInterface server
+useSSL=1
+#wtiport=8080
 wtiport=8443
 wtiwsName=/websocket
 wtiscoreboardaccount=scoreboard2

--- a/projects/WTI-API/src/main/config/ServerInit.java
+++ b/projects/WTI-API/src/main/config/ServerInit.java
@@ -111,7 +111,9 @@ public class ServerInit {
 		      keyStorePassword = p.getProperty(WTI_KEY_STORE_PASSWORD_KEY);
 		      certAlias = p.getProperty(WTI_CERT_ALIAS_KEY);
 
-		      System.out.println ("Found the following properties in " + WTI_INI_FILE_KEY + ": " + p);
+		      String infoMsg = "Found the following properties in " + WTI_INI_FILE_KEY + ": " + p;
+		      System.out.println (infoMsg);
+		      logger.info(infoMsg);
 
 		} catch(FileNotFoundException e) {
 			this.logger.info(WTI_INI_FILE_KEY + " File missing; reverting to default WTI port/socket/scoreboard values");

--- a/projects/WTI-API/src/main/config/ServerInit.java
+++ b/projects/WTI-API/src/main/config/ServerInit.java
@@ -31,18 +31,37 @@ import edu.csus.ecs.pc2.core.log.Log;
  */
 public class ServerInit {
 
+	// File where WTI properties are configured
+    public final String WTI_INI_FILE_KEY = "pc2v9.ini";
+	// Property keys for WTI
+    public final String WTI_HTTP_PORT_KEY = "wtiport";
+    private final String WTI_WEBSOCKET_NAME_KEY = "wtiwsName";
+    private final String WTI_SCOREBOARD_ACCT_KEY = "wtiscoreboardaccount";
+    private final String WTI_SCOREBOARD_PASS_KEY = "wtiscoreboardPassword";
     private final String WTI_PUBLIC_IP_OVERRIDE_KEY = "wtiOverridePublicIP";
+    // eg. allowedOSName1, allowedOSName2, ..., allowedOSNameLinux
+    private final String WTI_ALLOWED_OS_NAME_PREFIX_KEY = "allowedOSName";
+    // Property keys for running WTI over https
+    private final String WTI_USE_SSL_KEY = "useSSL";
     private final String WTI_KEY_STORE_PATH_KEY = "keyStoreFilePath";
     private final String WTI_KEY_STORE_PASSWORD_KEY = "keyStorePassword";
+
+    private static final boolean DEF_USE_SSL = false;
+    private static final int DEF_WTI_HTTP_PORT = 8080;
+    private static final String DEF_WEBSOCK_PATH = "/websocket";
+    private static final String DEF_SCOREBOARD_ACCT = "scoreboard2";
+    private static final String DEF_SCOREBOARD_PASS = "scoreboard2";
 
 	private static ServerInit init = null;
 	private static String publicIPOverride;
 	private static List<String> allowedOSNames;
 
+	private boolean useSSL = DEF_USE_SSL;
 	private int portNum;
 	private String socketSource;
 	private String scoreboardAccount;
 	private String scoreboardPassword;
+
 	private String keyStoreFilePath;
 	private String keyStorePassword;
 
@@ -63,13 +82,25 @@ public class ServerInit {
 	private void readIniFile() {
 
 		Properties p = new Properties();
+		String exceptKey = "none";
+
 		try {
 		      //p.load(new FileInputStream("WebTeamInterface.ini"));
-              p.load(new FileInputStream("pc2v9.ini"));
-		      this.portNum = Integer.parseInt(p.getProperty("wtiport"));
-		      this.socketSource = p.getProperty("wtiwsName");
-		      this.scoreboardAccount = p.getProperty("wtiscoreboardaccount", "scoreboard2");
-		      this.scoreboardPassword = p.getProperty("wtiscoreboardpassword", "scoreboard2");
+              p.load(new FileInputStream(WTI_INI_FILE_KEY));
+
+              exceptKey = WTI_USE_SSL_KEY;
+              String sslValue = p.getProperty(WTI_USE_SSL_KEY);
+              if(sslValue != null && Integer.parseInt(sslValue) > 0) {
+            	  this.useSSL = true;
+              } else {
+            	  this.useSSL = false;
+              }
+              exceptKey = WTI_HTTP_PORT_KEY;
+		      this.portNum = Integer.parseInt(p.getProperty(WTI_HTTP_PORT_KEY));
+
+		      this.socketSource = p.getProperty(WTI_WEBSOCKET_NAME_KEY);
+		      this.scoreboardAccount = p.getProperty(WTI_SCOREBOARD_ACCT_KEY, DEF_SCOREBOARD_ACCT);
+		      this.scoreboardPassword = p.getProperty(WTI_SCOREBOARD_PASS_KEY, DEF_SCOREBOARD_PASS);
 
 		      publicIPOverride = p.getProperty(WTI_PUBLIC_IP_OVERRIDE_KEY);
 		      allowedOSNames = getAllowedOSNames(p);
@@ -77,13 +108,13 @@ public class ServerInit {
 		      keyStoreFilePath = p.getProperty(WTI_KEY_STORE_PATH_KEY);
 		      keyStorePassword = p.getProperty(WTI_KEY_STORE_PASSWORD_KEY);
 
-		      System.out.println ("Found the following properties in pc2v9.ini: " + p);
+		      System.out.println ("Found the following properties in " + WTI_INI_FILE_KEY + ": " + p);
 
 		} catch(FileNotFoundException e) {
-			this.logger.info("pc2v9.ini File missing; reverting to default WTI port/socket/scoreboard values");
+			this.logger.info(WTI_INI_FILE_KEY + " File missing; reverting to default WTI port/socket/scoreboard values");
 			setDefaults();
 		} catch (NumberFormatException e) {
-            this.logger.info("No parsable integer wtiport value found in pc2v9.ini; reverting to default WTI port/socket/scoreboard values");
+            this.logger.info("No parsable integer '" + exceptKey + "' value found in " + WTI_INI_FILE_KEY + "; reverting to default WTI port/socket/scoreboard values");
             setDefaults();
 		} catch (IOException e) {
 			this.logger.info(e.getLocalizedMessage());
@@ -104,7 +135,7 @@ public class ServerInit {
 		List<String> allowedNames = new ArrayList<String>();
 		for (Object key : p.keySet()) {
 			String keyName = key.toString();
-			if (keyName.startsWith("allowedOSName")) {
+			if (keyName.startsWith(WTI_ALLOWED_OS_NAME_PREFIX_KEY)) {
 				allowedNames.add(p.getProperty(keyName));
 			}
 		}
@@ -112,10 +143,20 @@ public class ServerInit {
 	}
 
 	private void setDefaults() {
-		this.portNum = 8080;
-		this.socketSource ="/websocket";
-		this.scoreboardAccount = "scoreboard2";
-		this.scoreboardPassword = "scoreboard2";
+		this.useSSL = DEF_USE_SSL;
+		this.portNum = DEF_WTI_HTTP_PORT;
+		this.socketSource = DEF_WEBSOCK_PATH;
+		this.scoreboardAccount = DEF_SCOREBOARD_ACCT;
+		this.scoreboardPassword = DEF_SCOREBOARD_PASS;
+	}
+
+	/**
+	 * Returns true if the WTI server should listen for HTTPS browser (team) connections as opposed
+	 * to HTTP browser connections.
+	 * @return a boolean
+	 */
+	public boolean isUseSSL() {
+		return useSSL;
 	}
 
 	/**
@@ -178,14 +219,14 @@ public class ServerInit {
 			String localIpAddress = getLocalIp();
 			if (localIpAddress == null) throw new Exception("could not get local ip address.");
 
-			String baseUrl = new StringBuilder("https://")
+			String baseUrl = new StringBuilder(ini.isUseSSL() ? "https://" : "http://")
 					.append(localIpAddress)
 					.append(":")
 					.append(ini.getPortNum())
 					.append("/api")
 					.toString();
 
-			String websocketUrl = new StringBuilder("wss://")
+			String websocketUrl = new StringBuilder(ini.isUseSSL() ? "wss://" : "ws://")
 					.append(localIpAddress)
 					.append(":")
 					.append(ini.getPortNum())

--- a/projects/WTI-API/src/main/config/ServerInit.java
+++ b/projects/WTI-API/src/main/config/ServerInit.java
@@ -22,42 +22,46 @@ import edu.csus.ecs.pc2.core.log.Log;
  * the server listens for browser connections, the base name to be used for the websocket connections between
  * the server and browser sessions, and the scoreboard account/pw information which the WTI server uses to
  * fetch scoreboard information from the PC2 server.
- * 
+ *
  * The initialization values are read from the pc2v9.ini file in the WTI server's startup folder; if no such
  * file is present then default values are assigned.
- * 
+ *
  * @author EWU WTI Student Project Team
  *
  */
 public class ServerInit {
 
     private final String WTI_PUBLIC_IP_OVERRIDE_KEY = "wtiOverridePublicIP";
-    
+    private final String WTI_KEY_STORE_PATH_KEY = "keyStoreFilePath";
+    private final String WTI_KEY_STORE_PASSWORD_KEY = "keyStorePassword";
+
 	private static ServerInit init = null;
 	private static String publicIPOverride;
 	private static List<String> allowedOSNames;
-	
+
 	private int portNum;
 	private String socketSource;
 	private String scoreboardAccount;
 	private String scoreboardPassword;
+	private String keyStoreFilePath;
+	private String keyStorePassword;
 
 
 	private Log logger;
-	
+
 	private ServerInit() {
 		this.logger = Logging.getLogger();
 		this.readIniFile();
 	}
-	
+
 	public static ServerInit createServerInit() {
 		if (init == null)
 			init = new ServerInit();
 		return init;
 	}
-	
+
 	private void readIniFile() {
-		
+
 		Properties p = new Properties();
 		try {
 		      //p.load(new FileInputStream("WebTeamInterface.ini"));
@@ -66,10 +70,13 @@ public class ServerInit {
 		      this.socketSource = p.getProperty("wtiwsName");
 		      this.scoreboardAccount = p.getProperty("wtiscoreboardaccount", "scoreboard2");
 		      this.scoreboardPassword = p.getProperty("wtiscoreboardpassword", "scoreboard2");
-		      
+
 		      publicIPOverride = p.getProperty(WTI_PUBLIC_IP_OVERRIDE_KEY);
 		      allowedOSNames = getAllowedOSNames(p);
-		      
+
+		      keyStoreFilePath = p.getProperty(WTI_KEY_STORE_PATH_KEY);
+		      keyStorePassword = p.getProperty(WTI_KEY_STORE_PASSWORD_KEY);
+
 		      System.out.println ("Found the following properties in pc2v9.ini: " + p);
 
 		} catch(FileNotFoundException e) {
@@ -83,11 +90,11 @@ public class ServerInit {
 			setDefaults();
 		}
 	}
-	
+
 	/**
 	 * Returns a list of property values for every entry in the specified Properties object
 	 * whose key starts with the String "allowedOSName".
-	 * 
+	 *
 	 * @param p a Properties object which potentially contains entries giving allowed OS names.
 	 * @return a List<String> containing the values for all entries in the specified Properties whose key starts with "allowedOSName".
 	 * 			The returned list may be empty but will never be null.
@@ -98,7 +105,7 @@ public class ServerInit {
 		for (Object key : p.keySet()) {
 			String keyName = key.toString();
 			if (keyName.startsWith("allowedOSName")) {
-				allowedNames.add(p.getProperty(keyName)); 
+				allowedNames.add(p.getProperty(keyName));
 			}
 		}
 		return allowedNames;
@@ -110,7 +117,7 @@ public class ServerInit {
 		this.scoreboardAccount = "scoreboard2";
 		this.scoreboardPassword = "scoreboard2";
 	}
-	
+
 	/**
 	 * Returns the port number on which the WTI server should listen for browser (team) connections.
 	 * @return an integer port number
@@ -118,7 +125,7 @@ public class ServerInit {
 	public int getPortNum() {
 		return this.portNum;
 	}
-	
+
 	/**
 	 * Returns the String which is the base name for websocket connections between the WTI server and client (browser) sessions.
 	 * @return a String containing the websocket base name
@@ -126,7 +133,7 @@ public class ServerInit {
 	public String getWsName() {
 		return this.socketSource;
 	}
-	
+
 	/**
 	 * Returns a String containing the PC2 account name which the WTI server should use to login to the PC2 server to fetch
 	 * scoreboard information.
@@ -135,7 +142,7 @@ public class ServerInit {
 	public String getScoreboardAccount() {
 		return this.scoreboardAccount;
 	}
-	
+
 	/**
 	 * Returns a String containing the password for the PC2 scoreboard account.
 	 * @return a password String
@@ -143,7 +150,23 @@ public class ServerInit {
 	public String getScoreboardPassword() {
 		return this.scoreboardPassword;
 	}
-	
+
+	/**
+	 * Returns a String containing the SSL keystore file path.
+	 * @return a full path String
+	 */
+	public String getKeystoreFile() {
+		return this.keyStoreFilePath;
+	}
+
+	/**
+	 * Returns a String containing the SSL keystore password.
+	 * @return the password String
+	 */
+	public String getKeystorePassword() {
+		return this.keyStorePassword;
+	}
+
 	/**
 	 * This method constructs a JSON string containing the HTTP and WebSocket URLs which the WTI-UI front-end
 	 * code will use to contact this WTI server.  The JSON string is saved in a (hard-coded) file location
@@ -154,21 +177,21 @@ public class ServerInit {
 			ServerInit ini = ServerInit.createServerInit();
 			String localIpAddress = getLocalIp();
 			if (localIpAddress == null) throw new Exception("could not get local ip address.");
-			
-			String baseUrl = new StringBuilder("http://")
+
+			String baseUrl = new StringBuilder("https://")
 					.append(localIpAddress)
 					.append(":")
 					.append(ini.getPortNum())
 					.append("/api")
 					.toString();
-			
-			String websocketUrl = new StringBuilder("ws://")
+
+			String websocketUrl = new StringBuilder("wss://")
 					.append(localIpAddress)
 					.append(":")
 					.append(ini.getPortNum())
 					.append("/websocket/WTISocket")
 					.toString();
-			
+
 			JsonObject newJson = Json.createObjectBuilder()
 					.add("baseUrl", baseUrl)
 					.add("websocketUrl", websocketUrl)
@@ -183,16 +206,16 @@ public class ServerInit {
 			output.close();
 		}
 		catch (Exception ex) {
-			
+
 		}
 	}
-	
+
 	/**
 	 * Returns a String containing the local IP address of the machine on which the WTI server is running.
 	 * The returned address is initially obtained by calling {@link InetAddress#getHostAddress()} on the address
 	 * returned by {@link DatagramSocket#getLocalAddress()}. This is the address returned unless the pc2v9.ini
 	 * file contains an entry "wtiOverridePublicIP", in which case the value of that entry is returned instead.
-	 * 
+	 *
 	 * @return a String containing an IP address, or null if an exception occurs while fetching the local IP address.
 	 */
 	public static String getLocalIp() {
@@ -211,7 +234,7 @@ public class ServerInit {
 	}
 
 	/** Returns the {@link pc2.core.log.Log} logger being used by this WTI server
-	 * 
+	 *
 	 * @return a {@link pc2.core.log.Log} logger.
 	 */
 	public Log getLogger() {

--- a/projects/WTI-API/src/main/config/ServerInit.java
+++ b/projects/WTI-API/src/main/config/ServerInit.java
@@ -45,12 +45,14 @@ public class ServerInit {
     private final String WTI_USE_SSL_KEY = "useSSL";
     private final String WTI_KEY_STORE_PATH_KEY = "keyStoreFilePath";
     private final String WTI_KEY_STORE_PASSWORD_KEY = "keyStorePassword";
+    private final String WTI_CERT_ALIAS_KEY = "certificateAlias";
 
     private static final boolean DEF_USE_SSL = false;
     private static final int DEF_WTI_HTTP_PORT = 8080;
     private static final String DEF_WEBSOCK_PATH = "/websocket";
     private static final String DEF_SCOREBOARD_ACCT = "scoreboard2";
     private static final String DEF_SCOREBOARD_PASS = "scoreboard2";
+    private static final String DEF_KEY_STORE_PASSWORD = "contest";
 
 	private static ServerInit init = null;
 	private static String publicIPOverride;
@@ -63,8 +65,8 @@ public class ServerInit {
 	private String scoreboardPassword;
 
 	private String keyStoreFilePath;
-	private String keyStorePassword;
-
+	private String keyStorePassword = DEF_KEY_STORE_PASSWORD;
+	private String certAlias;
 
 	private Log logger;
 
@@ -107,6 +109,7 @@ public class ServerInit {
 
 		      keyStoreFilePath = p.getProperty(WTI_KEY_STORE_PATH_KEY);
 		      keyStorePassword = p.getProperty(WTI_KEY_STORE_PASSWORD_KEY);
+		      certAlias = p.getProperty(WTI_CERT_ALIAS_KEY);
 
 		      System.out.println ("Found the following properties in " + WTI_INI_FILE_KEY + ": " + p);
 
@@ -206,6 +209,14 @@ public class ServerInit {
 	 */
 	public String getKeystorePassword() {
 		return this.keyStorePassword;
+	}
+
+	/**
+	 * Returns a String containing the alias of the certificate to use from the keystore.
+	 * @return the certificate alias String
+	 */
+	public String getCertAlias() {
+		return this.certAlias;
 	}
 
 	/**

--- a/projects/WTI-API/src/main/config/WebServer.java
+++ b/projects/WTI-API/src/main/config/WebServer.java
@@ -35,6 +35,7 @@ import controllers.TeamsController;
 import edu.csus.ecs.pc2.api.ServerConnection;
 import edu.csus.ecs.pc2.api.exceptions.LoginFailureException;
 import edu.csus.ecs.pc2.api.exceptions.NotLoggedInException;
+import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.log.Log;
 import io.swagger.jaxrs.config.DefaultJaxrsConfig;
 
@@ -161,6 +162,13 @@ public class WebServer {
 	        SslContextFactory sslContextFactory = new SslContextFactory(true);
 	        sslContextFactory.setKeyStorePath(ini.getKeystoreFile());
             sslContextFactory.setKeyStoreType("PKCS12");
+            String alias = ini.getCertAlias();
+            // it's ok if this isn't specified since jetty will use the first one in the store
+            // you should specify a certificateAlias in the pc2v9.ini if there are multiple
+            // certificates in the key store file and you want to use a specific one.
+            if(!StringUtilities.isEmpty(alias)) {
+            	sslContextFactory.setCertAlias(alias);
+            }
 	        sslContextFactory.setKeyStorePassword(ini.getKeystorePassword());
 
             // suggestions from http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html

--- a/projects/WTI-API/src/main/config/WebServer.java
+++ b/projects/WTI-API/src/main/config/WebServer.java
@@ -8,8 +8,15 @@ import javax.servlet.ServletException;
 import javax.websocket.DeploymentException;
 import javax.websocket.server.ServerContainer;
 
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
@@ -17,6 +24,7 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -32,36 +40,36 @@ import io.swagger.jaxrs.config.DefaultJaxrsConfig;
 
 /**
  * This class encapsulates a Jetty webserver which acts as the WTI server listening for connections from team browsers.
- * 
+ *
  * The Jetty server is initialized with a set of {@link Handler}s for websocket connections, Swagger connections,
  * webcontent resources, and Jersey (JAX-RS) connections.
- * 
+ *
  * @author EWU WTI Student Project Team
  *
  */
 public class WebServer {
 	//the initialization values for the server
 	private static ServerInit ini;
-	
+
 	/**
 	 * Starts a Jetty server using the initialization values specified in the received {@link ServerInit} object.
-	 * 
+	 *
 	 * Verifies that the {@link ContestController} which will be used by Jetty will be able to successfully login to
-	 * the PC2 scoreboard account specified in the configuration.  If so, 
-	 * initializes the Jetty server with resource handlers, starts it listening on the port specified in the 
+	 * the PC2 scoreboard account specified in the configuration.  If so,
+	 * initializes the Jetty server with resource handlers, starts it listening on the port specified in the
 	 * received {@link ServerInit} object, and blocks (via a join()) waiting for the server to be shut down.
-	 * 
+	 *
 	 * @param initServer a {@link ServerInit} object containing initialization values for the server being started
-	 * 
+	 *
 	 * @throws LoginFailureException if a failure occurs when attempting to log in to the PC2 server using the
 	 * 								configured scoreboard account
 	 * @throws Exception if any other Exception occurs during webserver startup
 	 */
 	public static void startServer(ServerInit initServer) throws LoginFailureException, Exception {
 		ini = initServer;
-		
+
 		Log logger = ini.getLogger();
-		
+
 		try {
 			//make sure the ContestController created by the server is going to be able to login using the configured PC2 scoreboard account
 			if (!verifyPC2ScoreboardLogin()) {
@@ -78,17 +86,46 @@ public class WebServer {
 
 			//create a new Jetty server
 			logger.info("Creating Jetty server");
-			Server server = new Server(ini.getPortNum());
+			Server server = new Server();
 			System.out.println("Starting on port "+ini.getPortNum());
+
+	        // 1. Configure SSL Context with your keystore
+	        SslContextFactory sslContextFactory = new SslContextFactory(true);
+	        sslContextFactory.setKeyStorePath(ini.getKeystoreFile());
+            sslContextFactory.setKeyStoreType("PKCS12");
+	        sslContextFactory.setKeyStorePassword(ini.getKeystorePassword());
+
+            // suggestions from http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html
+            sslContextFactory.setIncludeCipherSuites("TLS_DHE_RSA.*", "TLS_ECDHE.*");
+            sslContextFactory.setExcludeProtocols("SSL", "SSLv2", "SSLv2Hello", "SSLv3");
+            sslContextFactory.setRenegotiationAllowed(false);
+
+            // 2. Configure HTTP Configuration
+            HttpConfiguration httpConfig = new HttpConfiguration();
+            httpConfig.setSecureScheme("https");
+            httpConfig.setSecurePort(ini.getPortNum());
+            httpConfig.setOutputBufferSize(32768);
+
+            HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
+            httpsConfig.addCustomizer(new SecureRequestCustomizer());
+
+            // 3. Create the HTTPS Connector
+            ServerConnector sslConnector = new ServerConnector(server,
+                new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
+                new HttpConnectionFactory(httpsConfig));
+            sslConnector.setPort(ini.getPortNum());
+            sslConnector.setIdleTimeout(0);
+
+            server.setConnectors(new Connector[] { sslConnector });
 
 			//install the endpoint handlers in Jetty
 			logger.info("Installing service handlers in Jetty");
 			server.setHandler(handlers);
-			
+
 			//start Jetty listening for endpoint references
 			logger.info("Starting Jetty server");
 			server.start();
-			
+
 			//block until all server threads are done (which won't normally happen - so, wait forever)
 			server.join();
 
@@ -106,12 +143,12 @@ public class WebServer {
 
 	//verifies that the provided (or default) PC2 scoreboard login credentials work
 	private static boolean verifyPC2ScoreboardLogin() {
-		
+
 		ini.getLogger().fine("Verifying PC2 scoreboard account login...");
-		
+
 		//create a scoreboard account connection to the PC2 server
 		ServerConnection scoreboardServerConn = new ServerConnection();
-	
+
 		//get the credentials to be used to login to the PC2 server, either those given in the WTI pc2v9.ini file or the defaults
 		String sbAccount = ini.getScoreboardAccount();
 		if (sbAccount==null || sbAccount.equals("")) {
@@ -121,7 +158,7 @@ public class WebServer {
 		if (sbPassword==null || sbPassword.equals("")) {
 			sbPassword = ContestController.DEFAULT_PC2_SCOREBOARD_PASSWORD;
 		}
-		
+
 		//try to login to the PC2 server
 		try {
 			ini.getLogger().fine("Attempting to login to PC2 scoreboard account '" + sbAccount + "'");
@@ -129,10 +166,10 @@ public class WebServer {
 		} catch (LoginFailureException e) {
 			ini.getLogger().severe("WTI Login failed for scoreboard account '" + sbAccount + "': " + e.getMessage());
 			return false;
-		} 
-		
+		}
+
 		ini.getLogger().fine("Successfully logged in to PC2 scoreboard account");
-		
+
 		//log the scoreboard account back out so the ContestController can re-login
 		try {
 			ini.getLogger().fine("Logging back out of PC2 scoreboard account pending team connections");
@@ -147,80 +184,89 @@ public class WebServer {
             System.err.println("Exception during scoreboard logout after successful login: " + e.getMessage());
             e.printStackTrace();
             return false;
-		    
+
 		}
-		
+
 		return true;
 	}
 
 	/**
-	 * Returns a {@link Handler} for websocket connections.  
-	 * 
-	 * The "context path" for the handler is set to be the websocket name specified in the {@link ServerInit} 
+	 * Returns a {@link Handler} for websocket connections.
+	 *
+	 * The "context path" for the handler is set to be the websocket name specified in the {@link ServerInit}
 	 * object used to start the server. An instance of {@link WTIWebsocketMediator} is set as an endpoint handler
 	 * for the handler.
-	 * 
-	 * @return a {@link ServletContextHandler} 
+	 *
+	 * @return a {@link ServletContextHandler}
 	 */
-	private static ServletContextHandler getWebsocketHandler() {
+//	private static WebSocketHandler getWebsocketHandler() {
+//		WebSocketHandler wsHandler = new WebSocketHandler() {
+//            @Override
+//            public void configure(WebSocketServletFactory factory) {
+//                // Register your custom socket class
+//                factory.register(WTIWebsocketMediator.class);
+//            }
+//		};
+//		return(wsHandler);
+private static ServletContextHandler getWebsocketHandler() {
 		ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
 		context.setContextPath(ini.getWsName());
 		try {
 			ServerContainer wscontainer = WebSocketServerContainerInitializer.configureContext(context);
 			wscontainer.addEndpoint(WTIWebsocketMediator.class);
-			
+
 		} catch (ServletException e) {
 			e.printStackTrace();
 		} catch (DeploymentException e) {
 			e.printStackTrace();
-		} 
+		}
 		return context;
 	}
-	
+
 	/**
 	 * Returns a {@link Handler} for webapp content.
-	 * 
+	 *
 	 * The webcontent resource base in the Handler is set to the WebContent folder of the WTI-UI project.
-	 * 
+	 *
 	 * @return a {@link ContextHandler}
 	 */
 	private static Handler getWebApp() {
-		
+
 		ResourceHandler webContent = new ResourceHandler();
 		webContent.setResourceBase("./WebContent/WTI-UI/");
-		
+
 		ContextHandler webApp = new ContextHandler();
 		webApp.setHandler(webContent);
-		
+
 		return webApp;
 	}
-	
+
 	/**
 	 * Returns a {@link Handler} for Swagger content.
-	 * 
+	 *
 	 * The webcontent resource base in the Handler is set to the WebContent folder of the WTI-UI project;
 	 * the context path for the Handler is set to "/swagger".
-	 * 
+	 *
 	 * @return a {@link ContextHandler}
 	 */
 	private static Handler getSwaggerHandler() {
 
 		ResourceHandler webContent = new ResourceHandler();
 		webContent.setResourceBase("./WebContent/webapp");
-		
+
 		ContextHandler swagger = new ContextHandler("/swagger");
 		swagger.setHandler(webContent);
-		
+
 		return swagger;
 	}
 
 	/**
 	 * Returns a {@link Handler} for Jersey (JAX-RS) connections.
-	 * 
-	 * The context path for the Handler is set to "/api"; the Handler has {@link ServletHolder}s containing 
+	 *
+	 * The context path for the Handler is set to "/api"; the Handler has {@link ServletHolder}s containing
 	 * JacksonJaxbJsonProvider, {@link TeamsController}, {@link ContestController}, {@link JacksonFeature},
 	 * Swagger, and CORS servlets.
-	 * 
+	 *
 	 * @return a {@link ServletContextHandler}
 	 * @throws LoginFailureException if the ContestController servlet could not log in to the PC2 server
 	 * @throws URISyntaxException if the URI built from the pc2v9.ini WTI attributes is invalid
@@ -229,21 +275,21 @@ public class WebServer {
 
 		//Add basic api servlet
 		ServletContextHandler api = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
-		api.setContextPath("/api"); 
+		api.setContextPath("/api");
 
 		ServletHolder servletHolder = api.addServlet(ServletContainer.class, "/*");
-		servletHolder.setInitParameter("jersey.config.server.provider.classnames", 
+		servletHolder.setInitParameter("jersey.config.server.provider.classnames",
 				"org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider, controllers.TeamsController, controllers.ContestController, org.glassfish.jersey.jackson.JacksonFeature");
 		servletHolder.setInitParameter("jersey.config.server.provider.packages", "jerseyConfig; io.swagger.jaxrs.json; io.swagger.jaxrs.listing");
 		servletHolder.setInitOrder(1); //force servlet to initialize when handler first starts
-		
-		
+
+
 		ServletHolder swaggerServlet = api.addServlet(DefaultJaxrsConfig.class, "/swagger-core");
 		swaggerServlet.setInitOrder(2);
 		swaggerServlet.setInitParameter("api.version", "1.0.0");
 		swaggerServlet.setInitParameter("swagger.api.basepath", String.format("http://%s:%s/api", ServerInit.getLocalIp(), ini.getPortNum()));
 		swaggerServlet.setInitParameter("swagger.api.title", "Web Team Interface");
-		
+
 		// Enable Cors
 		FilterHolder cors = api.addFilter(CrossOriginFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
 		cors.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");

--- a/projects/WTI-API/src/main/config/WebServer.java
+++ b/projects/WTI-API/src/main/config/WebServer.java
@@ -51,8 +51,17 @@ public class WebServer {
 	//the initialization values for the server
 	private static ServerInit ini;
 
+	public static void startServer(ServerInit initServer) throws LoginFailureException, Exception {
+		ini = initServer;
+		if(ini.isUseSSL()) {
+			startHTTPSServer();
+		} else {
+			startHTTPServer();
+		}
+	}
+
 	/**
-	 * Starts a Jetty server using the initialization values specified in the received {@link ServerInit} object.
+	 * Starts an HTTP Jetty server using the initialization values specified in the received {@link ServerInit} object.
 	 *
 	 * Verifies that the {@link ContestController} which will be used by Jetty will be able to successfully login to
 	 * the PC2 scoreboard account specified in the configuration.  If so,
@@ -65,15 +74,74 @@ public class WebServer {
 	 * 								configured scoreboard account
 	 * @throws Exception if any other Exception occurs during webserver startup
 	 */
-	public static void startServer(ServerInit initServer) throws LoginFailureException, Exception {
-		ini = initServer;
+	private static void startHTTPServer() throws LoginFailureException, Exception {
 
 		Log logger = ini.getLogger();
 
 		try {
 			//make sure the ContestController created by the server is going to be able to login using the configured PC2 scoreboard account
 			if (!verifyPC2ScoreboardLogin()) {
-				throw new LoginFailureException("PC2 Scoreboard login failed");
+				throw new LoginFailureException("PC2 Scoreboard login failed for HTTP");
+			}
+
+			// get the endpoint handlers which will be installed in Jetty
+			logger.info("Constructing HTTP Jetty service handlers");
+			HandlerList handlers = new HandlerList();
+			handlers.addHandler(getWebsocketHandler());
+			handlers.addHandler(getSwaggerHandler());
+			handlers.addHandler(getWebApp());
+			handlers.addHandler(getJerseyHandler());
+
+			//create a new Jetty server
+			logger.info("Creating HTTP Jetty server");
+			Server server = new Server(ini.getPortNum());
+			System.out.println("Starting HTTP on port "+ini.getPortNum());
+
+			//install the endpoint handlers in Jetty
+			logger.info("Installing HTTP service handlers in Jetty");
+			server.setHandler(handlers);
+
+			//start Jetty listening for endpoint references
+			logger.info("Starting HTTP Jetty server");
+			server.start();
+
+			//block until all server threads are done (which won't normally happen - so, wait forever)
+			server.join();
+
+		} catch (LoginFailureException ex) {
+			System.err.println("WTI HTTP server failed to login with PC2 Scoreboard account: " + ex);
+			logger.severe("WTI server failed to login with PC2 Scoreboard account: " + ex);
+			throw ex;
+		} catch (Exception ex) {
+			System.err.println(ex);
+			logger.severe("Exception during WTI HTTP server startup: " + ex);
+			throw ex;
+
+		}
+	}
+
+	/**
+	 * Starts an HTTPS Jetty server using the initialization values specified in the received {@link ServerInit} object.
+	 *
+	 * Verifies that the {@link ContestController} which will be used by Jetty will be able to successfully login to
+	 * the PC2 scoreboard account specified in the configuration.  If so,
+	 * initializes the Jetty server with resource handlers, starts it listening on the port specified in the
+	 * received {@link ServerInit} object, and blocks (via a join()) waiting for the server to be shut down.
+	 *
+	 * @param initServer a {@link ServerInit} object containing initialization values for the server being started
+	 *
+	 * @throws LoginFailureException if a failure occurs when attempting to log in to the PC2 server using the
+	 * 								configured scoreboard account
+	 * @throws Exception if any other Exception occurs during webserver startup
+	 */
+	private static void startHTTPSServer() throws LoginFailureException, Exception {
+
+		Log logger = ini.getLogger();
+
+		try {
+			//make sure the ContestController created by the server is going to be able to login using the configured PC2 scoreboard account
+			if (!verifyPC2ScoreboardLogin()) {
+				throw new LoginFailureException("PC2 Scoreboard login failed for HTTPS");
 			}
 
 			// get the endpoint handlers which will be installed in Jetty
@@ -85,9 +153,9 @@ public class WebServer {
 			handlers.addHandler(getJerseyHandler());
 
 			//create a new Jetty server
-			logger.info("Creating Jetty server");
+			logger.info("Creating HTTPS Jetty server");
 			Server server = new Server();
-			System.out.println("Starting on port "+ini.getPortNum());
+			System.out.println("Starting HTTPS on port "+ini.getPortNum());
 
 	        // 1. Configure SSL Context with your keystore
 	        SslContextFactory sslContextFactory = new SslContextFactory(true);
@@ -119,23 +187,23 @@ public class WebServer {
             server.setConnectors(new Connector[] { sslConnector });
 
 			//install the endpoint handlers in Jetty
-			logger.info("Installing service handlers in Jetty");
+			logger.info("Installing HTTPS service handlers in Jetty");
 			server.setHandler(handlers);
 
 			//start Jetty listening for endpoint references
-			logger.info("Starting Jetty server");
+			logger.info("Starting HTTPS Jetty server");
 			server.start();
 
 			//block until all server threads are done (which won't normally happen - so, wait forever)
 			server.join();
 
 		} catch (LoginFailureException ex) {
-			System.err.println("WTI server failed to login with PC2 Scoreboard account: " + ex);
-			logger.severe("WTI server failed to login with PC2 Scoreboard account: " + ex);
+			System.err.println("WTI HTTPS server failed to login with PC2 Scoreboard account: " + ex);
+			logger.severe("WTI HTTPS server failed to login with PC2 Scoreboard account: " + ex);
 			throw ex;
 		} catch (Exception ex) {
 			System.err.println(ex);
-			logger.severe("Exception during WTI server startup: " + ex);
+			logger.severe("Exception during WTI HTTPS server startup: " + ex);
 			throw ex;
 
 		}
@@ -208,7 +276,7 @@ public class WebServer {
 //            }
 //		};
 //		return(wsHandler);
-private static ServletContextHandler getWebsocketHandler() {
+	private static ServletContextHandler getWebsocketHandler() {
 		ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
 		context.setContextPath(ini.getWsName());
 		try {
@@ -287,7 +355,12 @@ private static ServletContextHandler getWebsocketHandler() {
 		ServletHolder swaggerServlet = api.addServlet(DefaultJaxrsConfig.class, "/swagger-core");
 		swaggerServlet.setInitOrder(2);
 		swaggerServlet.setInitParameter("api.version", "1.0.0");
-		swaggerServlet.setInitParameter("swagger.api.basepath", String.format("http://%s:%s/api", ServerInit.getLocalIp(), ini.getPortNum()));
+		String webProtocol = "https";
+		if(!ini.isUseSSL()) {
+			webProtocol = "http";
+		}
+		swaggerServlet.setInitParameter("swagger.api.basepath", String.format("%s://%s:%s/api",
+				webProtocol, ServerInit.getLocalIp(), ini.getPortNum()));
 		swaggerServlet.setInitParameter("swagger.api.title", "Web Team Interface");
 
 		// Enable Cors

--- a/projects/WTI-API/src/main/config/WebServer.java
+++ b/projects/WTI-API/src/main/config/WebServer.java
@@ -96,7 +96,10 @@ public class WebServer {
 			//create a new Jetty server
 			logger.info("Creating HTTP Jetty server");
 			Server server = new Server(ini.getPortNum());
-			System.out.println("Starting HTTP on port "+ini.getPortNum());
+
+			String infoMsg = "Starting HTTP on port "+ini.getPortNum();
+			System.out.println(infoMsg);
+			logger.info(infoMsg);
 
 			//install the endpoint handlers in Jetty
 			logger.info("Installing HTTP service handlers in Jetty");
@@ -156,7 +159,10 @@ public class WebServer {
 			//create a new Jetty server
 			logger.info("Creating HTTPS Jetty server");
 			Server server = new Server();
-			System.out.println("Starting HTTPS on port "+ini.getPortNum());
+
+			String infoMsg = "Starting HTTPS on port "+ini.getPortNum();
+			System.out.println(infoMsg);
+			logger.info(infoMsg);
 
 	        // 1. Configure SSL Context with your keystore
 	        SslContextFactory sslContextFactory = new SslContextFactory(true);

--- a/projects/WTI-API/src/main/controllers/MainController.java
+++ b/projects/WTI-API/src/main/controllers/MainController.java
@@ -51,7 +51,8 @@ public abstract class MainController {
 	protected static ServerInit ini = ServerInit.createServerInit();
 	protected static Log logger = Logging.getLogger();
 
-	private final String websocketUrl = String.format("wss://localhost:%s%s/WTISocket", ini.getPortNum(), ini.getWsName());
+	private final String websocketUrl = String.format("%s://localhost:%s%s/WTISocket",
+	        ini.isUseSSL() ? "wss" : "ws", ini.getPortNum(), ini.getWsName());
 	protected static WTIWebsocket client;
 
 	public MainController() throws URISyntaxException {

--- a/projects/WTI-API/src/main/controllers/MainController.java
+++ b/projects/WTI-API/src/main/controllers/MainController.java
@@ -46,12 +46,12 @@ public abstract class MainController {
 	// *** There may be a memory leak issue here: what if a team drops without invoking logout?  This might be a problem if
 	// this class were to be used in a contest running, say, over the Internet for days or weeks...
 	protected static HashMap<String, ServerConnection> connections = new HashMap<String, ServerConnection>();
-	
+
 	//the following two fields are "static" because they need to be referenced by the static initialization block in ContestController
 	protected static ServerInit ini = ServerInit.createServerInit();
 	protected static Log logger = Logging.getLogger();
-	
-	private final String websocketUrl = String.format("ws://localhost:%s%s/WTISocket", ini.getPortNum(), ini.getWsName());
+
+	private final String websocketUrl = String.format("wss://localhost:%s%s/WTISocket", ini.getPortNum(), ini.getWsName());
 	protected static WTIWebsocket client;
 
 	public MainController() throws URISyntaxException {
@@ -60,10 +60,10 @@ public abstract class MainController {
 	}
 
 	/**
-	 * Searches the given array of IProblems and returns the first problem whose name matches the specified 
+	 * Searches the given array of IProblems and returns the first problem whose name matches the specified
 	 * nameOfProblem, or returns an {@link EmptyProblem} object if there was no match.
 	 * <P>
-	 * Note that this method is only invoked by the {@link TeamsController} class, and only from TeamsController 
+	 * Note that this method is only invoked by the {@link TeamsController} class, and only from TeamsController
 	 * methods submitClarification(), submitRun(), and submitTestRun().  This means that the received array
 	 * contains only actual contest problems (in the case of being invoked by submitting a Run), or may
 	 * also contain "Categories" (which are, somewhat illogically, defined as "class Category extends Problem") in
@@ -75,10 +75,10 @@ public abstract class MainController {
 	 * ProblemImplementation (NOT an array of Problems).  This works because both ProblemImplementation and
 	 * Problem implement IProblem.  Thus, while the declared ("Apparent") type of the elements in the received
 	 * array is "IProblem", the ACTUAL TYPE of the elements will in all cases be "ProblemImplementation".
-	 * 
+	 *
 	 * @param problems an array of IProblems, which are actually ProblemImplementations.
 	 * @param nameOfProblem a String giving the name of the desired problem.
-	 * 
+	 *
 	 * @return the named problem if it is found in the input array; otherwise, an {@link EmptyProblem} object.
 	 */
 	protected IProblem findProblem(IProblem[] problems, String nameOfProblem) {
@@ -97,17 +97,17 @@ public abstract class MainController {
 				return lang;
 		return new EmptyLanguage();
 	}
-	
+
 	protected void subscription(Contest teamCon, String teamId) {
 		teamCon.addRunListener(new RunsService(teamId, client));
 //		teamCon.addTestRunListener(new TestRunService(teamId, client));  //this was commented-out because it requires implementing Test Run support in PC2 API
 		teamCon.addClarificationListener(new ClarificationService(teamId, client));
 		teamCon.addContestConfigurationUpdateListener(new ConfigurationService(teamId, client));
-		
+
 		//listen for a connectionDropped so we can notify the UI that a forced logout has happened
         teamCon.addConnectionListener(new DroppedConnectionListener(teamId, client));
 	}
-	
+
 	protected ServerConnection createNewServerConnection() {
 		return new ServerConnection();
 	}

--- a/samps/contests/clics_sumithello/config/system.pc2.yaml
+++ b/samps/contests/clics_sumithello/config/system.pc2.yaml
@@ -20,7 +20,17 @@ accounts:
 
   - account: SCOREBOARD
     site: 1
+    count: 2
+
+  - account: FEEDER
+    site: 1
     count: 1
+
+# enable perms for FEEDER 1 to edit runs and submit runs
+permissions:
+  - account: FEEDER
+    number: 1
+    enable: SHADOW_PROXY_TEAM, EDIT_RUN, START_CONTEST_CLOCK, STOP_CONTEST_CLOCK
     
 auto-judging:
   - account: JUDGE
@@ -40,5 +50,9 @@ auto-judging:
     number: 5
     letters: B
     enabled: yes
+
+# pc2 Shadow CCS settings
+shadow-mode: false
+ccs-test-mode : true
 
 # EOF Contest Configuration


### PR DESCRIPTION
### Description of what the PR does
Add optional support for HTTPS (SSL) Web Team Interface using 4 new keys in the WTI's `pc2v9.ini` file.

1. useSSL - 0 or 1 as to disable (0) or enable (1) HTTPS/SSL
2. keyStoreFilePath - Where the PKCS12 key self-signed certificate is stored
3. keyStorePassword - password used for protecting the self-signed keystore
4. certificateAlias - optional alias name of the certificate to use from the keystore.  Not needed if there's only one key in the keystore.

Instructions are included below on how to create a self-signed certificate and register it as a CA on the server and client machines.  
CI: Create **scoreboard** and **feeder** accounts by default on the **clics_sumithello** sample contest.

### Issue which the PR addresses
Fixes #104 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Unzip/extract the `pc2v9/projects/WebTeamInterface-1.2-.zip` to a clean folder.  For testing, I used: `C:\\Users\\Public`.  The zip will extract to `C:\\Users\\Public\\WebTeamInterface-1.2`.  For the rest of these steps, it will be assumed that the WTI is installed in that folder.  If you install it somewhere else, you'll have to adjust your paths accordingly.

2. A self-signed certificate has to be created.  The JDK **keytool** utility will be used to do this.  You will need the IP address of the machine from where you are running the WTI Server from.  The IP on my test machine is: 192.168.1.145.  You'll have to replace that in the command below with YOUR server's IP address.  Now, from a **administrator** command prompt, execute the following commands (note the `keytool` command has been broken up on several lines for clarity.  It should be entered as a single line.  When it prompts for a password, use '**contest**'):
```
cd \Users\Public\WebTeamInterface-1.2
keytool -genkeypair -alias WTIssl -keyalg RSA -keysize 2048
       -validity 365 -keystore wtikeystore.jks -storetype PKCS12
       -dname "CN=localhost, O=ICPC, L=Waco, S=TX, C=US" -ext
       "san=dns:localhost,dns:www.icpc.global,ip:127.0.0.1,
        ip:192.168.1.145"
```

3. Create the public certificate so we can add it to the JDK's trusted store.  Execute the following command to create `wtipublicssl.crt` (when it prompts you for a password, use the password you entered above, '**contest**'):
```
keytool -exportcert -alias WTIssl -keystore wtikeystore.jks -rfc -file wtipublicssl.crt
```

4. Add the public certificate to the JDK's trusted certificate key store.  This done so that when the **WTI-UI** makes API requests to the **WTI-API** over SSL, the _Jersey_ server will allow the connection using the trusted certificate.  You'll have to know where your JDK is installed for the next command.  Change the path to JDK in the command below to wherever you have yours installed.  Execute the following command (when prompted for a password, use '**changeit**' NOT '**contest**'.  It is asking for the password to the **_JDK_**'s trusted keystore, which is '**changeit**'):
```
keytool -import -alias WTIssl -file "wtipublicssl.crt"
        -keystore "C:/Program Files/Java/jdk1.8.0_321/jre/lib/security/cacerts"
```
  When it asks you to Trust this certificate?, type 'yes'.
Note: If you're using a newer version of the JDK, you may be able to replace the `-keystore "C:/Program Files/Java/jdk1.8.0_321/jre/lib/security/cacerts"` above with the -cacerts option.  Also, different versions of the JDK may put the cacerts file in a different place, so you may have to search for it in your JAVA_HOME.
  
5. Edit the `C:\Users\Public\WebTeamInterface-1.2\pc2v9.ini` file and enable HTTPS/SSL support by finding and changing the value of the `useSSL `key (in the `[Server]` section] from **0** to **1** and commenting out the `wtiport=8080` and uncommenting the line `wtiport=8443`.  This will enable HTTPS/SSL and have it use port **8443**. Also change the `keyStoreFilePath` key to `/Users/Public/WebTeamInterface-1.2/wtikeystore.jks`.  The relevant part of the `pc2v9.ini` should look something like this:
```
# For WebTeamInterface server
useSSL=1
#wtiport=8080
wtiport=8443
wtiwsName=/websocket
wtiscoreboardaccount=scoreboard2
wtiscoreboardpassword=scoreboard2

# For SSL
keyStoreFilePath=/Users/Public/WebTeamInterface-1.2/wtikeystore.jks
keyStorePassword=contest
```

6. Start up a clean contest using the **clics_sumithello** sample.
7. Start up the WTI
8. From a new command prompt, execute `netstat -na` and look for a line that shows it is listening on port 8443.  This confirms that the WTI server is in fact listening on the HTTPS SSL port.
```
  TCP    0.0.0.0:8443           0.0.0.0:0              LISTENING
```

10. On a client PC (which can be the same as the place you're running the server), we have to add the trusted certificate to the Operating System's trusted certificates.  On **Windows**, from **Explorer**, double-click on the `wtipublicssl.crt` file.  This will bring up the _Certificate import_ wizard.
 Click on the “**Install Certificate…**” button.
 For the **Store Location**, select **Local Machine**.  Click on the appropriate radio button and press **Next**.
 Select **Place all certificates in the following store**, and press the “**Browse…**” button.
 Look for the “**Trusted Root Certification Authorities**” and select it, then press **OK**.
 Press the **Next** button.
 Press the **Finish** button.
11. From a browser, browse to: [https://localhost:8443](https://localhost:8443)
12. The WTI splash screen (login page) should appear.  Log in using the standard username **team1** and password **team1**.
13. Click the **Scoreboard** tab.  The scoreboard should appear.  This indicates that end-to-end functionality has been achieved using HTTPS SSL.  This causes both browser and web socket traffic using port 8443 (HTTPS).
14. You can feel free to start the contest, make submissions, judge them, add clarifications, etc.


