### PR TITLE
I1251 wti scoreboard groups

### DIFF
--- a/projects/WTI-API/src/main/controllers/ContestController.java
+++ b/projects/WTI-API/src/main/controllers/ContestController.java
@@ -18,6 +18,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.XML;
@@ -38,9 +39,11 @@ import edu.csus.ecs.pc2.core.IniFile;
 import edu.csus.ecs.pc2.core.StringUtilities;
 import edu.csus.ecs.pc2.core.exception.IllegalContestState;
 import edu.csus.ecs.pc2.core.log.Log;
+import edu.csus.ecs.pc2.core.model.Account;
 import edu.csus.ecs.pc2.core.model.ClientId;
 import edu.csus.ecs.pc2.core.model.ClientType.Type;
 import edu.csus.ecs.pc2.core.model.ElementId;
+import edu.csus.ecs.pc2.core.model.Group;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.model.Run;
 import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
@@ -802,7 +805,8 @@ public class ContestController extends MainController {
 						//					logger.fine("Got the following XML from DSA:");
 						//					logger.fine(xmlStandings);
 						logger.info("Converting DSA XML to JSON");
-						currentJSONStandings = this.getJSONStandings(xmlStandings);
+						currentJSONStandings = this.enrichScoreboardTeamGroups(this.getJSONStandings(xmlStandings),
+								internalContest);
 						//					logger.fine("Got the following JSON standings:");
 						//					logger.fine(currentJSONStandings);
 					} catch (IllegalContestState e) {
@@ -869,6 +873,135 @@ public class ContestController extends MainController {
 		
 		return jsonStandingsObject.toString();
 
+	}
+
+	/**
+	 * Adds multi-group membership to each scoreboard row.
+	 * <p>
+	 * PC2 standings XML only carries the team's primary group on each {@code teamStanding} node
+	 * ({@code teamGroupId}, {@code teamGroupName}, {@code groupRank}). A team may belong to several groups;
+	 * the UI needs every {@code standingsHeader.groupList.group} {@code id} that should include that team.
+	 * </p>
+	 * <p>
+	 * For each team row, looks up the {@link Account} and appends a {@code teamGroupIds} array: for each
+	 * {@code group} in the header {@code groupList}, if {@code externalId} matches the group's CMS id and
+	 * the account {@link Account#isGroupMember} for that group, the group's {@code id} string is added.
+	 * Those ids match the scoreboard group filter in the browser.
+	 * </p>
+	 * <p>
+	 * On any failure, returns the input JSON unchanged.
+	 * </p>
+	 *
+	 * @param jsonStandings JSON string from {@link #getJSONStandings(String)}
+	 * @param contest       contest providing team accounts and {@link Group} definitions
+	 * @return JSON with {@code teamGroupIds} set on each processed {@code teamStanding}, or the original string if
+	 *         enrichment is skipped or throws
+	 */
+	private String enrichScoreboardTeamGroups(String jsonStandings, IInternalContest contest) {
+		if (jsonStandings == null || contest == null) {
+			return jsonStandings;
+		}
+		try {
+			JSONObject root = new JSONObject(jsonStandings);
+
+			// PC2 XML-to-JSON must expose contestStandings, header, and team rows. If any are missing,
+			// we cannot align group ids with teams, so return the payload unchanged (client keeps legacy behavior).
+			// (In other words, the following block of code verifies that all the required elements are found in
+			// the received jsonStandings.)
+			if (!root.has("contestStandings")) {
+				return jsonStandings;
+			}
+			JSONObject contestStandings = root.getJSONObject("contestStandings");
+			if (!contestStandings.has("standingsHeader") || !contestStandings.has("teamStanding")) {
+				return jsonStandings;
+			}
+			JSONObject standingsHeader = contestStandings.getJSONObject("standingsHeader");
+			JSONObject groupListObj = null;
+			// org.json may preserve "groupList" casing from XML; we also want to accept "grouplist" for defensive parsing.
+			if (standingsHeader.has("groupList")) {
+				groupListObj = standingsHeader.getJSONObject("groupList");
+			} else if (standingsHeader.has("grouplist")) {
+				groupListObj = standingsHeader.getJSONObject("grouplist");
+			}
+			// No group metadata means nothing to merge with account membership.
+			if (groupListObj == null || !groupListObj.has("group")) {
+				return jsonStandings;
+			}
+
+			// Header "group" entries use externalId (CMS group id) and id (sequential scoreboard id used in the UI filter).
+			// Construct a Map CMS id -> PC2 Group so we can call account.isGroupMember(ElementId) for each header row.
+			JSONArray groupArray = asJsonArray(groupListObj.get("group"));
+			HashMap<Integer, Group> groupByCmsId = new HashMap<Integer, Group>();
+			for (Group g : contest.getGroups()) {
+				groupByCmsId.put(Integer.valueOf(g.getGroupId()), g);
+			}
+
+			// Walk the list of teamStandings (one teamStanding element per team); for each team, insert into 
+			// the teamStanding an array containing teamGroupIds for the group(s) to which that team belongs.
+			Object rawTeams = contestStandings.get("teamStanding");
+			JSONArray teamArray = asJsonArray(rawTeams);
+			int defaultSite = contest.getSiteNumber();
+			for (int i = 0; i < teamArray.length(); i++) {
+				JSONObject team = teamArray.getJSONObject(i);
+				if (!team.has("teamId")) {
+					//can't do anything with this teamStanding row if it contains no teamId
+					continue;
+				}
+				//get the team number
+				int teamNum = team.optInt("teamId", -1);
+				if (teamNum < 0) {
+					continue;
+				}
+				//get the account associated with the team
+				int siteNum = team.has("teamSiteId") ? team.getInt("teamSiteId") : defaultSite;
+				ClientId cid = new ClientId(siteNum, Type.TEAM, teamNum);
+				Account account = contest.getAccount(cid);
+				if (account == null) {
+					//can't do anything with this team if there's no account for them
+					continue;
+				}
+				// Collect every scoreboard group "id" from the header for which this account belongs to that group.
+				JSONArray memberStandingsIds = new JSONArray();
+				for (int gi = 0; gi < groupArray.length(); gi++) {
+					JSONObject groupJson = groupArray.getJSONObject(gi);
+					if (!groupJson.has("externalId") || !groupJson.has("id")) {
+						continue;
+					}
+					int extId = groupJson.getInt("externalId");
+					Group scoredGroup = groupByCmsId.get(Integer.valueOf(extId));
+					if (scoredGroup != null && account.isGroupMember(scoredGroup.getElementId())) {
+						Object idObj = groupJson.get("id");
+						String standingsId = idObj == null ? "" : String.valueOf(idObj).trim();
+						if (!standingsId.isEmpty()) {
+							memberStandingsIds.put(standingsId);
+						}
+					}
+				}
+				//insert the groupIds for this team in the team's teamStanding row
+				team.put("teamGroupIds", memberStandingsIds);
+			}
+			
+			//return an updated JSON string which now also contains the groupIds in each teamStanding row
+			return root.toString();
+			
+		} catch (Exception e) {
+			// Malformed JSON, missing fields, or type mismatches: do not fail the request; the UI can still filter by primary teamGroupId.
+			logger.warning("ContestController.enrichScoreboardTeamGroups failed while adding teamGroupIds; returning unenriched JSON: " + e.getMessage());
+			return jsonStandings;
+		}
+	}
+
+	/** Wraps a single JSONObject from XML in a one-element JSONArray so callers can always use indexed loops. */
+	private static JSONArray asJsonArray(Object orig) throws JSONException {
+		if (orig == null) {
+			return new JSONArray();
+		}
+		if (orig instanceof JSONArray) {
+			return (JSONArray) orig;
+		}
+		JSONArray array = new JSONArray();
+		array.put(orig);
+		return array;
 	}
 
 	/**

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -7,7 +7,7 @@
                 <span class="scoreboard-group-filter-label">Group</span>
                 <select
                     [(ngModel)]="selectedGroupId"
-                    (ngModelChange)="onGroupFilterChange()"
+                    (change)="onGroupFilterChange($event)"
                     name="scoreboardGroup"
                     class="scoreboard-group-select">
                     <!-- add an "All Teams" option to the dropdown list -->

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.html
@@ -1,6 +1,23 @@
 <div class='filter-table-container'>
 
     <div class='table-container scoreboard-table'>
+    	<!-- Add a group-selection dropdown list, but only if there is more than one group in the contest containing teams -->
+        <div class='scoreboard-controls' *ngIf="groupOptions.length > 1">
+            <label class="scoreboard-group-filter">
+                <span class="scoreboard-group-filter-label">Group</span>
+                <select
+                    [(ngModel)]="selectedGroupId"
+                    (ngModelChange)="onGroupFilterChange()"
+                    name="scoreboardGroup"
+                    class="scoreboard-group-select">
+                    <!-- add an "All Teams" option to the dropdown list -->
+                    <option value="">All teams</option>
+                    <!-- add each separate group name to the dropdown list -->
+                    <option *ngFor="let g of groupOptions" [value]="g.id">{{ g.displayName }}</option>
+                </select>
+            </label>
+        </div>
+
 		<table style="border-collapse: separate; border-spacing: 6px 6px;">
             <tr>
                 <th>Rank</th>
@@ -23,10 +40,14 @@
                 </th>
                 <th style="text-align: center">Solved</th>
                 <th style="text-align: center">Score</th>
-                <th></th>
             </tr>
-            <tr *ngFor= 'let team of teamStandings' >
-                <td style="text-align: center">{{ team.rank }}</td>
+            <!-- loop through all teamStandings, tracking in-group index -->
+            <tr *ngFor="let team of teamStandings; let i = index">
+            
+            	<!-- display next team's rank WITHIN THE CURRENTLY SELECTED GROUP -->
+                <td style="text-align: center">{{ getDisplayRank(team, i) }}</td>
+                
+                <!-- display team name -->
                 <td>{{ team.teamName }}</td>
                 
   				<!-- Render problem detail cells, but only if the contest has started -->

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.scss
@@ -6,6 +6,36 @@
   flex: 1;
 }
 
+//scoreboard control elements such as group dropdown
+.scoreboard-controls {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  margin: 0 0 0.75rem;
+  padding: 0;
+}
+
+.scoreboard-group-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 100%;
+}
+
+.scoreboard-group-filter-label {
+	font-size: 0.9375rem;
+	font-weight: 600;
+	color: #333;
+}
+
+.scoreboard-group-select {
+  width: auto;
+  max-width: min(28rem, 100%);
+  min-width: 10rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 5px;
+  border: 1px solid $border1;
+}
+
 .scoreboard-table {
 	td, th {
   		padding: 2px 4px !important;		

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
@@ -103,10 +103,15 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	}
 
 	/**
-	 * Update scoreboard standings whenever group dropdown ("filter") changes
+	 * Update scoreboard standings whenever group dropdown ("filter") changes.
+	 * Blur the select afterward so arrow keys scroll the scoreboard instead of
+	 * cycling dropdown options (a focused native select keeps consuming those keys).
 	 */
-	onGroupFilterChange(): void {
+	onGroupFilterChange(event?: Event): void {
 		this.teamStandings = this.getFilteredStandings(this.fullTeamStandings);
+		if (event?.target instanceof HTMLSelectElement) {
+			event.target.blur();
+		}
 	}
 
 	/**

--- a/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
+++ b/projects/WTI-UI/src/app/modules/scoreboard/components/scoreboard-page/scoreboard-page.component.ts
@@ -3,7 +3,6 @@ import { IContestService } from 'src/app/modules/core/abstract-services/i-contes
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { AppTitleService } from 'src/app/modules/core/services/app-title.service';
-import * as Constants from 'src/constants';
 import { DEBUG_MODE } from 'src/constants';
 import { UiHelperService } from 'src/app/modules/core/services/ui-helper.service';
 
@@ -12,6 +11,11 @@ interface ProblemHeader {
     color: [number, number, number];
     textColor: 'black' | 'white';
     url: string;
+}
+
+interface ScoreboardGroupOption {
+	id: string;
+	displayName: string;
 }
   
 @Component({
@@ -22,6 +26,10 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	
 	private _unsubscribe = new Subject<void>();
 	teamStandings: any = [];
+	private fullTeamStandings: any[] = [];
+	groupOptions: ScoreboardGroupOption[] = [];
+	selectedGroupId = '';
+
 	numProblems: number = 0;
 	problemDetailHeaders: ProblemHeader[] = [];
 	
@@ -73,40 +81,266 @@ export class ScoreboardPageComponent implements OnInit, OnDestroy, DoCheck {
 	private loadStandings(): void {
 		this._contestService.getStandings()
 			.pipe(takeUntil(this._unsubscribe))
-			.subscribe((standings: string) => {
-				//console.log("standings string:");
-				//console.log(standings);
-				this.teamStandings = this.getTeamStandingsArray(standings);
+			.subscribe((standings: any) => {
+				// Snapshot all team rows, derive dropdown options from the header groupList (or from rows if the header is unusable),
+				// reset an invalid filter choice, then derive visible rows and table metadata from the same payload.
+				const rows = this.getTeamStandingsArray(standings);
+				this.fullTeamStandings = rows;
+				this.groupOptions = this.buildGroupDropdownOptions(standings, rows);
+				// Hide the filter unless two or more groups qualify; clear selection if the chosen group vanished.
+				if (this.groupOptions.length <= 1) {
+					this.selectedGroupId = '';
+				} else if (
+					this.selectedGroupId !== '' &&
+					!this.groupOptions.some(g => g.id === this.selectedGroupId)
+				) {
+					this.selectedGroupId = '';
+				}
+				this.teamStandings = this.getFilteredStandings(rows);
 				this.numProblems = this.getNumProblems(standings);
 				this.problemDetailHeaders = this.getProblemDetailHeaders(standings);
 			});
+	}
+
+	/**
+	 * Update scoreboard standings whenever group dropdown ("filter") changes
+	 */
+	onGroupFilterChange(): void {
+		this.teamStandings = this.getFilteredStandings(this.fullTeamStandings);
+	}
+
+	/**
+	 * Returns the value shown in the Rank column for one team row, depending on whether a group filter is active.
+	 *
+	 * - No group selected: use contest-wide {@code rank} from the standings payload (PC2 overall placement).
+	 * - Group selected and this row's primary group matches the filter ({@code teamGroupId}): use {@code groupRank}
+	 *   when present (within-group rank from PC2 for that primary group).
+	 * - Group selected but the row is included because of another group (e.g. {@code teamGroupIds}) or {@code groupRank}
+	 *   is missing: use {@code filteredIndex + 1} for a simple 1-based order in the currently filtered table.
+	 *
+	 * PC2 only emits {@code groupRank} for the team's primary group; it is not reused when the user filters to a
+	 * non-primary group membership.
+	 *
+	 * @param team one element from {@code teamStandings} (filtered or full)
+	 * @param filteredIndex zero-based index in the current {@code teamStandings} array (after group filter)
+	 */
+	getDisplayRank(team: any, filteredIndex: number): string | number {
+		if (this.selectedGroupId === '') {
+			return team.rank;
+		}
+		const primaryMatches = String(team.teamGroupId ?? '') === this.selectedGroupId;
+		if (primaryMatches) {
+			const gr = team.groupRank;
+			if (gr !== undefined && gr !== null && String(gr) !== '') {
+				return gr;
+			}
+		}
+		return filteredIndex + 1;
 	}
 
 
 	/**
 	 * Pull each teamStanding node out of the received JSON, load it into an array,
 	 * and return the array of team standing elements.
+	 * Normalizes each row's problemSummaryInfo to an array so the template NgFor never receives a lone object.
 	 */
-	private getTeamStandingsArray(standings: any) {
+	private getTeamStandingsArray(standings: any): any[] {
+		const contest = standings?.contestStandings;
+		if (!contest) {
+			return [];
+		}
+		const teams = this.normalizeToArray(contest.teamStanding);
+		for (const team of teams) {
+			this.ensureProblemSummaryInfoArray(team);
+		}
+		return teams;
+	}
 
-		const contest = standings.contestStandings ;
-		//console.log("ContestStandings element:");
-		//console.log(contest);
-		
-		const teams = contest.teamStanding ;
-		//console.log("TeamStandings elements:");
-		//console.log(teams);
-		
-		let tempArray: any = [] ;
-		
-		for (let temp of teams) {
-			tempArray.push(temp);
+	/** Repeated XML elements may arrive as one object or an array depending on parser and row count.
+	  * This method ensures the specified "nodes" argument is an iterable array.
+	  */
+	private normalizeToArray(nodes: unknown): any[] {
+		if (nodes == null) {
+			return [];
+		}
+		return Array.isArray(nodes) ? nodes : [nodes];
+	}
+
+	/**
+	 * XML-to-JSON may emit a lone problemSummaryInfo object; template NgFor requires an iterable array.
+	 * Missing or null becomes an empty array.
+	 */
+	private ensureProblemSummaryInfoArray(team: unknown): void {
+		if (!team || typeof team !== 'object') {
+			return;
+		}
+		const row = team as Record<string, unknown>;
+		const psi = row.problemSummaryInfo;
+		if (psi == null) {
+			row.problemSummaryInfo = [];
+		} else if (!Array.isArray(psi)) {
+			row.problemSummaryInfo = [psi];
+		}
+	}
+
+	/**
+	 * Returns an array of options for populating the scoreboard Group dropdown. The preferred source is 
+	 * standingsHeader.groupList.group (see DefaultScoringAlgorithm.dumpGroupList)
+	 * with teamCount > 0. Option values use each group's "id" (matches WTI-enriched teamGroupIds / legacy teamGroupId).
+	 * If the header omits usable group rows, falls back to groups inferred from team standings.
+	 */
+	private buildGroupDropdownOptions(standings: any, teams: any[]): ScoreboardGroupOption[] {
+		const fromHeader = this.buildGroupOptionsFromHeader(standings);
+		if (fromHeader.length > 0) {
+			return fromHeader;
+		}
+		return this.buildGroupOptionsFromTeamRows(teams);
+	}
+
+	/** Builds an array of Group Options from standingsHeader.groupList, using only entries with teamCount 
+	 *  strictly greater than zero. 
+	 */
+	private buildGroupOptionsFromHeader(standings: any): ScoreboardGroupOption[] {
+		const header = standings?.contestStandings?.standingsHeader;
+		//if header is missing, the groupList is empty
+		if (!header) {
+			return [];
+		}
+		//if there is no grouplist (aka groupList) in the header, the group list is empty
+		const groupList = header.groupList ?? header.grouplist;
+		if (!groupList || typeof groupList !== 'object') {
+			return [];
 		}
 		
-//		console.log("Individual Team Standings:");
-//		console.log(tempArray);
+		//get the list of groups
+		const raw = (groupList as { group?: unknown }).group;
 		
-		return tempArray;
+		//ensure we have an ARRAY of group objects
+		const groups = this.normalizeToArray(raw);
+		
+		//start with an empty list of group dropdown options
+		const out: ScoreboardGroupOption[] = [];
+		
+		//check each group in the groupList.  For each group, safely read id/title/teamCount across JSON quirks; 
+		//keep only groups with a non-empty id and positive team count; assign a readable label.
+		for (const g of groups) {
+		
+			//normalize each item in this group to an object, either what it was to start with or an empty-string Record
+			const row = g && typeof g === 'object' ? (g as Record<string, unknown>) : {};
+			
+			//pull the standard fields (id, title, teamCount, etc.) out of the group row
+			const id = this.readXmlishField(row, 'id');
+			const title = this.readXmlishField(row, 'title');
+			const teamCountVal = this.readXmlishField(row, 'teamCount');
+			const teamCountAlt = row['teamcount'] ?? row['team_count'];
+			const tc = this.parsePositiveCount(teamCountVal ?? teamCountAlt);
+			const stringGroupId = id !== undefined && id !== null && String(id).trim() !== ''
+				? String(id).trim()
+				: '';
+				
+			//skip invalid or empty groups
+			if (stringGroupId === '' || !(tc > 0)) {
+				continue;
+			}
+			
+			//If title is present (after trim), use it as label; otherwise use 'Group+stringId' as label
+			const label = title !== undefined && title !== null && String(title).trim() !== ''
+				? String(title).trim()
+				: `Group ${stringGroupId}`;
+				
+				
+			//insert the stringGroupId and label into the output array
+			out.push({ id: stringGroupId, displayName: label });
+		}
+		
+		//return options sorted alphabetically by display name, case-insensitive
+		return out.sort((a, b) =>
+			a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' })
+		);
+	}
+
+	/**
+	 * The fields in scoreboard records come from XML converted to JSON.  Depending on what XML serializer and
+	 * schema was used, the same conceptual attribute (id, title, teamCount, ...) can appear either
+	 * directly as a property on the object representing the <group> element, e.g. { id: "1", title: "..." }, or
+	 * inside a synthetic child keyed something like @attributes, e.g. { "@attributes": { id: "1", title: "..." } }.
+	 * readXmlishField is a tiny normalization helper: "give me the value for logical field field from this JSON object, 
+	 * no matter which of those two layouts we got."
+	 */
+	private readXmlishField(obj: Record<string, unknown>, field: string): unknown {
+		// JSON-from-XML sometimes puts attributes on @attributes instead of alongside child nodes.
+		if (field in obj) {
+			return obj[field];
+		}
+		const attr = obj['@attributes'];
+		if (attr && typeof attr === 'object' && field in (attr as object)) {
+			return (attr as Record<string, unknown>)[field];
+		}
+		return undefined;
+	}
+
+	private parsePositiveCount(value: unknown): number {
+		if (value === undefined || value === null) {
+			return NaN;
+		}
+		if (typeof value === 'number') {
+			return Number.isFinite(value) ? value : NaN;
+		}
+		const n = parseInt(String(value).trim(), 10);
+		return Number.isFinite(n) ? n : NaN;
+	}
+
+	/** Fallback: one row per teamGroupId present on team standings (legacy / missing header). */
+	private buildGroupOptionsFromTeamRows(teams: any[]): ScoreboardGroupOption[] {
+		const idToLabel = new Map<string, string>();
+		for (const row of teams) {
+			const id = row?.teamGroupId;
+			const name = row?.teamGroupName;
+			if (id === undefined || id === null || String(id).trim() === '') {
+				continue;
+			}
+			const sid = String(id);
+			idToLabel.set(sid, (name !== undefined && name !== null && String(name).trim() !== '')
+				? String(name)
+				: `Group ${sid}`);
+		}
+		return Array.from(idToLabel.entries())
+			.sort((a, b) => a[1].localeCompare(b[1], undefined, { sensitivity: 'base' }))
+			.map(([id, displayName]) => ({ id, displayName }));
+	}
+
+	private getFilteredStandings(allRows: any[]): any[] {
+		if (this.selectedGroupId === '') {
+			return allRows.slice();
+		}
+		const sid = this.selectedGroupId;
+		// WTI puts all group ids on each row; otherwise only PC2 primary teamGroupId exists.
+		return allRows.filter(row => this.rowBelongsToSelectedGroup(row, sid));
+	}
+
+	/**
+	 * Prefer WTI-enriched `teamGroupIds` (all groups the team belongs to).
+	 * Otherwise fall back to PC2's single {@code teamGroupId} (primary group only).
+	 */
+	private rowBelongsToSelectedGroup(row: any, selectedId: string): boolean {
+		const ids = this.getTeamGroupIdsFromRow(row);
+		if (ids.length > 0) {
+			return ids.indexOf(selectedId) >= 0;
+		}
+		return String(row.teamGroupId ?? '') === selectedId;
+	}
+
+	private getTeamGroupIdsFromRow(row: any): string[] {
+		const raw = row?.teamGroupIds;
+		if (raw == null) {
+			return [];
+		}
+		if (Array.isArray(raw)) {
+			return raw
+				.map((x: unknown) => String(x).trim())
+				.filter(s => s !== '');
+		}
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
### Description of what the PR does

Adds support for selecting different groups on the WTI scoreboard.  Specifically,
- Updates WTI-UI `scoreboard-page.component.{ts,html,sccs}` so that if there is more than one `group` containing teams in the contest, a dropdown list for group selection appears on the WTI Scoreboard page; selecting a group from the dropdown causes the scoreboard to display (only) teams in the selected group, ranked from 1..N within the selected group.
- Updates WTI-API `ContestController` so that it augments the JSON returned to a `scoreboard` endpoint query to include all groups of which the requesting team is a member (the existing implementation only provides a team's "primary group", which is not sufficient to determine what teams to display if teams can be members of more than one group).

### What the PR does NOT do:
- Does not provide support for contests set up with "divisions" (for example, PacNW contests).  That is, the PR only supports contests where there is no `wtiBoardUseDivisions` entry in the WTI `pc2v9.ini` file.  Support for divisions will be handled via work under a separate Issue:  #689.

### Issue which the PR addresses

Fixes #1251

### Environment in which the PR was developed:
Windows 11, java version "1.8.0_381", Chrome Version 148.0.7778.96 (Official Build) (64-bit)

### Precise steps for _testing_ the PR:

#### Setup
- Download and unzip the PR distribution (or build it on your own machine from the branch).

#### Verify that the WTI Scoreboard works correctly when there are multiple displayable groups but a given team only appears in single group.
1. Download and unzip the `WF49BakuFinalized.zip` file from https://drive.google.com/drive/folders/1GPl7c8MzmhSUZ905vvPkpE59FR_Y4EwC?usp=drive_link. This is a PC2 profile for the WF Baku contest, in which there are multiple displayable groups but each team is a member of only one group.
1. Copy the `/profiles` folder and the `profiles.properties` file into the root of the unzipped PC2 distribution.
1. Start a PC2 server and PC2 Admin.
1. Verify that the Admin shows accounts, problems, etc. from the proper contest.
1. On the PC2 Admin `ConfigureContest>Accounts` tab, edit the `scoreboard2` account:  change the password to "scoreboard2" (an alternative would be to update the WTI pc2v9.ini file to specify the existing scoreboard2 password prior to starting the WTI Server).
1. In the PC2 distribution "projects" folder, unzip the `WTI-Interface.zip` file.
1. In the resulting WTI-Interface folder, start the WTI Server (`./bin/pc2wti`).
1. Verify that the last line on the console indicates the server was started.
1. Open a browser. Either clear the browser's cache, or open an "Icognito mode" browser window.
1. Connect to the WTI server (typically by opening http://localhost:8080).
1. Login as a team.  You can use any team in the contest, but you'll have to look on the PC2 Admin Accounts tab, select a team, and Edit the team to get the correct password.
1. Select the `Scoreboard` menu on the WTI.
1. Verify that a `Group` dropdown list appears at the top of the scoreboard, and that the default (selected) entry is "All teams".
1. Verify that the rankings shown on the WTI scoreboard match those shown on the PC2 Admin `RunContest>Standings` screen.
1. On the WTI Scoreboard `Groups` dropdown, select a specific group.
1. On the PC2 Admin `RunContest>Standings` screen, click the checkbox in the right-side panel that matches the selected group.
1. Verify that standings shown in the WTI Scoreboard match those shown on the PC2 Admin for the same group.
1. If desired (just to convince yourself), select different groups on the WTI and PC2 Admin and verify they match.

#### Verify that the WTI Scoreboard works correctly when there are multiple displayable groups and a given team appears in multiple groups.
1. Shut down the WTI browser and the WTI Server.
1. On the PC2 Admin `Configure Contest` screen, `Accounts` tab, select any team.  Notice what Group is listed for that team (in the `Groups` column).
1.  Click the `Edit` button, and scroll down in the `Groups` pane and verify that the correct Group (from the previous step) is checked.
1.  Add a checkmark for a DIFFERENT GROUP -- but make sure it is one of the actual groups for this contest (Africa&Arab, Asia East, Asia West, Asia Pacific, Europe, Latin America, Northern Eurasia, or North America).    Do NOT disable the checkmark which already existed.  (The effect of this is that you have put this particular team in multiple groups).
1. Repeat the above step for an additional one or two teams -- so that you have several teams in multiple different groups.
1. Restart the WTI server, open a browser, login as a team, and select the WTI "Scoreboard" menu.  
1. Select each of the groups in the dropdown "Group" list; verify that each team you assigned to multiple groups does appear in that group's scoreboard (and also that each team still appears in its original group scoreboard).
1. Verify that each group's WTI scoreboard matches the PC2 Admin Standings for that group.

#### Verify that the WTI Scoreboard works correctly when there is exactly one displayable group and all teams are in that group.
1. Shut down the WTI browser, the WTI Server, the PC2 Admin, and the PC2 server.
1. In the PC2 distribution root, DELETE the `profiles` and `logs` folders, and the `profiles.properties` file.  
1. In the PC2 distribution `projects` folder, DELETE the `WebTeamInterface` folder (but not the `.zip` file from which that folder was extracted).  This puts you back to a clean PC2 installation.
1. Download and unzip the `GNY2025Finalized.zip` file from https://drive.google.com/drive/folders/1GPl7c8MzmhSUZ905vvPkpE59FR_Y4EwC?usp=drive_link.  (This is a contest with just one displayable group.)
1. Copy the `/profiles` folder and the `profiles.properties` file into the root of the unzipped (clean) PC2 distribution.
1. Follow steps 3-12 (only) above to get to the WTI Scoreboard page.  (Note: the Admin password is "Gny2o25".)
1. Verify that **there is no "Group" dropdown** on the WTI scoreboard.  (This is because the PR only provides a "Group" dropdown when there's more than one selectable group.)
1. If desired, verify that the WTI scoreboard results as shown match PC2.  Since the contest is "Finalized" but the Scoreboard is still "Frozen", you will see "Pending Runs" on the WTI scoreboard.  To unfreeze the scoreboard, you'll need to do the following:
    -   On the PC2 Admin Settings tab, click `Unfreeze Scoreboard`.
    -  Click `Update` at the bottom of the Admin Settings screen.
1. Verify that the WTI scoreboard standings match those shown in the PC2 Admin `ConfigureContest>Standings` tab.



#### Verify that contests without groups work correctly.
1. Shut down the WTI browser, the WTI Server, the PC2 Admin, and the PC2 server.
1. In the PC2 distribution root, DELETE the `profiles` and `logs` folders, and the `profiles.properties` file.  
1. In the PC2 distribution `projects` folder, DELETE the `WebTeamInterface` folder (but not the `.zip` file from which that folder was extracted).  This puts you back to a clean PC2 installation.
1. Download and unzip the `PC2MultiSumitHelloSample.zip` file from https://drive.google.com/drive/folders/1GPl7c8MzmhSUZ905vvPkpE59FR_Y4EwC?usp=drive_link.  This is a PC2 profile for a contest with no groups.
1. Copy the `/profiles` folder and the `profiles.properties` file into the root of the unzipped (clean) PC2 distribution.
1. Follow steps 3-12 (only) above to get to the WTI Scoreboard page. The PC2 Admin password is the default; there should be 8 problems in the contest named Hello1, Hello2, Hello3, Hello4, Sumit1, Sumit2, Sumit3, and Sumit4.  There should be 28 runs in the contest.
1. Verify that **there is no "Group" dropdown** on the WTI scoreboard.  (This is because the PR only provides a "Group" dropdown when there's more than one selectable group.)
1. Verify that the WTI scoreboard standings match those shown in the PC2 Admin `ConfigureContest>Standings` tab.


