### PR TITLE
i_1280 Fix max_run_time

### DIFF
--- a/src/edu/csus/ecs/pc2/clics/API202306/JSON202306Utilities.java
+++ b/src/edu/csus/ecs/pc2/clics/API202306/JSON202306Utilities.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.clics.API202306;
 
 import java.text.SimpleDateFormat;
@@ -42,6 +42,8 @@ public class JSON202306Utilities extends JSONUtilities {
     public static final String AWARD_KEY = "awards";
 
     public static final String ORGANIZATION_KEY = "organizations";
+
+    public static final String PC2_SUBMISSION_ID_KEY = "pc2_submission_id";
 
     public static final String JSON_ANNOTATION_INTERFACE = ".JsonProperty";
 
@@ -201,6 +203,58 @@ public class JSON202306Utilities extends JSONUtilities {
 
         stringBuilder.append("}");
 
+    }
+
+    /**
+     * Add an event prefix to a buffer, optionally including a custom notification property in the
+     * event notification prefix.
+     * Adds event, (event) id, customProperty (an customValue) (if non-null) and data keyword to string.
+     *
+     * @param stringBuilder
+     * @param eventType
+     * @param data - json data for object
+     * @param customProperty - if non-null, adds property name with value customValue
+     * @param customValue - if customProperty is non-null, this is the value to assign (may be null)
+     */
+    public String getJSONEvent(String eventName, long eventSequence, String id, String data,
+            String customProperty, String customValue) {
+        StringBuilder stringBuilder = new StringBuilder();
+        appendJSONEvent(stringBuilder, eventName, eventSequence, id, data);
+        return stringBuilder.toString();
+    }
+
+    public void appendJSONEvent(StringBuilder stringBuilder, String eventName, long eventSequence, String id, String data,
+            String customProperty, String customValue) {
+
+        // {"type": "<event type>", "token": "<token>", "id": "<id>", "op": "<type of operation>", "data": <JSON data for element>, "customProperty": <customValue> }
+
+        stringBuilder.append("{");
+        appendPair(stringBuilder, "type", eventName);
+        stringBuilder.append(",");
+
+        appendPair(stringBuilder, "token", EventFeedJSON.getEventId(eventSequence));
+        stringBuilder.append(",");
+
+        if(id == null) {
+            appendPairNullValue(stringBuilder, "id");
+        } else {
+            appendPair(stringBuilder, "id", id);
+        }
+        stringBuilder.append(",");
+
+        stringBuilder.append("\"data\": ");
+
+        stringBuilder.append(data);
+
+        // Check if this is a "judgements" delete notification, if so, add PC2 custom property indicating
+        // the submission id
+        if(customProperty != null) {
+            stringBuilder.append(",\"");
+            stringBuilder.append(customProperty);
+            stringBuilder.append("\": ");
+            // null is safe here
+            stringBuilder.append(customValue);
+        }
     }
 
 }

--- a/src/edu/csus/ecs/pc2/core/execute/ExecutionData.java
+++ b/src/edu/csus/ecs/pc2/core/execute/ExecutionData.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.core.execute;
 
 import java.io.Serializable;
@@ -55,6 +55,8 @@ public class ExecutionData implements Serializable {
 
     private long executeTimeMS = 0;
 
+    private long maxExecuteTimeMS = 0;
+
     private long validateTimeMS = 0;
 
     private Exception executionException = null;
@@ -66,7 +68,7 @@ public class ExecutionData implements Serializable {
     private boolean failedToCompile = false;
 
     private String additionalInformation = "";
-    
+
     //fields associated with "point-scoring" contests
     private double score ;
     private CLICS_JUDGEMENT_ACRONYM judgementAcronym ;
@@ -293,10 +295,18 @@ public class ExecutionData implements Serializable {
 
     public void setExecuteTimeMS(long inExecuteTime){
         executeTimeMS = inExecuteTime;
+        // Keep track of longest execution time
+        if(executeTimeMS > maxExecuteTimeMS) {
+            maxExecuteTimeMS = executeTimeMS;
+        }
     }
 
     public long getExecuteTimeMS(){
         return executeTimeMS;
+    }
+
+    public long getMaxExecuteTimeMS() {
+        return maxExecuteTimeMS;
     }
 
     public void setvalidateTimeMS(long validateTime){
@@ -415,7 +425,7 @@ public class ExecutionData implements Serializable {
 
         return retStr;
     }
-    
+
     /**
      * When the same execute data is to be used between successive test cases, certain fields should be reset.
      * Specifically, those related to the actual execution and validation of the test case run.
@@ -439,7 +449,7 @@ public class ExecutionData implements Serializable {
         memoryLimitExceeded = false;
         failedToCompile = false;
         additionalInformation = "";
-        
+
         //fields associated with "point-scoring" contests
         double score = 0;
         CLICS_JUDGEMENT_ACRONYM judgementAcronym = null;

--- a/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
+++ b/src/edu/csus/ecs/pc2/ui/AutoJudgingMonitor.java
@@ -1,4 +1,4 @@
-// Copyright (C) 1989-2025 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
+// Copyright (C) 1989-2026 PC2 Development Team: John Clevenger, Douglas Lane, Samir Ashoo, and Troy Boudreau.
 package edu.csus.ecs.pc2.ui;
 
 import java.util.ArrayList;
@@ -610,12 +610,12 @@ public class AutoJudgingMonitor implements UIPlugin {
 
                 judgementRecord = new JudgementRecord(elementId, contest.getClientId(), solved, true, true);
                 judgementRecord.setValidatorResultString(results);
-                
+
                 //if it's a point-scoring contest, put the score and the judgement into the JudgementRecord
                 if (contest.getContestInformation().isScoreboardTypeScore()) {
-                    
+
                     judgementRecord.setScore(executionData.getScore());
-                    
+
                     CLICS_JUDGEMENT_ACRONYM acronym = executionData.getJudgementAcronym();
                     String judgementDescription ;
                     if (acronym != null) {
@@ -668,7 +668,7 @@ public class AutoJudgingMonitor implements UIPlugin {
             long milliDiff = cal.getTime().getTime() - startTimeCalendar.getTime().getTime();
             long totalSeconds = milliDiff / 1000;
             judgementRecord.setHowLongToJudgeInSeconds(totalSeconds);
-            judgementRecord.setExecuteMS(executeTimeMS);
+            judgementRecord.setExecuteMS(executionData.getMaxExecuteTimeMS());
             judgementRecord.setJudgeStartDate(fetchedRun.getJudgeStartDate());
 
             runResultFiles = new RunResultFiles(fetchedRun, fetchedRun.getProblemId(), judgementRecord, executable.getExecutionData());

--- a/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
+++ b/src/edu/csus/ecs/pc2/ui/SelectJudgementPaneNew.java
@@ -4,6 +4,7 @@ package edu.csus.ecs.pc2.ui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Frame;
@@ -28,7 +29,6 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.border.TitledBorder;
@@ -63,7 +63,6 @@ import edu.csus.ecs.pc2.core.model.RunResultFiles;
 import edu.csus.ecs.pc2.core.model.SerializedFile;
 import edu.csus.ecs.pc2.core.security.Permission;
 import edu.csus.ecs.pc2.ui.judge.JudgeView;
-import java.awt.Dimension;
 
 /**
  * Select a Judgement Pane.
@@ -157,7 +156,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     private JLabel validatorAnswer = null;
 
     private JLabel selectJudgementCheckboxLabel = null;
-    
+
     private JButton viewOutputsAndDataButton = null;
 
     private GregorianCalendar startTimeCalendar;
@@ -191,7 +190,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     private JLabel additionalInfoTextLabel;
 
     private JLabel addtionalInfoMoreButtonLabel;
-    
+
     private boolean isPointScoring = false;
 
     /**
@@ -224,9 +223,9 @@ public class SelectJudgementPaneNew extends JPanePlugin {
     @Override
     public void setContestAndController(IInternalContest inContest, IInternalController inController) {
         super.setContestAndController(inContest, inController);
-        
+
         isPointScoring = inContest.getContestInformation().isScoreboardTypeScore();
-        
+
         log = getController().getLog();
 
         displayTeamName = new DisplayTeamName();
@@ -412,7 +411,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             if (executable != null) {
                 executionData = executable.getExecutionData();
                 if (judgementRecord != null) {
-                    judgementRecord.setExecuteMS(executionData.getExecuteTimeMS());
+                    judgementRecord.setExecuteMS(executionData.getMaxExecuteTimeMS());
                     judgementRecord.setScore(executionData.getScore());
                 }
             }
@@ -539,7 +538,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             // if there IS a computer judgement, try to find a corresponding RunResultFile record
             RunResultFiles matchingResult = null;
             if (computerJudgement != null) {
-                
+
                 // search the RunResultFiles array for a matching result
                 if (runResultFiles != null) {
                     for (int i = 0; i < runResultFiles.length; i++) {
@@ -887,7 +886,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
      * Takes a boolean condition whether to override stop on first failure condition
      */
     protected void executeRun(boolean overrideStopOnFirstFailedTestCase) {
-       
+
         executeTimeMS = 0;
         System.gc();
 
@@ -957,7 +956,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             getTestResultsFrame().setData(run, runFiles, problem, getProblemDataFiles());
             getTestResultsFrame().setVisible(true);
         }
-        executeTimeMS = executable.getExecutionData().getExecuteTimeMS();
+        executeTimeMS = executable.getExecutionData().getMaxExecuteTimeMS();
 
         // Show validator results, if there are any.
 
@@ -1002,12 +1001,12 @@ public class SelectJudgementPaneNew extends JPanePlugin {
 
                 judgementRecord = new JudgementRecord(elementId, run.getSubmitter(), solved, true);
                 judgementRecord.setValidatorResultString(results);
-                
+
                 //if it's a point-scoring contest, put the score and the judgement into the JudgementRecord
                 if (isPointScoring) {
-                    
+
                     judgementRecord.setScore(executionData.getScore());
-                    
+
                     CLICS_JUDGEMENT_ACRONYM acronym = executionData.getJudgementAcronym();
                     String judgementDescription ;
                     if (acronym != null) {
@@ -1458,7 +1457,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
             if (executionData != null) {
                 String additionalText = null;
                 boolean enableMoreButton = false;
-                
+
                 if (isPointScoring && executionData.getJudgementAcronym() == CLICS_JUDGEMENT_ACRONYM.AC) {
                     DecimalFormat df = new DecimalFormat("0.0###");
                     additionalText = "Score: " + df.format(executionData.getScore());
@@ -1563,7 +1562,7 @@ public class SelectJudgementPaneNew extends JPanePlugin {
         // this will be null if we are accepting the computer judgement
         if (executable != null) {
             executionData = executable.getExecutionData();
-            judgementRecord.setExecuteMS(executionData.getExecuteTimeMS());
+            judgementRecord.setExecuteMS(executionData.getMaxExecuteTimeMS());
             judgementRecord.setScore(executionData.getScore());
         }
         newRunResultFiles = new RunResultFiles(newRun, newRun.getProblemId(), judgementRecord, executionData);


### PR DESCRIPTION
### Description of what the PR does
Keep track of the longest execution time in `ExecutionData `using a new member (`maxExecuteTimeMS`) along with the appropriate accessor and mutator.  Previously, the `executeTimeMS `(`getExecuteTimeMS(`)) member was used and this represents the execution time of the last test case.  This caused the wrong value to appear on the CLICS event feed, as well as on the PC2 GUI that shows the execution data for a run.

### Issue which the PR addresses
Fixes #1280 

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
java version "1.8.0_321"
Java(TM) SE Runtime Environment (build 1.8.0_321-b07)
Java HotSpot(TM) 64-Bit Server VM (build 25.321-b07, mixed mode)

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)

1. Load a clean copy of the **clics_sumithello** contest.
2. Bring up the **administrator1** client.
3. Bring up the **feeder1** client and start it (press **Start** button).
4. In command prompt window, issue the following curl command to read the event feed: `curl -k https://administrator1:administrator1@localhost:50443/contests/SumH/event-feed`
5. A bunch of events will scroll out and then it will sit there.
6. Back on the **administrator1** client, start the contest (**Times**->**Start All**)
7. Bring up a team client (`pc2team`) and log in as **team1**/**team1**.
8. Make a submission for the **Sumit** problem (I used **GNU C++** and `isumit.cpp`).
9. Open the **pc2judge** client using **judge3** (it's set up to autojudge **Sumit**).
10. In the curl window, a bunch of events should have scrolled by.  A bunch of "**runs**" followed by a "**judgements**".  Look at the "`max_run_time`" property (it's the last one).
11. Scroll back through the runs (there are 7 of them) and look for the one with the biggest "`run_time`" property.  The data for my run is shown below.  The "`max_run_time`" property of the "**judgements**" notification should match the largest "`run_time`".
12. Back on the **administrator1** client, go to the **Run Contest**->**Runs** tab.
13. Select the only run then press **View Judgements** at the bottom.
14. Look at the X time column.  It should match the "`max_run_time`" property seen on the event feed.
15. You can make additional submissions if you like because the values will change slightly so you can see it may choose a different one as the one with the "`max_run_time`" next time.
16. You can **^C** the `curl `to kill it.
17. Then close the judge, administrator and team clients.
18. Stop the contest (from the server, the **Times** tab, **Stop All**).
19. Close the server.
20. Done.

<img width="1194" height="311" alt="image" src="https://github.com/user-attachments/assets/01f141ae-f5f2-4c6d-969e-5655c60561c8" />

```
{"type":"runs","token":"pc2-49","id":"TestCase--5468749453065596807","data": {"id":"TestCase--5468749453065596807","judgement_id":"Run-7165368412488011938","ordinal":1,"judgement_type_id":"AC","time":"2026-08-26T22:06:03.981-04","contest_time":"00:05:11.792","run_time":0.263}}
{"type":"runs","token":"pc2-50","id":"TestCase--2183730955800265169","data": {"id":"TestCase--2183730955800265169","judgement_id":"Run-7165368412488011938","ordinal":2,"judgement_type_id":"AC","time":"2026-08-26T22:06:04.183-04","contest_time":"00:05:11.994","run_time":0.043}}
{"type":"runs","token":"pc2-51","id":"TestCase--926307959591635682","data": {"id":"TestCase--926307959591635682","judgement_id":"Run-7165368412488011938","ordinal":3,"judgement_type_id":"AC","time":"2026-08-26T22:06:04.375-04","contest_time":"00:05:12.186","run_time":0.036}}
{"type":"runs","token":"pc2-52","id":"TestCase--6239247762799142711","data": {"id":"TestCase--6239247762799142711","judgement_id":"Run-7165368412488011938","ordinal":4,"judgement_type_id":"AC","time":"2026-08-26T22:06:04.561-04","contest_time":"00:05:12.372","run_time":0.044}}
{"type":"runs","token":"pc2-53","id":"TestCase--425797505456334511","data": {"id":"TestCase--425797505456334511","judgement_id":"Run-7165368412488011938","ordinal":5,"judgement_type_id":"AC","time":"2026-08-26T22:06:04.736-04","contest_time":"00:05:12.547","run_time":0.03}}
{"type":"runs","token":"pc2-54","id":"TestCase--604826351888607225","data": {"id":"TestCase--604826351888607225","judgement_id":"Run-7165368412488011938","ordinal":6,"judgement_type_id":"AC","time":"2026-08-26T22:06:04.899-04","contest_time":"00:05:12.710","run_time":0.027}}
{"type":"runs","token":"pc2-55","id":"TestCase-1607340676828528961","data": {"id":"TestCase-1607340676828528961","judgement_id":"Run-7165368412488011938","ordinal":7,"judgement_type_id":"AC","time":"2026-08-26T22:06:05.070-04","contest_time":"00:05:12.881","run_time":0.027}}
{"type":"judgements","token":"pc2-56","id":"Run-7165368412488011938","data": {"id":"Run-7165368412488011938","submission_id":"1","judgement_type_id":"AC","start_time":"2026-08-26T22:05:59.750-04","start_contest_time":"00:05:07.721","end_time":"2026-08-26T22:06:05.189-04","end_contest_time":"00:05:13.160","max_run_time":0.263}}
```

