### PR TITLE
i_1286 Validate user-entered freeze duration in ContestInformationPane

### DIFF
--- a/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
+++ b/src/edu/csus/ecs/pc2/ui/ContestInformationPane.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.awt.BorderLayout;
@@ -51,9 +51,11 @@ import edu.csus.ecs.pc2.core.CommandVariableReplacer;
 import edu.csus.ecs.pc2.core.Constants;
 import edu.csus.ecs.pc2.core.IInternalController;
 import edu.csus.ecs.pc2.core.StringUtilities;
+import edu.csus.ecs.pc2.core.Utilities;
 import edu.csus.ecs.pc2.core.model.ContestInformation;
 import edu.csus.ecs.pc2.core.model.ContestInformation.TeamDisplayMask;
 import edu.csus.ecs.pc2.core.model.ContestInformationEvent;
+import edu.csus.ecs.pc2.core.model.ContestTime;
 import edu.csus.ecs.pc2.core.model.IContestInformationListener;
 import edu.csus.ecs.pc2.core.model.IInternalContest;
 import edu.csus.ecs.pc2.core.scoring.DefaultScoringAlgorithm;
@@ -1109,9 +1111,12 @@ public class ContestInformationPane extends JPanePlugin {
 
     /**
      * Returns a new ContestInformation object containing data fetched from this pane's fields.
+     * @param validating If true, some display fields will be validated and throw an IllegalArgumentException if bad.
+     *        In addition, if true, some display fields may be changed (normalized).
      * @return a ContestInformation object
+     * @throws IllegalArgumentException if a field value is bad
      */
-    protected ContestInformation getFromFields() {
+    protected ContestInformation getFromFields(boolean validating) throws IllegalArgumentException {
         ContestInformation newContestInformation = new ContestInformation();
         ContestInformation currentContestInformation = getContest().getContestInformation();
 
@@ -1180,8 +1185,8 @@ public class ContestInformationPane extends JPanePlugin {
             newContestInformation.setContestShortName(savedContestInformation.getContestShortName());
             newContestInformation.setExternalYamlPath(savedContestInformation.getExternalYamlPath());
 
-            //TODO: why is the following being done here when it is overridden below?
-            newContestInformation.setFreezeTime(savedContestInformation.getFreezeTime());
+            // setFreezeTime is always called below so this is indeed unnecessary
+            // newContestInformation.setFreezeTime(savedContestInformation.getFreezeTime());
 
             newContestInformation.setLastRunNumberSubmitted(savedContestInformation.getLastRunNumberSubmitted());
             newContestInformation.setAutoStartContest(savedContestInformation.isAutoStartContest());
@@ -1189,11 +1194,25 @@ public class ContestInformationPane extends JPanePlugin {
 
         newContestInformation.setScoringProperties(scoringPropertiesPane.getProperties());
 
-        newContestInformation.setFreezeTime(contestFreezeLengthTextField.getText());
+        // make sure time is formatted properly
+        String freezeField = contestFreezeLengthTextField.getText();
+        long freezeSeconds = Utilities.convertStringToSeconds(freezeField);
+        if(freezeSeconds == -1) {
+            if(validating) {
+                throw new IllegalArgumentException("Invalid freeze time \"" + freezeField + "\" specified.");
+            }
+        } else {
+            freezeField = ContestTime.formatTime(freezeSeconds);
+            if(validating) {
+                // Update display to show possibly normalized freeze duration
+                contestFreezeLengthTextField.setText(freezeField);
+            }
+        }
+        newContestInformation.setFreezeTime(freezeField);
 
         newContestInformation.setThawed(scoreboardHasBeenUnfrozen);
 
-        // fill in sandbox/interative grace time adjustments
+        // fill in sandbox/interactive grace time adjustments
         newContestInformation.setSandboxGraceTimeSecs(StringUtilities.getIntegerValue("0" + getSandboxGraceTimeTextField().getText(), savedContestInformation.getSandboxGraceTimeSecs()));
         newContestInformation.setSandboxInteractiveGraceMultiplier(StringUtilities.getIntegerValue("0" + this.getSandboxInteractiveMultiplierTextField().getText(), savedContestInformation.getSandboxInteractiveGraceMultiplier()));
 
@@ -1219,7 +1238,7 @@ public class ContestInformationPane extends JPanePlugin {
     }
 
     protected void enableUpdateButton() {
-        ContestInformation newChoice = getFromFields();
+        ContestInformation newChoice = getFromFields(false);
 
         if (getContest().getContestInformation().isSameAs(newChoice)) {
             setEnableButtons(false);
@@ -1308,7 +1327,14 @@ public class ContestInformationPane extends JPanePlugin {
 
 
     private void updateContestInformation() {
-        ContestInformation contestInformation = getFromFields();
+        ContestInformation contestInformation = null;
+
+        try {
+            contestInformation = getFromFields(true);
+        } catch(IllegalArgumentException e) {
+            JOptionPane.showMessageDialog(null, e.getLocalizedMessage(), "Bad Value Specified", JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
 
         getController().updateContestInformation(contestInformation);
     }
@@ -1994,7 +2020,7 @@ public class ContestInformationPane extends JPanePlugin {
         }
         return rigidArea3;
     }
-    
+
     private Component getRigidArea4() {
         if (rigidArea4==null) {
             rigidArea4 = Box.createRigidArea(new Dimension(20,20));


### PR DESCRIPTION
### Description of what the PR does
Make sure the user entered a valid freeze duration when an attempt is made to save (update) the settings. Throw an exception if it's bad.  In the future, additional fields can easily be validated and throw an exception as well.

Cleaned up some comments and dunsel code.

### Issue which the PR addresses
Fixes #1286 
### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 11
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
1) Load a new contest such as `clics_sumithello`
2) Start the **administrator1** client up
3) On the **Configure Contest->Settings** tab, enter an invalid _Scoreboard Freeze Length_, such as `a:30:00` and press **Update**.
4) Note that a message dialog is displayed indicating the value is bad:
 
<img width="527" height="365" alt="image" src="https://github.com/user-attachments/assets/f4c4ea50-3d06-4cc9-8e2f-17c96edde3d3" />

Previously, this incorrect value was accepted and set.
5. Dismiss the message box.
6. Enter a value such as `25:00` and press **Update**.
7. Note the value changes in the text field to "0:25:00" (which is the normalized format).
<img width="533" height="277" alt="image" src="https://github.com/user-attachments/assets/c509cef8-bfb7-4bd4-aa4a-116c483b7e8b" />

**Note:** The freeze length entered will be normalized.  That is, a value of 160:00 will be normalized to 2:40:00 since 160 minutes is 2 hours and 40 minutes.   In addition, entering a freeze length of 3600 would set the freeze time to 1:00:00.  This behavior is by design (existing methods were used to perform this normalization process).  Feel free to try it.
