### PR TITLE
i1235: enforce uncompressed source size for pc2submit zip submissions

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/SubmissionService.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -658,7 +659,17 @@ public class SubmissionService implements Feature {
                     return Response.status(Response.Status.BAD_REQUEST).entity("only one zip archive is allowed").build();
                 }
 
-                srcFiles = EventFeedUtilities.getIFiles(firstFile.getData());
+                try {
+                    byte[] zipBytes = Base64.getDecoder().decode(firstFile.getData());
+                    long maxSourceSizeBytes = model.getContestInformation().getMaxSourceSizeInBytes();
+                    EventFeedUtilities.enforceUncompressedZipSourceSizeLimit(zipBytes, maxSourceSizeBytes);
+                    srcFiles = EventFeedUtilities.getIFiles(zipBytes, maxSourceSizeBytes);
+                } catch (SubmissionRejectedException sre) {
+                    log.log(Level.WARNING, "SubmissionRejectedException (Source too large) submitting CLICS API run for team "
+                            + team_id + " by " + user);
+                    return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
+                            .entity("Unable to submit run: " + sre.getLocalizedMessage()).build();
+                }
             }
             String entry = sub.getEntry_point();
             IFile mainFile = srcFiles.get(0);

--- a/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
+++ b/src/edu/csus/ecs/pc2/convert/EventFeedUtilities.java
@@ -4,15 +4,19 @@ package edu.csus.ecs.pc2.convert;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
+import edu.csus.ecs.pc2.core.exception.SubmissionRejectedException;
 import edu.csus.ecs.pc2.core.model.IFile;
 import edu.csus.ecs.pc2.core.model.IFileImpl;
 
@@ -132,6 +136,94 @@ public final class EventFeedUtilities {
     }
 
     /**
+     * Reject a zip if the claimed uncompressed size of its file entries exceeds {@code maxSourceSizeBytes}.
+     * Uses zip central-directory metadata ({@link ZipEntry#getSize()}); does not inflate entry contents.
+     * A {@code maxSourceSizeBytes} of 0 or less means there is no source-size limit.
+     *
+     * @param base64Data base64-encoded zip bytes
+     * @param maxSourceSizeBytes contest maximum combined source size in bytes
+     * @throws SubmissionRejectedException if the claimed uncompressed size exceeds the limit
+     * @throws IllegalArgumentException if the data is not valid base64, the zip is unreadable, or an entry size is unknown
+     */
+    public static void enforceUncompressedZipSourceSizeLimit(String base64Data, long maxSourceSizeBytes)
+            throws SubmissionRejectedException {
+        enforceUncompressedZipSourceSizeLimit(Base64.getDecoder().decode(base64Data), maxSourceSizeBytes);
+    }
+
+    /**
+     * Reject a zip if the claimed uncompressed size of its file entries exceeds {@code maxSourceSizeBytes}.
+     * Uses zip central-directory metadata ({@link ZipEntry#getSize()}); does not inflate entry contents.
+     * A {@code maxSourceSizeBytes} of 0 or less means there is no source-size limit.
+     *
+     * @param zipBytes raw zip file bytes
+     * @param maxSourceSizeBytes contest maximum combined source size in bytes
+     * @throws SubmissionRejectedException if the claimed uncompressed size exceeds the limit
+     * @throws IllegalArgumentException if the zip is unreadable or an entry size is unknown
+     */
+    public static void enforceUncompressedZipSourceSizeLimit(byte[] zipBytes, long maxSourceSizeBytes)
+            throws SubmissionRejectedException {
+        if (maxSourceSizeBytes <= 0) {
+            return;
+        }
+        long sourceSize = getUncompressedZipSize(zipBytes);
+        if (sourceSize > maxSourceSizeBytes) {
+            String sizeMsg = "Source file(s) are too large (" + sourceSize + " bytes) - maximum is " + maxSourceSizeBytes + " bytes.";
+            throw new SubmissionRejectedException(sizeMsg, SubmissionRejectedException.SubmissionRejectionReason.SOURCE_TOO_BIG);
+        }
+    }
+
+    /**
+     * Sum the claimed uncompressed sizes of file entries in a zip, without extracting those entries.
+     * Uses {@link ZipFile} so sizes come from the central directory rather than by inflating payloads.
+     *
+     * @param zipBytes raw zip file bytes
+     * @return total uncompressed size in bytes of non-directory entries
+     * @throws IllegalArgumentException if {@code zipBytes} is null, the zip cannot be read, or any file entry has unknown size ({@link ZipEntry#getSize()} {@code < 0})
+     */
+    public static long getUncompressedZipSize(byte[] zipBytes) {
+        if (zipBytes == null) {
+            throw new IllegalArgumentException("zip data is null");
+        }
+        File tmp = null;
+        try {
+            // Create a temp file for holding the (unexpanded) zip data. Note that createTempFile 
+        	// appends a unique random value to the file name so concurrent POSTs do not share a temp file.
+            tmp = File.createTempFile("srcszchk", ".zip");
+            Files.write(tmp.toPath(), zipBytes);
+            long total = 0;
+            try (ZipFile zipFile = new ZipFile(tmp)) {
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                //check each entry in the (unexpanded) zip file
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    String entryName = entry.getName();
+                    if (entry.isDirectory() || entryName == null || entryName.isEmpty() || entryName.endsWith("/")) {
+                        continue;
+                    }
+                    long size = entry.getSize();
+                    if (size < 0) {
+                        throw new IllegalArgumentException("zip entry uncompressed size is unknown: " + entryName);
+                    }
+                    total += size;
+                }
+            }
+            return total;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (tmp != null) {
+                try {
+                    Files.deleteIfExists(tmp.toPath());
+                } catch (Exception e) {
+                    ; // best-effort immediate delete; do not wait for JVM exit
+                }
+            }
+        }
+    }
+
+    /**
      * Get files from a zipfile's base64 encoded string data
      *
      * @param base64Data String comprising a zip file encoded as base64
@@ -146,12 +238,33 @@ public final class EventFeedUtilities {
     }
 
     /**
-     * Get files from a zipfile's bytes.
+     * Get files from a zipfile's bytes with no uncompressed-size cap.
+     * Callers such as shadow replay that must extract whatever the remote CCS stored should use this overload.
      *
      * @param bytes bytes comprising a zip file.
      * @return list of IFiles extracted from the input bytes
      */
     public static List<IFile> getIFiles(byte[] bytes) {
+        try {
+            return getIFiles(bytes, 0);
+        } catch (SubmissionRejectedException e) {
+            // max of 0 means unlimited, so this should not occur
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get files from a zipfile's bytes, optionally stopping if inflated contents exceed a size limit.
+     * A {@code maxUncompressedBytes} of 0 or less means there is no limit (same behavior as {@link #getIFiles(byte[])}).
+     * The limit is applied to the running total of bytes actually inflated, so a zip whose headers understate
+     * entry sizes cannot expand without bound in memory.
+     *
+     * @param bytes bytes comprising a zip file
+     * @param maxUncompressedBytes maximum combined uncompressed file bytes allowed; {@code <= 0} for unlimited
+     * @return list of IFiles extracted from the input bytes
+     * @throws SubmissionRejectedException if inflated contents would exceed {@code maxUncompressedBytes}
+     */
+    public static List<IFile> getIFiles(byte[] bytes, long maxUncompressedBytes) throws SubmissionRejectedException {
 
         List<IFile> files = new ArrayList<IFile>();
 
@@ -160,6 +273,7 @@ public final class EventFeedUtilities {
         try {
             zipStream = new ZipInputStream(new ByteArrayInputStream(bytes));
             ZipEntry entry = null;
+            long extracted = 0;
             /**
              * Read each zip entry, add IFile.
              */
@@ -176,7 +290,14 @@ public final class EventFeedUtilities {
                     int bytesRead = 0;
                     while ((bytesRead = zipStream.read(buffer)) != -1)
                     {
+                        if (maxUncompressedBytes > 0 && extracted + bytesRead > maxUncompressedBytes) {
+                            throw new SubmissionRejectedException(
+                                    "Source file(s) are too large (" + (extracted + bytesRead) + " bytes) - maximum is "
+                                            + maxUncompressedBytes + " bytes.",
+                                    SubmissionRejectedException.SubmissionRejectionReason.SOURCE_TOO_BIG);
+                        }
                         byteOutputStream.write(buffer, 0, bytesRead);
+                        extracted += bytesRead;
                     }
 
                     String base64Data = getBase64Data(byteOutputStream.toByteArray());
@@ -189,6 +310,15 @@ public final class EventFeedUtilities {
             }
             zipStream.close();
 
+        } catch (SubmissionRejectedException e) {
+            if (zipStream != null){
+                try {
+                    zipStream.close();
+                } catch (Exception ze) {
+                    ; // problem closing stream, ignore.
+                }
+            }
+            throw e;
         } catch (Exception e) {
             if (zipStream != null){
                 try {


### PR DESCRIPTION
### Description of what the PR does

Previously, `pc2submit` only applied submission size limits based on the HTTP `Content-Length` of the **compressed** (zipped) POST. The result was that highly compressible source could exceed the contest limit on source code submission size (default 256 KiB) and still be accepted. (This happened in the NAC 2026 dress rehearsal, where submission 747 was 31 MB uncompressed, but only ~92 KB zipped.) This PR closes that loophole.

Specifically, CLICS `POST /submissions` (class `SubmissionService`) now checks **claimed uncompressed** zip entry sizes (`ZipEntry.getSize()` via the zip central directory) against `ContestInformation.getMaxSourceSizeInBytes()` **before** extracting (uncompressing) the zip file.

In addition, `SubmissionService` now utilizes new methods in `EventFeedUtilities` to monitor the actual in-memory unzipping process by keeping a **running inflated-byte cap** during extraction (uncompression) so a zip that understates sizes cannot expand without bound in memory.  (Such a condition could happen if a zip file lied about the total payload size -- which would be easy for an attacker to spoof by creating a zip with bad headers).

Oversized submits made via the `pc2submit` command now return HTTP **413** with the same “Source file(s) are too large" error message as WTI.

Additional notes:
- The submission paths for WTI and  `pc2team` are unchanged (they use `submitJudgeRun`, which is unaffected by this PR). 
- Running PC2 in Shadow mode still uses unlimited `getIFiles(byte[])` (see separate issue #1291).

### Issue which the PR addresses
Fixes #1235

### Environment in which the PR was developed 
Windows 11, Eclipse 2020-12 (4.18.0), Java version "1.8.0_271", Cursor version 3.13.25

### Precise steps for _testing_ the PR 

The important case is a source code file submitted using `pc2submit` whose **uncompressed size > contest max**, but where the **zip + JSON is still small enough** to pass the Jetty `SubmitPostSizeLimitFilter` used in a POST to `SubmissionService`. Note that random large files often get rejected by the POST-size filter first and do **not** exercise this PR.

### Setup

1. Ensure you have Python3 on your machine.
1. Start a PC2 Server loading the `clics_sumithello` contest.
1. Start a PC2 Admin.
1. On the Admin **Configure Contest->Times** tab, start the contest clock running.
1. Start a PC2 Event Feeder client and login as `feeder1`.
1. Click the `Start` button on the EF GUI to start the **Web Server** running (note that the default port is **50443**). Examine the console and confirm the webserver is running.
1. Verify that your **.netrc** file contains an entry like
`machine localhost login team1 password team1`.  (If not, create such an entry.)  
In Windows, the **.netrc** file is located at `C:\USERS\<username>`.
1. Open a terminal window in the PC2 distribution and enter the command
```
python ./bin/pc2submit --url https://localhost:50443 --problem A ./samps/src/hello.cpp
```
This should return a message like
```
Warning: `./samps/src/hello.cpp' has not been modified for 482857 minutes!
Submission information:
  filename:    ./samps/src/hello.cpp
  contest:     SumH
  problem:     A
  language:    GNU C++
  url:         https://localhost:50443/
There are warnings for this submission!
Do you want to continue? (y/n)
```
If you do not get a message like the above, **stop** and check your network setup; you need to be able to connect to the contest in order to run the following tests.
(Note: the "warning" is simply because you are submitting a PC2 sample source file that hasn't been changed in quite a while).

9. Enter `y` to submit the program, then verify that you get a message on the console like `Submission received: id = s1, time = 20:19:47`.
1. On the PC2 Admin **Run Contest->Runs** tab, verify that you see a newly-submitted run.  This proves that you can submit a run using `pc2submit`.  

### Primary Test: submisson of a compressible source file which is over the uncompressed limit
1. Download the file https://github.com/icpcsysops/NAC2026/blob/main/contests/dress/results/primary/replay/747.zip from the NAC2026 Dress Rehearsal.  This is a zip file of about 91K (so, much less than the default source size limit of 256K) but which contains a (compressed) source file that is over 30MB when uncompressed.
1. Unzip the downloaded zip file.  This should produce a 30MB file named `jeirr.cpp`.
1. Submit the `jeirr.cpp` file with `pc2submit` as above.
1. Verify that when you answer `y` to the question `Do you want to continue?`, a message like the following is returned:
```
Submission failed (code 413 - Unable to submit run: Source file(s) are too large (31610880 bytes) - maximum is 262144 bytes.)
```
5. Check the PC2 Admin RUNS grid; verify that no new submission was accepted.

### Optional additional tests:  WTI / pc2team unchanged

Submit an oversized file via **pc2team** and/or **WTI**.  Verify that such a file is still rejected (it should not be accepted because **pc2team** and **WTI** already contained code to prohibit such a submission, and no changes were made to either of these submission components).

### Optional additional test:  POST filter still works

Submit an **incompressible** file larger than the max (e.g. 300 KiB of random bytes).  Such a file should still be rejected by the existing POST-size filter which is applied before the file is ever unzipped. That is how it should work; this PR does not replace that filter.

